### PR TITLE
[codex] harden CLI scheduling payloads

### DIFF
--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,15 +92,15 @@ type TaskCreatePayload struct {
 
 // ChecklistItemCreatePayload — all 9 fields for checklist item creation.
 type ChecklistItemCreatePayload struct {
-	Cd   float64       `json:"cd"`
-	Md   *float64      `json:"md"`
-	Tt   string        `json:"tt"`
-	Ss   int           `json:"ss"`
-	Sp   *float64      `json:"sp"`
-	Ix   int           `json:"ix"`
-	Ts   []string      `json:"ts"`
-	Lt   bool          `json:"lt"`
-	Xx   WireExtension `json:"xx"`
+	Cd float64       `json:"cd"`
+	Md *float64      `json:"md"`
+	Tt string        `json:"tt"`
+	Ss int           `json:"ss"`
+	Sp *float64      `json:"sp"`
+	Ix int           `json:"ix"`
+	Ts []string      `json:"ts"`
+	Lt bool          `json:"lt"`
+	Xx WireExtension `json:"xx"`
 }
 
 // TagCreatePayload — all 5 fields for tag creation.
@@ -182,6 +182,12 @@ func parseArgs(args []string) map[string]string {
 		}
 	}
 	return result
+}
+
+func hasExplicitSchedule(opts map[string]string) bool {
+	_, hasWhen := opts["when"]
+	_, hasScheduled := opts["scheduled"]
+	return hasWhen || hasScheduled
 }
 
 func fatal(op string, err error) {
@@ -407,6 +413,27 @@ func (u *taskUpdate) Schedule(st int, sr, tir any) *taskUpdate {
 	u.fields["sr"] = sr
 	u.fields["tir"] = tir
 	return u
+}
+
+func (u *taskUpdate) Today() *taskUpdate {
+	today := todayMidnightUTC()
+	return u.Schedule(1, today, today)
+}
+
+func (u *taskUpdate) Anytime() *taskUpdate {
+	return u.Schedule(1, nil, nil)
+}
+
+func (u *taskUpdate) Someday() *taskUpdate {
+	return u.Schedule(2, nil, nil)
+}
+
+func (u *taskUpdate) Inbox() *taskUpdate {
+	return u.Schedule(0, nil, nil)
+}
+
+func (u *taskUpdate) ScheduleDate(ts int64) *taskUpdate {
+	return u.Schedule(1, ts, ts)
 }
 
 func (u *taskUpdate) Deadline(dd int64) *taskUpdate {
@@ -740,14 +767,13 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 	if v, ok := opts["when"]; ok {
 		switch v {
 		case "today":
-			today := todayMidnightUTC()
-			u.Schedule(1, today, today)
+			u.Today()
 		case "anytime":
-			u.Schedule(1, nil, nil)
+			u.Anytime()
 		case "someday":
-			u.Schedule(2, nil, nil)
+			u.Someday()
 		case "inbox":
-			u.Schedule(0, nil, nil)
+			u.Inbox()
 		}
 	}
 	if v, ok := opts["deadline"]; ok {
@@ -760,29 +786,29 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 			ts := t.Unix()
 			u.Scheduled(ts, ts)
 			if _, hasWhen := opts["when"]; !hasWhen {
-				u.Schedule(1, ts, ts)
+				u.ScheduleDate(ts)
 			}
 		}
 	}
 	if v, ok := opts["area"]; ok && v != "" {
 		u.Area(v)
-		// When adding an area, also move out of Inbox (st=0 → st=1)
-		if _, hasWhen := opts["when"]; !hasWhen {
-			u.Schedule(1, 0, 0) // Anytime
+		// When adding an area, also move out of Inbox unless a schedule was explicit.
+		if !hasExplicitSchedule(opts) {
+			u.Anytime()
 		}
 	}
 	if v, ok := opts["project"]; ok && v != "" {
 		u.Project(v)
-		// When adding a project, also move out of Inbox (st=0 → st=1)
-		if _, hasWhen := opts["when"]; !hasWhen {
-			u.Schedule(1, 0, 0) // Anytime
+		// When adding a project, also move out of Inbox unless a schedule was explicit.
+		if !hasExplicitSchedule(opts) {
+			u.Anytime()
 		}
 	}
 	if v, ok := opts["heading"]; ok && v != "" {
 		u.Heading(v)
-		// When adding a heading, also move out of Inbox (st=0 → st=1)
-		if _, hasWhen := opts["when"]; !hasWhen {
-			u.Schedule(1, 0, 0) // Anytime
+		// When adding a heading, also move out of Inbox unless a schedule was explicit.
+		if !hasExplicitSchedule(opts) {
+			u.Anytime()
 		}
 	}
 	if v, ok := opts["tags"]; ok && v != "" {
@@ -836,8 +862,7 @@ func cmdPurge(history *thingscloud.History, taskUUID string) {
 }
 
 func cmdMoveToToday(history *thingscloud.History, taskUUID string) {
-	today := todayMidnightUTC()
-	u := newTaskUpdate().Schedule(1, today, today)
+	u := newTaskUpdate().Today()
 
 	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
 	if err := history.Write(env); err != nil {
@@ -1084,8 +1109,7 @@ func buildBatchMoveToToday(op BatchOp) (thingscloud.Identifiable, map[string]str
 		return nil, nil, fmt.Errorf("move-to-today requires uuid")
 	}
 
-	today := todayMidnightUTC()
-	u := newTaskUpdate().Schedule(1, today, today)
+	u := newTaskUpdate().Today()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-today", "uuid": op.UUID}, nil
@@ -1099,7 +1123,7 @@ func buildBatchMoveToProject(op BatchOp) (thingscloud.Identifiable, map[string]s
 		return nil, nil, fmt.Errorf("move-to-project requires project")
 	}
 
-	u := newTaskUpdate().Project(op.Project).Schedule(1, 0, 0)
+	u := newTaskUpdate().Project(op.Project).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-project", "uuid": op.UUID, "project": op.Project}, nil
@@ -1113,7 +1137,7 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 		return nil, nil, fmt.Errorf("move-to-area requires area")
 	}
 
-	u := newTaskUpdate().Area(op.Area).Schedule(1, 0, 0)
+	u := newTaskUpdate().Area(op.Area).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-area", "uuid": op.UUID, "area": op.Area}, nil
@@ -1135,14 +1159,13 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 	if op.When != "" {
 		switch op.When {
 		case "today":
-			today := todayMidnightUTC()
-			u.Schedule(1, today, today)
+			u.Today()
 		case "anytime":
-			u.Schedule(1, nil, nil)
+			u.Anytime()
 		case "someday":
-			u.Schedule(2, nil, nil)
+			u.Someday()
 		case "inbox":
-			u.Schedule(0, nil, nil)
+			u.Inbox()
 		}
 	}
 	if op.Deadline != "" {
@@ -1153,19 +1176,19 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 	if op.Project != "" {
 		u.Project(op.Project)
 		if op.When == "" {
-			u.Schedule(1, 0, 0)
+			u.Anytime()
 		}
 	}
 	if op.Area != "" {
 		u.Area(op.Area)
 		if op.When == "" {
-			u.Schedule(1, 0, 0)
+			u.Anytime()
 		}
 	}
 	if op.Heading != "" {
 		u.Heading(op.Heading)
 		if op.When == "" {
-			u.Schedule(1, 0, 0)
+			u.Anytime()
 		}
 	}
 	if len(op.Tags) > 0 {

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func requirePayloadMap(t *testing.T, env any) map[string]any {
+	t.Helper()
+	envelope, ok := env.(writeEnvelope)
+	if !ok {
+		t.Fatalf("expected writeEnvelope, got %T", env)
+	}
+	payload, ok := envelope.payload.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map payload, got %T", envelope.payload)
+	}
+	return payload
+}
+
+func assertAnytimeSchedule(t *testing.T, payload map[string]any) {
+	t.Helper()
+	if payload["st"] != 1 {
+		t.Fatalf("st = %v, want 1", payload["st"])
+	}
+	if payload["sr"] != nil {
+		t.Fatalf("sr = %v, want nil", payload["sr"])
+	}
+	if payload["tir"] != nil {
+		t.Fatalf("tir = %v, want nil", payload["tir"])
+	}
+}
+
+func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
+	payload := newTaskUpdate().Project("project-1").Anytime().build()
+
+	assertAnytimeSchedule(t, payload)
+	if got := payload["pr"]; got == nil {
+		t.Fatal("project field was not set")
+	}
+}
+
+func TestHasExplicitSchedule(t *testing.T) {
+	tests := []struct {
+		name string
+		opts map[string]string
+		want bool
+	}{
+		{
+			name: "none",
+			opts: map[string]string{},
+			want: false,
+		},
+		{
+			name: "when",
+			opts: map[string]string{"when": "today"},
+			want: true,
+		},
+		{
+			name: "scheduled",
+			opts: map[string]string{"scheduled": "2026-05-20"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasExplicitSchedule(tt.opts); got != tt.want {
+				t.Fatalf("hasExplicitSchedule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
+	env, _, err := buildBatchMoveToProject(BatchOp{
+		UUID:    "task-1",
+		Project: "project-1",
+	})
+	if err != nil {
+		t.Fatalf("buildBatchMoveToProject failed: %v", err)
+	}
+
+	payload := requirePayloadMap(t, env)
+	assertAnytimeSchedule(t, payload)
+
+	bs, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	var wire struct {
+		P map[string]any `json:"p"`
+	}
+	if err := json.Unmarshal(bs, &wire); err != nil {
+		t.Fatalf("unmarshal wire payload failed: %v", err)
+	}
+	if wire.P["sr"] != nil {
+		t.Fatalf("wire sr = %v, want null", wire.P["sr"])
+	}
+	if wire.P["tir"] != nil {
+		t.Fatalf("wire tir = %v, want null", wire.P["tir"])
+	}
+}
+
+func TestBatchMoveToAreaUsesNullScheduleDates(t *testing.T) {
+	env, _, err := buildBatchMoveToArea(BatchOp{
+		UUID: "task-1",
+		Area: "area-1",
+	})
+	if err != nil {
+		t.Fatalf("buildBatchMoveToArea failed: %v", err)
+	}
+
+	assertAnytimeSchedule(t, requirePayloadMap(t, env))
+}
+
+func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
+	tests := []struct {
+		name string
+		op   BatchOp
+	}{
+		{
+			name: "project",
+			op:   BatchOp{UUID: "task-1", Project: "project-1"},
+		},
+		{
+			name: "area",
+			op:   BatchOp{UUID: "task-1", Area: "area-1"},
+		},
+		{
+			name: "heading",
+			op:   BatchOp{UUID: "task-1", Heading: "heading-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, _, err := buildBatchEdit(tt.op)
+			if err != nil {
+				t.Fatalf("buildBatchEdit failed: %v", err)
+			}
+			assertAnytimeSchedule(t, requirePayloadMap(t, env))
+		})
+	}
+}
+
+func TestBatchEditExplicitWhenWinsOverAutoAnytime(t *testing.T) {
+	env, _, err := buildBatchEdit(BatchOp{
+		UUID:    "task-1",
+		Project: "project-1",
+		When:    "someday",
+	})
+	if err != nil {
+		t.Fatalf("buildBatchEdit failed: %v", err)
+	}
+
+	payload := requirePayloadMap(t, env)
+	if payload["st"] != 2 {
+		t.Fatalf("st = %v, want 2", payload["st"])
+	}
+	if payload["sr"] != nil {
+		t.Fatalf("sr = %v, want nil", payload["sr"])
+	}
+	if payload["tir"] != nil {
+		t.Fatalf("tir = %v, want nil", payload["tir"])
+	}
+}


### PR DESCRIPTION
## Summary

- add explicit `taskUpdate` helpers for Today, Anytime, Someday, Inbox, and date scheduling
- replace auto-Anytime update payloads that used `sr: 0` / `tir: 0` with explicit `null` date fields
- keep explicit `--scheduled` from being cleared when `edit` also assigns an area, project, or heading
- add CLI payload tests for batch move/edit scheduling semantics

## Context

Several update paths used `Schedule(1, 0, 0)` as shorthand for Anytime while assigning projects, areas, or headings. That is risky because `sr=0` and `tir=0` can be interpreted as the Unix epoch rather than "no scheduled date". The create path already uses nullable date fields for this distinction; this patch makes sparse update payloads do the same.

## Validation

- `go test ./cmd/things-cli -count=1`
- `go test ./...`