### PR TITLE
[codex] add state query helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,13 +302,22 @@ state := syncer.State()
 inbox, _ := state.TasksInInbox(sync.QueryOpts{})
 today, _ := state.TasksInToday(sync.QueryOpts{})
 anytime, _ := state.TasksInAnytime(sync.QueryOpts{})
+someday, _ := state.TasksInSomeday(sync.QueryOpts{})
+upcoming, _ := state.TasksInUpcoming(sync.QueryOpts{})
 
 // Query by container
 tasks, _ := state.TasksInProject(projectUUID, sync.QueryOpts{})
 tasks, _ := state.TasksInArea(areaUUID, sync.QueryOpts{})
+tasks, _ := state.TasksUnderHeading(headingUUID, sync.QueryOpts{})
+headings, _ := state.HeadingsInProject(projectUUID, sync.QueryOpts{})
+
+// Query by tag or text
+tasks, _ := state.TasksWithTag(tagUUID, sync.QueryOpts{})
+tasks, _ := state.SearchTasks("invoice", sync.QueryOpts{})
 
 // List all
 projects, _ := state.AllProjects(sync.QueryOpts{})
+headings, _ := state.AllHeadings(sync.QueryOpts{})
 areas, _ := state.AllAreas(sync.QueryOpts{})
 tags, _ := state.AllTags(sync.QueryOpts{})
 ```

--- a/sync/integration_test.go
+++ b/sync/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"testing"
+	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
 )
@@ -158,11 +159,21 @@ func TestStateQueries(t *testing.T) {
 	defer syncer.Close()
 
 	// Create test data directly
+	today := startOfDay(time.Now())
+	tomorrow := today.Add(24 * time.Hour)
+
 	syncer.saveTask(&things.Task{UUID: "inbox-1", Title: "Inbox Task", Schedule: things.TaskScheduleInbox, Status: things.TaskStatusPending})
 	syncer.saveTask(&things.Task{UUID: "anytime-1", Title: "Anytime Task", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "today-1", Title: "Today Task", Schedule: things.TaskScheduleAnytime, ScheduledDate: &today, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "someday-1", Title: "Someday Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "upcoming-1", Title: "Upcoming Task", Schedule: things.TaskScheduleSomeday, ScheduledDate: &tomorrow, Status: things.TaskStatusPending})
 	syncer.saveTask(&things.Task{UUID: "completed-1", Title: "Completed Task", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusCompleted})
 	syncer.saveTask(&things.Task{UUID: "trashed-1", Title: "Trashed Task", InTrash: true})
 	syncer.saveTask(&things.Task{UUID: "project-1", Title: "Test Project", Type: things.TaskTypeProject})
+	syncer.saveTask(&things.Task{UUID: "heading-1", Title: "Test Heading", Type: things.TaskTypeHeading, ParentTaskIDs: []string{"project-1"}})
+	syncer.saveTask(&things.Task{UUID: "under-heading-1", Title: "Under Heading Task", ActionGroupIDs: []string{"heading-1"}, Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "tagged-1", Title: "Tagged Task", TagIDs: []string{"tag-1"}, Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "search-1", Title: "Needle Task", Note: "hidden haystack", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
 
 	state := syncer.State()
 
@@ -217,4 +228,132 @@ func TestStateQueries(t *testing.T) {
 			t.Error("returned task is not a project")
 		}
 	})
+
+	t.Run("TasksInToday returns tasks scheduled today", func(t *testing.T) {
+		tasks, err := state.TasksInToday(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInToday failed: %v", err)
+		}
+		if !hasTask(tasks, "today-1") {
+			t.Error("today task should be returned")
+		}
+		if hasTask(tasks, "anytime-1") {
+			t.Error("unscheduled anytime task should not be returned in Today")
+		}
+	})
+
+	t.Run("TasksInAnytime returns unscheduled anytime tasks", func(t *testing.T) {
+		tasks, err := state.TasksInAnytime(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInAnytime failed: %v", err)
+		}
+		if !hasTask(tasks, "anytime-1") {
+			t.Error("anytime task should be returned")
+		}
+		if hasTask(tasks, "today-1") {
+			t.Error("today task should not be returned in Anytime")
+		}
+		if hasTask(tasks, "completed-1") {
+			t.Error("completed task should be excluded by default")
+		}
+	})
+
+	t.Run("TasksInAnytime includes completed when requested", func(t *testing.T) {
+		tasks, err := state.TasksInAnytime(QueryOpts{IncludeCompleted: true})
+		if err != nil {
+			t.Fatalf("TasksInAnytime failed: %v", err)
+		}
+		if !hasTask(tasks, "completed-1") {
+			t.Error("completed task should be included")
+		}
+	})
+
+	t.Run("TasksInSomeday returns unscheduled someday tasks", func(t *testing.T) {
+		tasks, err := state.TasksInSomeday(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInSomeday failed: %v", err)
+		}
+		if !hasTask(tasks, "someday-1") {
+			t.Error("someday task should be returned")
+		}
+		if hasTask(tasks, "upcoming-1") {
+			t.Error("scheduled someday task should not be returned in Someday")
+		}
+	})
+
+	t.Run("TasksInUpcoming returns future scheduled tasks", func(t *testing.T) {
+		tasks, err := state.TasksInUpcoming(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInUpcoming failed: %v", err)
+		}
+		if !hasTask(tasks, "upcoming-1") {
+			t.Error("upcoming task should be returned")
+		}
+		if hasTask(tasks, "someday-1") {
+			t.Error("unscheduled someday task should not be returned in Upcoming")
+		}
+	})
+
+	t.Run("Heading queries return headings and child tasks", func(t *testing.T) {
+		headings, err := state.AllHeadings(QueryOpts{})
+		if err != nil {
+			t.Fatalf("AllHeadings failed: %v", err)
+		}
+		if !hasTask(headings, "heading-1") {
+			t.Error("heading should be returned")
+		}
+
+		projectHeadings, err := state.HeadingsInProject("project-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("HeadingsInProject failed: %v", err)
+		}
+		if !hasTask(projectHeadings, "heading-1") {
+			t.Error("project heading should be returned")
+		}
+
+		tasks, err := state.TasksUnderHeading("heading-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksUnderHeading failed: %v", err)
+		}
+		if !hasTask(tasks, "under-heading-1") {
+			t.Error("task under heading should be returned")
+		}
+	})
+
+	t.Run("TasksWithTag returns tagged tasks", func(t *testing.T) {
+		tasks, err := state.TasksWithTag("tag-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksWithTag failed: %v", err)
+		}
+		if !hasTask(tasks, "tagged-1") {
+			t.Error("tagged task should be returned")
+		}
+	})
+
+	t.Run("SearchTasks returns matching tasks", func(t *testing.T) {
+		tasks, err := state.SearchTasks("needle", QueryOpts{})
+		if err != nil {
+			t.Fatalf("SearchTasks failed: %v", err)
+		}
+		if !hasTask(tasks, "search-1") {
+			t.Error("matching task title should be returned")
+		}
+
+		tasks, err = state.SearchTasks("haystack", QueryOpts{})
+		if err != nil {
+			t.Fatalf("SearchTasks failed: %v", err)
+		}
+		if !hasTask(tasks, "search-1") {
+			t.Error("matching task note should be returned")
+		}
+	})
+}
+
+func hasTask(tasks []*things.Task, uuid string) bool {
+	for _, task := range tasks {
+		if task.UUID == uuid {
+			return true
+		}
+	}
+	return false
 }

--- a/sync/state.go
+++ b/sync/state.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -117,7 +118,7 @@ func (st *State) TasksInInbox(opts QueryOpts) ([]*things.Task, error) {
 
 // TasksInToday returns tasks scheduled for today
 func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
-	today := time.Now().Truncate(24 * time.Hour)
+	today := startOfDay(time.Now())
 	tomorrow := today.Add(24 * time.Hour)
 
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1
@@ -131,6 +132,39 @@ func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
 	query += ` ORDER BY today_index, "index"`
 
 	rows, err := st.db.Query(query, today.Unix(), tomorrow.Unix())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return st.scanTaskUUIDs(rows)
+}
+
+// TasksInAnytime returns tasks in Anytime.
+func (st *State) TasksInAnytime(opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1 AND scheduled_date IS NULL AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query)
+}
+
+// TasksInSomeday returns tasks in Someday.
+func (st *State) TasksInSomeday(opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 2 AND scheduled_date IS NULL AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query)
+}
+
+// TasksInUpcoming returns tasks scheduled for future dates.
+func (st *State) TasksInUpcoming(opts QueryOpts) ([]*things.Task, error) {
+	tomorrow := startOfDay(time.Now()).Add(24 * time.Hour)
+
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 2
+		AND scheduled_date >= ? AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY scheduled_date, "index"`
+
+	rows, err := st.db.Query(query, tomorrow.Unix())
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +210,61 @@ func (st *State) TasksInArea(areaUUID string, opts QueryOpts) ([]*things.Task, e
 	return st.scanTaskUUIDs(rows)
 }
 
