### PR TITLE
[codex] fix history auth and sync pagination

### DIFF
--- a/histories.go
+++ b/histories.go
@@ -130,6 +130,7 @@ func (c *Client) Histories() ([]*History, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err
@@ -168,6 +169,7 @@ func (c *Client) CreateHistory() (*History, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err
@@ -199,6 +201,7 @@ func (h *History) Delete() error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", h.Client.password))
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return err

--- a/histories_test.go
+++ b/histories_test.go
@@ -2,8 +2,21 @@ package thingscloud
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func authCapturingServer(statusCode int, body string) (*httptest.Server, *http.Header) {
+	var captured http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		fmt.Fprintln(w, body)
+	}))
+	return server, &captured
+}
 
 func TestClient_Histories(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
@@ -18,6 +31,20 @@ func TestClient_Histories(t *testing.T) {
 		}
 		if len(hs) != 1 {
 			t.Errorf("Expected to receive %d histories, but got %d", 1, len(hs))
+		}
+	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(http.StatusOK, `[]`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if _, err := c.Histories(); err != nil {
+			t.Fatalf("Histories failed: %v", err)
+		}
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
 		}
 	})
 
@@ -49,6 +76,20 @@ func TestClient_CreateHistory(t *testing.T) {
 			t.Fatalf("Expected key %s but got %s", "33333abb-bfe4-4b03-a5c9-106d42220c72", h.ID)
 		}
 	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(http.StatusOK, `{}`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if _, err := c.CreateHistory(); err != nil {
+			t.Fatalf("CreateHistory failed: %v", err)
+		}
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
+		}
+	})
 }
 
 func TestHistory_Delete(t *testing.T) {
@@ -62,6 +103,21 @@ func TestHistory_Delete(t *testing.T) {
 		err := h.Delete()
 		if err != nil {
 			t.Fatalf("Expected request to succeed, but didn't: %q", err.Error())
+		}
+	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(http.StatusAccepted, `{}`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		h := History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+		if err := h.Delete(); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
 		}
 	})
 }

--- a/items.go
+++ b/items.go
@@ -71,7 +71,7 @@ func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 			items = append(items, item)
 		}
 	}
-	h.LoadedServerIndex = h.LoadedServerIndex + len(v.Items)
+	h.LoadedServerIndex = opts.StartIndex + len(v.Items)
 	h.LatestServerIndex = v.CurrentItemIndex
 	h.EndTotalContentSize = v.EndTotalContentSize
 	h.LatestTotalContentSize = v.LatestTotalContentSize

--- a/items_test.go
+++ b/items_test.go
@@ -2,6 +2,8 @@ package thingscloud
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -23,6 +25,37 @@ func TestHistory_Items(t *testing.T) {
 
 		if len(items) < 1 {
 			t.Fatalf("Expected items, but got none: %#v", items)
+		}
+	})
+
+	t.Run("TracksLoadedServerIndexFromStartIndex", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("start-index"); got != "100" {
+				t.Errorf("start-index = %q, want %q", got, "100")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"items":[{"task-101":{"e":"Task6","t":0,"p":{"tt":"Task 101","tp":0}}},{"task-102":{"e":"Task6","t":0,"p":{"tt":"Task 102","tp":0}}}],"current-item-index":105,"schema":301}`)
+		}))
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		h := &History{
+			Client: c,
+			ID:     "33333abb-bfe4-4b03-a5c9-106d42220c72",
+		}
+		_, more, err := h.Items(ItemsOptions{StartIndex: 100})
+		if err != nil {
+			t.Fatalf("Items failed: %v", err)
+		}
+		if h.LoadedServerIndex != 102 {
+			t.Errorf("LoadedServerIndex = %d, want %d", h.LoadedServerIndex, 102)
+		}
+		if h.LatestServerIndex != 105 {
+			t.Errorf("LatestServerIndex = %d, want %d", h.LatestServerIndex, 105)
+		}
+		if !more {
+			t.Error("Expected more items")
 		}
 	})
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -25,8 +25,8 @@ type dbExecutor interface {
 
 // Syncer manages persistent sync with Things Cloud
 type Syncer struct {
-	rawDB   *sql.DB     // underlying connection for Close() and Begin()
-	db      dbExecutor  // current executor (db or tx)
+	rawDB   *sql.DB    // underlying connection for Close() and Begin()
+	db      dbExecutor // current executor (db or tx)
 	client  *things.Client
 	history *things.History
 }
@@ -163,9 +163,9 @@ func (s *Syncer) Sync() ([]Change, error) {
 		}
 		allChanges = append(allChanges, changes...)
 
-		// Use server's current-item-index as next start position
-		// (not len(items) - items get expanded from nested structure)
-		startIndex = s.history.LatestServerIndex
+		// Use loaded server item-batches as the next start position.
+		// The expanded item count can differ from the server batch count.
+		startIndex = s.history.LoadedServerIndex
 		hasMore = more
 	}
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -1,10 +1,66 @@
 package sync
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
 )
+
+func TestSync_PaginatesFromStoredCursor(t *testing.T) {
+	t.Parallel()
+
+	const historyID = "test-history-id"
+
+	page101 := `{"items":[{"task-page101":{"e":"Task6","t":0,"p":{"tt":"Page 101 Task","tp":0}}}],"current-item-index":102,"schema":301}`
+	page102 := `{"items":[{"task-page102":{"e":"Task6","t":0,"p":{"tt":"Page 102 Task","tp":0}}}],"current-item-index":102,"schema":301}`
+	historyMeta := `{"latest-server-index":102,"latest-schema-version":301,"is-empty":false,"latest-total-content-size":0}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			switch r.URL.Query().Get("start-index") {
+			case "100":
+				fmt.Fprint(w, page101)
+			case "101":
+				fmt.Fprint(w, page102)
+			default:
+				fmt.Fprint(w, `{"items":[],"current-item-index":102,"schema":301}`)
+			}
+			return
+		}
+		fmt.Fprint(w, historyMeta)
+	}))
+	defer ts.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	client := things.New(ts.URL, "test@example.com", "password")
+	syncer, err := Open(dbPath, client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	if err := syncer.saveSyncState(historyID, 100); err != nil {
+		t.Fatalf("saveSyncState failed: %v", err)
+	}
+
+	changes, err := syncer.Sync()
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Errorf("changes = %d, want %d", len(changes), 2)
+	}
+	if got := syncer.LastSyncedIndex(); got != 102 {
+		t.Errorf("LastSyncedIndex = %d, want %d", got, 102)
+	}
+}
 
 func TestOpen(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- add the missing `Authorization: Password ...` header to `Histories`, `CreateHistory`, and `History.Delete`
- make `History.Items` compute `LoadedServerIndex` from the requested `start-index`, so pagination works after a stored non-zero cursor
- update `Syncer.Sync` to request the next page from `LoadedServerIndex` and add regression coverage

## Context

This covers the auth issue already raised in #4 and the sync pagination issue raised in #5. While checking #5, I found the one-line fix still breaks incremental syncs that resume from a stored cursor greater than zero: after fetching `start-index=100`, it asks for `start-index=1`. This patch fixes that cursor accounting in `Items()` as well.

## Validation

- `go test ./...`