### PR TITLE
fix: Sync() only fetches the first page of history items

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -165,7 +165,7 @@ func (s *Syncer) Sync() ([]Change, error) {
 
 		// Use server's current-item-index as next start position
 		// (not len(items) - items get expanded from nested structure)
-		startIndex = s.history.LatestServerIndex
+		startIndex = s.history.LoadedServerIndex
 		hasMore = more
 	}
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -1,10 +1,90 @@
 package sync
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
 )
+
+// TestSync_PaginatesAllPages verifies that Sync() steps through every page of
+// history items. Before the fix, the loop used LatestServerIndex (the server's
+// total item count) as the next start-index, which caused the second request to
+// ask for items at the very end of the history and receive nothing. The correct
+// field is LoadedServerIndex, which accumulates the number of item-batches
+// received so far.
+func TestSync_PaginatesAllPages(t *testing.T) {
+	t.Parallel()
+
+	const historyID = "test-history-id"
+
+	// Page 1: one item-batch, server total = 2 (so hasMore = 1 < 2 = true)
+	page1 := `{"items":[{"task-page1":{"e":"Task6","t":0,"p":{"tt":"Page 1 Task","tp":0}}}],"current-item-index":2,"schema":301}`
+	// Page 2: one item-batch, server total = 2 (so hasMore = 2 < 2 = false)
+	page2 := `{"items":[{"task-page2":{"e":"Task6","t":0,"p":{"tt":"Page 2 Task","tp":0}}}],"current-item-index":2,"schema":301}`
+	// History metadata for the pre-check getServerIndex call
+	historyMeta := `{"latest-server-index":2,"latest-schema-version":301,"is-empty":false,"latest-total-content-size":0}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		if strings.HasSuffix(path, "/items") {
+			startIndex := r.URL.Query().Get("start-index")
+			switch startIndex {
+			case "0":
+				fmt.Fprint(w, page1)
+			case "1":
+				// Correct next start-index after receiving 1 item-batch (LoadedServerIndex=1)
+				fmt.Fprint(w, page2)
+			default:
+				// Wrong start-index (e.g. LatestServerIndex=2): return empty to simulate the bug
+				fmt.Fprint(w, `{"items":[],"current-item-index":2,"schema":301}`)
+			}
+			return
+		}
+		// History metadata endpoint
+		fmt.Fprint(w, historyMeta)
+	}))
+	defer ts.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	client := things.New(ts.URL, "test@example.com", "password")
+	syncer, err := Open(dbPath, client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	// Pre-seed sync state so Sync() skips the OwnHistory() network call
+	// and goes straight to fetching items.
+	if err := syncer.saveSyncState(historyID, 0); err != nil {
+		t.Fatalf("saveSyncState failed: %v", err)
+	}
+
+	changes, err := syncer.Sync()
+	if err != nil {
+		t.Fatalf("Sync() failed: %v", err)
+	}
+
+	// Both pages must have been processed
+	if len(changes) != 2 {
+		t.Errorf("expected 2 changes (one per page), got %d", len(changes))
+	}
+
+	state := syncer.State()
+	tasks, err := state.AllTasks(QueryOpts{})
+	if err != nil {
+		t.Fatalf("AllTasks failed: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks in state, got %d — pagination stopped early", len(tasks))
+	}
+}
 
 func TestOpen(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
While using this SDK against my own account, I found that `Syncer.Sync()` silently produces incomplete, stale data. On my account (55,054 history items spanning two years), only ~2,500 items — the oldest ones — were ever processed. Current tasks were invisible, all modification timestamps were from the earliest weeks of the history, and `sync_state` recorded `server_index = 55054`, making the syncer believe it was fully up to date and skip all future syncs.

**Root cause:** The pagination loop uses `s.history.LatestServerIndex` as the `start-index` for each subsequent request. `LatestServerIndex` is the server's total item count and is constant across pages, so after the first batch the syncer asks for items at the very end of the history, receives nothing, and stops. The correct field is `LoadedServerIndex`, which accumulates the number of item-batches received so far. All the `cmd/` tools already use this correctly.

**Fix:** One line in `sync/sync.go`:

```diff
-startIndex = s.history.LatestServerIndex
+startIndex = s.history.LoadedServerIndex
```

A regression test (`TestSync_PaginatesAllPages`) is included. It uses a fake two-page server where the correct next index (1) returns page 2 and the wrong index (2) returns empty — confirming the test would have caught the original bug.