### PR TITLE
fix: add Authorization header to Histories, CreateHistory, and Delete

### DIFF
--- a/histories.go
+++ b/histories.go
@@ -130,6 +130,7 @@ func (c *Client) Histories() ([]*History, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err
@@ -168,6 +169,7 @@ func (c *Client) CreateHistory() (*History, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err
@@ -199,6 +201,7 @@ func (h *History) Delete() error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", h.Client.password))
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return err

--- a/histories_test.go
+++ b/histories_test.go
@@ -2,8 +2,32 @@ package thingscloud
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 )
+
+// authCapturingServer creates a test server that captures headers and serves a fixture file.
+func authCapturingServer(t *testing.T, statusCode int, fixture string) (*httptest.Server, *http.Header) {
+	t.Helper()
+	var captured http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		f, err := os.Open(fmt.Sprintf("tapes/%s", fixture))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer f.Close()
+		content, _ := io.ReadAll(f)
+		w.WriteHeader(statusCode)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, string(content))
+	}))
+	return server, &captured
+}
 
 func TestClient_Histories(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
@@ -18,6 +42,18 @@ func TestClient_Histories(t *testing.T) {
 		}
 		if len(hs) != 1 {
 			t.Errorf("Expected to receive %d histories, but got %d", 1, len(hs))
+		}
+	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(t, 200, "histories-success.json")
+		defer server.Close()
+
+		c := New(fmt.Sprintf("http://%s", server.Listener.Addr().String()), "martin@example.com", "secret")
+		c.Histories() //nolint:errcheck
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
 		}
 	})
 
@@ -49,6 +85,18 @@ func TestClient_CreateHistory(t *testing.T) {
 			t.Fatalf("Expected key %s but got %s", "33333abb-bfe4-4b03-a5c9-106d42220c72", h.ID)
 		}
 	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(t, 200, "create-history-success.json")
+		defer server.Close()
+
+		c := New(fmt.Sprintf("http://%s", server.Listener.Addr().String()), "martin@example.com", "secret")
+		c.CreateHistory() //nolint:errcheck
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
+		}
+	})
 }
 
 func TestHistory_Delete(t *testing.T) {
@@ -62,6 +110,19 @@ func TestHistory_Delete(t *testing.T) {
 		err := h.Delete()
 		if err != nil {
 			t.Fatalf("Expected request to succeed, but didn't: %q", err.Error())
+		}
+	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(t, 202, "create-history-success.json")
+		defer server.Close()
+
+		c := New(fmt.Sprintf("http://%s", server.Listener.Addr().String()), "martin@example.com", "secret")
+		h := History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+		h.Delete() //nolint:errcheck
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
 		}
 	})
 }


### PR DESCRIPTION
While using this SDK in my own project, I found that `Histories()` always returns a 404 error. The root cause is that three methods on the account history endpoints make authenticated API calls without setting the `Authorization` header.

The Things Cloud server returns HTTP 404 (not 401) for unauthenticated requests to these endpoints, so the failure gives no hint that auth is the problem.

**Affected methods:**
- `Client.Histories()` — GET `/own-history-keys`
- `Client.CreateHistory()` — POST `/own-history-keys`
- `History.Delete()` — DELETE `/own-history-keys/:id`

All three now set `Authorization: Password <password>`, matching the pattern already used in `Verify()`.

Tests are extended to assert the header is present on each request.