+// AllHeadings returns all headings.
+func (st *State) AllHeadings(opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 2 AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query)
+}
+
+// HeadingsInProject returns headings belonging to a project.
+func (st *State) HeadingsInProject(projectUUID string, opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 2 AND project_uuid = ? AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query, projectUUID)
+}
+
+// TasksUnderHeading returns tasks belonging to a heading.
+func (st *State) TasksUnderHeading(headingUUID string, opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND heading_uuid = ? AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query, headingUUID)
+}
+
+// TasksWithTag returns tasks tagged with the given tag UUID.
+func (st *State) TasksWithTag(tagUUID string, opts QueryOpts) ([]*things.Task, error) {
+	query := `
+		SELECT t.uuid
+		FROM tasks t
+		INNER JOIN task_tags tt ON tt.task_uuid = t.uuid
+		WHERE t.type = 0 AND tt.tag_uuid = ? AND t.deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY t."index"`
+	return st.queryTasks(query, tagUUID)
+}
+
+// SearchTasks returns tasks whose title or note contains query.
+func (st *State) SearchTasks(query string, opts QueryOpts) ([]*things.Task, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []*things.Task{}, nil
+	}
+
+	sqlQuery := `
+		SELECT uuid
+		FROM tasks
+		WHERE type = 0 AND deleted = 0
+			AND (title LIKE ? ESCAPE '\' OR note LIKE ? ESCAPE '\')`
+	sqlQuery = applyTaskQueryOpts(sqlQuery, opts)
+	sqlQuery += ` ORDER BY "index"`
+
+	pattern := likePattern(query)
+	return st.queryTasks(sqlQuery, pattern, pattern)
+}
+
 // ChecklistItems returns checklist items for a task
 func (st *State) ChecklistItems(taskUUID string) ([]*things.CheckListItem, error) {
 	rows, err := st.db.Query(`
@@ -205,8 +294,8 @@ func (st *State) ChecklistItems(taskUUID string) ([]*things.CheckListItem, error
 
 // Helper methods
 
-func (st *State) queryTasks(query string) ([]*things.Task, error) {
-	rows, err := st.db.Query(query)
+func (st *State) queryTasks(query string, args ...any) ([]*things.Task, error) {
+	rows, err := st.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -231,5 +320,27 @@ func (st *State) scanTaskUUIDs(rows *sql.Rows) ([]*things.Task, error) {
 			tasks = append(tasks, task)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return tasks, nil
+}
+
+func applyTaskQueryOpts(query string, opts QueryOpts) string {
+	if !opts.IncludeCompleted {
+		query += " AND status != 3"
+	}
+	if !opts.IncludeTrashed {
+		query += " AND in_trash = 0"
+	}
+	return query
+}
+
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+func likePattern(query string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return "%" + replacer.Replace(query) + "%"
 }


### PR DESCRIPTION
## Summary

- add state query helpers for Anytime, Someday, Upcoming, headings, heading children, tags, and text search
- switch Today range calculation to local-day boundaries instead of duration truncation
- add regression coverage for the new query helpers and QueryOpts filtering
- update README state-query examples to match the implemented API

## Context

The README already advertised `TasksInAnytime`, but `sync.State` only exposed Inbox, Today, Project, and Area task queries. These helpers make the persistent sync state more usable for clients that need Things-style views, including OpenClaw-style integrations.

`SearchTasks` is intentionally a simple SQLite `LIKE` search over title and note. It is not a full-text index.

## Validation

- `go test ./sync -run TestStateQueries -count=1`
- `go test ./...`