### PR TITLE
[codex] cache things-cli read state

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ things-cli areas
 things-cli projects
 things-cli tags
 
+# Optional read-state cache location
+export THINGS_CLI_CACHE=/path/to/things-cli-state.json
+
 # Create
 things-cli create "Title" [--note ...] [--when today|anytime|someday|inbox] \
   [--deadline YYYY-MM-DD] [--scheduled YYYY-MM-DD] \

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -15,7 +15,7 @@ Or create a `.env` file and source it: `source .env`
 Full-featured CLI for CRUD operations on Things Cloud.
 
 ```bash
-# Read operations (loads full state)
+# Read operations (uses an incremental local state cache)
 things-cli list [--today] [--inbox] [--area NAME] [--project NAME]
 things-cli show <uuid>
 things-cli areas
@@ -40,6 +40,9 @@ echo '[
 
 # Batch commands: create, complete, trash, purge, move-to-today,
 #                 move-to-project, move-to-area, edit
+
+# Optional read-state cache location:
+#   THINGS_CLI_CACHE=/path/to/things-cli-state.json
 
 # Create options:
 #   --note "text"           Add a note

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -6,12 +6,13 @@ import (
 	"hash/crc32"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,15 +93,15 @@ type TaskCreatePayload struct {
 
 // ChecklistItemCreatePayload — all 9 fields for checklist item creation.
 type ChecklistItemCreatePayload struct {
-	Cd   float64       `json:"cd"`
-	Md   *float64      `json:"md"`
-	Tt   string        `json:"tt"`
-	Ss   int           `json:"ss"`
-	Sp   *float64      `json:"sp"`
-	Ix   int           `json:"ix"`
-	Ts   []string      `json:"ts"`
-	Lt   bool          `json:"lt"`
-	Xx   WireExtension `json:"xx"`
+	Cd float64       `json:"cd"`
+	Md *float64      `json:"md"`
+	Tt string        `json:"tt"`
+	Ss int           `json:"ss"`
+	Sp *float64      `json:"sp"`
+	Ix int           `json:"ix"`
+	Ts []string      `json:"ts"`
+	Lt bool          `json:"lt"`
+	Xx WireExtension `json:"xx"`
 }
 
 // TagCreatePayload — all 5 fields for tag creation.
@@ -453,7 +454,78 @@ type cliContext struct {
 	history *thingscloud.History
 }
 
-func initCLI() *cliContext {
+type cliStateCache struct {
+	HistoryID   string        `json:"historyId"`
+	ServerIndex int           `json:"serverIndex"`
+	State       *memory.State `json:"state"`
+}
+
+func commandNeedsHistoryHead(cmd string) bool {
+	switch cmd {
+	case "create", "create-area", "create-tag", "add-checklist", "edit", "complete", "trash", "purge", "move-to-today", "batch":
+		return true
+	default:
+		return false
+	}
+}
+
+func cliStateCachePath() string {
+	if path := os.Getenv("THINGS_CLI_CACHE"); path != "" {
+		return path
+	}
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "things-cloud-sdk", "things-cli-state.json")
+	}
+	return filepath.Join(os.TempDir(), "things-cloud-sdk", "things-cli-state.json")
+}
+
+func loadCLIStateCache(path string) (*cliStateCache, error) {
+	bs, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cache cliStateCache
+	if err := json.Unmarshal(bs, &cache); err != nil {
+		return nil, err
+	}
+	if cache.State == nil {
+		cache.State = memory.NewState()
+	} else {
+		normalizeMemoryState(cache.State)
+	}
+	return &cache, nil
+}
+
+func normalizeMemoryState(state *memory.State) {
+	if state.Areas == nil {
+		state.Areas = map[string]*thingscloud.Area{}
+	}
+	if state.Tasks == nil {
+		state.Tasks = map[string]*thingscloud.Task{}
+	}
+	if state.Tags == nil {
+		state.Tags = map[string]*thingscloud.Tag{}
+	}
+	if state.CheckListItems == nil {
+		state.CheckListItems = map[string]*thingscloud.CheckListItem{}
+	}
+}
+
+func saveCLIStateCache(path string, cache *cliStateCache) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	bs, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, bs, 0o600)
+}
+
+func initCLI(syncHistoryHead bool) *cliContext {
 	username := requireEnv("THINGS_USERNAME")
 	password := requireEnv("THINGS_PASSWORD")
 
@@ -470,30 +542,69 @@ func initCLI() *cliContext {
 	if err != nil {
 		fatal("get history", err)
 	}
-	if err := history.Sync(); err != nil {
-		fatal("sync history", err)
+	if syncHistoryHead {
+		if err := history.Sync(); err != nil {
+			fatal("sync history", err)
+		}
 	}
 
 	return &cliContext{client: c, history: history}
 }
 
+func (ctx *cliContext) serverIndex() int {
+	history, err := ctx.client.History(ctx.history.ID)
+	if err != nil {
+		fatal("get server index", err)
+	}
+	return history.LatestServerIndex
+}
+
 func (ctx *cliContext) loadState() *memory.State {
-	var allItems []thingscloud.Item
+	cachePath := cliStateCachePath()
+	cache, err := loadCLIStateCache(cachePath)
+	if err != nil {
+		fatal("load state cache", err)
+	}
+
+	state := memory.NewState()
 	startIndex := 0
+	if cache != nil && cache.HistoryID == ctx.history.ID {
+		state = cache.State
+		startIndex = cache.ServerIndex
+	}
+
+	latestServerIndex := ctx.serverIndex()
+	if startIndex > latestServerIndex {
+		state = memory.NewState()
+		startIndex = 0
+	}
+
 	for {
+		if startIndex >= latestServerIndex {
+			break
+		}
+		ctx.history.LoadedServerIndex = startIndex
 		items, hasMore, err := ctx.history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
 		if err != nil {
 			fatal("fetch items", err)
 		}
-		allItems = append(allItems, items...)
+		if err := state.Update(items...); err != nil {
+			fatal("update state", err)
+		}
+		startIndex = ctx.history.LoadedServerIndex
 		if !hasMore {
 			break
 		}
-		startIndex = ctx.history.LoadedServerIndex
 	}
 
-	state := memory.NewState()
-	state.Update(allItems...)
+	if err := saveCLIStateCache(cachePath, &cliStateCache{
+		HistoryID:   ctx.history.ID,
+		ServerIndex: startIndex,
+		State:       state,
+	}); err != nil {
+		fatal("save state cache", err)
+	}
+
 	return state
 }
 
@@ -1184,12 +1295,15 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: things-cli <command> [args]
 
-Read commands (load state from cloud):
+Read commands (use an incremental local state cache):
   list [--today] [--inbox] [--area NAME] [--project NAME]
   show <uuid>
   areas
   projects
   tags
+
+Environment:
+  THINGS_CLI_CACHE=/path/to/things-cli-state.json  Override read-state cache file
 
 Write commands (fast — skip state loading):
   create "Title" [--note ...] [--when today|anytime|someday|inbox]
@@ -1231,8 +1345,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := initCLI()
 	cmd := os.Args[1]
+	ctx := initCLI(commandNeedsHistoryHead(cmd))
 
 	switch cmd {
 	// Read commands — need state

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+)
+
+func TestCommandNeedsHistoryHead(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"list", false},
+		{"show", false},
+		{"areas", false},
+		{"projects", false},
+		{"tags", false},
+		{"create", true},
+		{"edit", true},
+		{"complete", true},
+		{"trash", true},
+		{"batch", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := commandNeedsHistoryHead(tt.cmd); got != tt.want {
+				t.Fatalf("commandNeedsHistoryHead(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCLIStateCachePathUsesEnvOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	t.Setenv("THINGS_CLI_CACHE", path)
+
+	if got := cliStateCachePath(); got != path {
+		t.Fatalf("cliStateCachePath() = %q, want %q", got, path)
+	}
+}
+
+func TestCLIStateCacheMissingFile(t *testing.T) {
+	cache, err := loadCLIStateCache(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if cache != nil {
+		t.Fatalf("cache = %#v, want nil", cache)
+	}
+}
+
+func TestCLIStateCacheRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "state.json")
+	state := memory.NewState()
+	state.Tasks["task-1"] = &thingscloud.Task{
+		UUID:  "task-1",
+		Title: "Cached Task",
+	}
+	state.Areas["area-1"] = &thingscloud.Area{
+		UUID:  "area-1",
+		Title: "Cached Area",
+	}
+
+	cache := &cliStateCache{
+		HistoryID:   "history-1",
+		ServerIndex: 42,
+		State:       state,
+	}
+	if err := saveCLIStateCache(path, cache); err != nil {
+		t.Fatalf("saveCLIStateCache failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat cache failed: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("cache path is a directory")
+	}
+
+	loaded, err := loadCLIStateCache(path)
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if loaded.HistoryID != "history-1" {
+		t.Fatalf("HistoryID = %q, want history-1", loaded.HistoryID)
+	}
+	if loaded.ServerIndex != 42 {
+		t.Fatalf("ServerIndex = %d, want 42", loaded.ServerIndex)
+	}
+	if loaded.State.Tasks["task-1"].Title != "Cached Task" {
+		t.Fatalf("task title = %q, want Cached Task", loaded.State.Tasks["task-1"].Title)
+	}
+	if loaded.State.Areas["area-1"].Title != "Cached Area" {
+		t.Fatalf("area title = %q, want Cached Area", loaded.State.Areas["area-1"].Title)
+	}
+}
+
+func TestCLIStateCacheNormalizesEmptyState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	cache := &cliStateCache{
+		HistoryID:   "history-1",
+		ServerIndex: 7,
+		State:       &memory.State{},
+	}
+	if err := saveCLIStateCache(path, cache); err != nil {
+		t.Fatalf("saveCLIStateCache failed: %v", err)
+	}
+
+	loaded, err := loadCLIStateCache(path)
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if loaded.State.Tasks == nil {
+		t.Fatal("Tasks map was not initialized")
+	}
+	if loaded.State.Areas == nil {
+		t.Fatal("Areas map was not initialized")
+	}
+	if loaded.State.Tags == nil {
+		t.Fatal("Tags map was not initialized")
+	}
+	if loaded.State.CheckListItems == nil {
+		t.Fatal("CheckListItems map was not initialized")
+	}
+}


### PR DESCRIPTION
## Summary

- add an incremental local state cache for `things-cli` read commands
- avoid the startup `history.Sync()` call for read-only commands
- fetch only delta items after the cached server index, rebuilding from zero only when the cache cursor is ahead of the server
- document `THINGS_CLI_CACHE` for overriding the cache file path
- add tests for command classification and cache round-tripping

## Context

Before this change, every read command rebuilt `memory.State` from `start-index=0`, and `initCLI()` also fetched history items before dispatching the command. That made commands like `list`, `show`, `areas`, `projects`, and `tags` pay a full-history cost on every invocation.

The cache stores the aggregated `memory.State` plus the last server index. On subsequent read commands, the CLI checks the current server index and applies only new history items to the cached state. Write commands still sync the history head before writing so `ancestor-index` stays valid.

This branch is independent of the pagination fix in #6: before fetching a delta page, it seeds `history.LoadedServerIndex` with the cached cursor so the current `main` implementation continues from the correct position.

## Validation

- `go test ./cmd/things-cli -count=1`
- `go test ./...`