### PR TITLE
[codex] add things-cli view commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,13 @@ go build -o things-cli ./cmd/things-cli/
 
 ```bash
 # Read
-things-cli list [--today] [--inbox] [--area NAME] [--project NAME]
+things-cli list [--today] [--inbox] [--anytime] [--someday] [--upcoming] [--search QUERY] [--area NAME] [--project NAME]
+things-cli today
+things-cli inbox
+things-cli anytime
+things-cli someday
+things-cli upcoming
+things-cli search <query>
 things-cli show <uuid>
 things-cli areas
 things-cli projects

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -16,7 +16,13 @@ Full-featured CLI for CRUD operations on Things Cloud.
 
 ```bash
 # Read operations (loads full state)
-things-cli list [--today] [--inbox] [--area NAME] [--project NAME]
+things-cli list [--today] [--inbox] [--anytime] [--someday] [--upcoming] [--search QUERY] [--area NAME] [--project NAME]
+things-cli today
+things-cli inbox
+things-cli anytime
+things-cli someday
+things-cli upcoming
+things-cli search <query>
 things-cli show <uuid>
 things-cli areas
 things-cli projects

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -6,12 +6,13 @@ import (
 	"hash/crc32"
 	"math/big"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,15 +93,15 @@ type TaskCreatePayload struct {
 
 // ChecklistItemCreatePayload — all 9 fields for checklist item creation.
 type ChecklistItemCreatePayload struct {
-	Cd   float64       `json:"cd"`
-	Md   *float64      `json:"md"`
-	Tt   string        `json:"tt"`
-	Ss   int           `json:"ss"`
-	Sp   *float64      `json:"sp"`
-	Ix   int           `json:"ix"`
-	Ts   []string      `json:"ts"`
-	Lt   bool          `json:"lt"`
-	Xx   WireExtension `json:"xx"`
+	Cd float64       `json:"cd"`
+	Md *float64      `json:"md"`
+	Tt string        `json:"tt"`
+	Ss int           `json:"ss"`
+	Sp *float64      `json:"sp"`
+	Ix int           `json:"ix"`
+	Ts []string      `json:"ts"`
+	Lt bool          `json:"lt"`
+	Xx WireExtension `json:"xx"`
 }
 
 // TagCreatePayload — all 5 fields for tag creation.
@@ -539,9 +540,16 @@ func taskToOutput(t *thingscloud.Task) TaskOutput {
 	return out
 }
 
-func cmdList(state *memory.State, args []string) {
-	opts := parseArgs(args)
-	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
+func sameDay(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+func listTasks(state *memory.State, opts map[string]string) []TaskOutput {
+	now := time.Now().UTC()
+	tomorrowStart := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+	searchQuery := strings.ToLower(strings.TrimSpace(opts["search"]))
 
 	var tasks []TaskOutput
 	for _, task := range state.Tasks {
@@ -551,12 +559,34 @@ func cmdList(state *memory.State, args []string) {
 
 		// Filters
 		if _, ok := opts["today"]; ok {
-			if task.Schedule != thingscloud.TaskScheduleAnytime || task.ScheduledDate == nil || !task.ScheduledDate.Equal(todayStart) {
+			if task.Schedule != thingscloud.TaskScheduleAnytime || task.ScheduledDate == nil || !sameDay(*task.ScheduledDate, now) {
 				continue
 			}
 		}
 		if _, ok := opts["inbox"]; ok {
 			if task.Schedule != thingscloud.TaskScheduleInbox {
+				continue
+			}
+		}
+		if _, ok := opts["anytime"]; ok {
+			if task.Schedule != thingscloud.TaskScheduleAnytime || task.ScheduledDate != nil {
+				continue
+			}
+		}
+		if _, ok := opts["someday"]; ok {
+			if task.Schedule != thingscloud.TaskScheduleSomeday || task.ScheduledDate != nil {
+				continue
+			}
+		}
+		if _, ok := opts["upcoming"]; ok {
+			if task.Schedule != thingscloud.TaskScheduleSomeday || task.ScheduledDate == nil || task.ScheduledDate.Before(tomorrowStart) {
+				continue
+			}
+		}
+		if searchQuery != "" {
+			title := strings.ToLower(task.Title)
+			note := strings.ToLower(task.Note)
+			if !strings.Contains(title, searchQuery) && !strings.Contains(note, searchQuery) {
 				continue
 			}
 		}
@@ -568,14 +598,38 @@ func cmdList(state *memory.State, args []string) {
 		}
 		if projectName, ok := opts["project"]; ok {
 			projectUUID := findProjectUUID(state, projectName)
-			if !containsStr(task.ActionGroupIDs, projectUUID) {
+			if !containsStr(task.ParentTaskIDs, projectUUID) {
 				continue
 			}
 		}
 
 		tasks = append(tasks, taskToOutput(task))
 	}
-	outputJSON(tasks)
+
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].ScheduledDate != nil && tasks[j].ScheduledDate != nil && *tasks[i].ScheduledDate != *tasks[j].ScheduledDate {
+			return *tasks[i].ScheduledDate < *tasks[j].ScheduledDate
+		}
+		if tasks[i].Title != tasks[j].Title {
+			return tasks[i].Title < tasks[j].Title
+		}
+		return tasks[i].UUID < tasks[j].UUID
+	})
+
+	return tasks
+}
+
+func cmdList(state *memory.State, args []string) {
+	outputJSON(listTasks(state, parseArgs(args)))
+}
+
+func cmdListWithOpts(state *memory.State, opts map[string]string) {
+	outputJSON(listTasks(state, opts))
+}
+
+func cmdSearch(state *memory.State, args []string) {
+	requireArgs(args, 1, "things-cli search <query>")
+	cmdListWithOpts(state, map[string]string{"search": strings.Join(args, " ")})
 }
 
 func cmdShow(state *memory.State, uuid string) {
@@ -1185,7 +1239,13 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: things-cli <command> [args]
 
 Read commands (load state from cloud):
-  list [--today] [--inbox] [--area NAME] [--project NAME]
+  list [--today] [--inbox] [--anytime] [--someday] [--upcoming] [--search QUERY] [--area NAME] [--project NAME]
+  today
+  inbox
+  anytime
+  someday
+  upcoming
+  search <query>
   show <uuid>
   areas
   projects
@@ -1238,6 +1298,18 @@ func main() {
 	// Read commands — need state
 	case "list":
 		cmdList(ctx.loadState(), os.Args[2:])
+	case "today":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"today": "true"})
+	case "inbox":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"inbox": "true"})
+	case "anytime":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"anytime": "true"})
+	case "someday":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"someday": "true"})
+	case "upcoming":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"upcoming": "true"})
+	case "search":
+		cmdSearch(ctx.loadState(), os.Args[2:])
 	case "show":
 		requireArgs(os.Args[2:], 1, "things-cli show <uuid>")
 		cmdShow(ctx.loadState(), os.Args[2])

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+)
+
+func testStateForListFilters() *memory.State {
+	state := memory.NewState()
+	today := time.Now().UTC()
+	tomorrow := today.Add(24 * time.Hour)
+
+	state.Areas["area-1"] = &thingscloud.Area{UUID: "area-1", Title: "Work"}
+	state.Tasks["project-1"] = &thingscloud.Task{
+		UUID:  "project-1",
+		Title: "Project Alpha",
+		Type:  thingscloud.TaskTypeProject,
+	}
+	state.Tasks["inbox-1"] = &thingscloud.Task{
+		UUID:     "inbox-1",
+		Title:    "Inbox Task",
+		Schedule: thingscloud.TaskScheduleInbox,
+	}
+	state.Tasks["today-1"] = &thingscloud.Task{
+		UUID:          "today-1",
+		Title:         "Today Task",
+		Schedule:      thingscloud.TaskScheduleAnytime,
+		ScheduledDate: &today,
+	}
+	state.Tasks["anytime-1"] = &thingscloud.Task{
+		UUID:     "anytime-1",
+		Title:    "Anytime Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+	}
+	state.Tasks["someday-1"] = &thingscloud.Task{
+		UUID:     "someday-1",
+		Title:    "Someday Task",
+		Schedule: thingscloud.TaskScheduleSomeday,
+	}
+	state.Tasks["upcoming-1"] = &thingscloud.Task{
+		UUID:          "upcoming-1",
+		Title:         "Upcoming Task",
+		Note:          "needle in note",
+		Schedule:      thingscloud.TaskScheduleSomeday,
+		ScheduledDate: &tomorrow,
+	}
+	state.Tasks["project-task-1"] = &thingscloud.Task{
+		UUID:          "project-task-1",
+		Title:         "Project Task",
+		Schedule:      thingscloud.TaskScheduleAnytime,
+		ParentTaskIDs: []string{"project-1"},
+	}
+	state.Tasks["area-task-1"] = &thingscloud.Task{
+		UUID:     "area-task-1",
+		Title:    "Area Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+		AreaIDs:  []string{"area-1"},
+	}
+	state.Tasks["completed-1"] = &thingscloud.Task{
+		UUID:     "completed-1",
+		Title:    "Completed Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+		Status:   thingscloud.TaskStatusCompleted,
+	}
+	state.Tasks["trashed-1"] = &thingscloud.Task{
+		UUID:     "trashed-1",
+		Title:    "Trashed Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+		InTrash:  true,
+	}
+	return state
+}
+
+func outputUUIDs(tasks []TaskOutput) []string {
+	uuids := make([]string, len(tasks))
+	for i, task := range tasks {
+		uuids[i] = task.UUID
+	}
+	return uuids
+}
+
+func requireUUIDs(t *testing.T, tasks []TaskOutput, want ...string) {
+	t.Helper()
+	got := outputUUIDs(tasks)
+	if len(got) != len(want) {
+		t.Fatalf("uuids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("uuids = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestListTasksLocationFilters(t *testing.T) {
+	state := testStateForListFilters()
+
+	requireUUIDs(t, listTasks(state, map[string]string{"today": "true"}), "today-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"inbox": "true"}), "inbox-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"someday": "true"}), "someday-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"upcoming": "true"}), "upcoming-1")
+
+	anytime := outputUUIDs(listTasks(state, map[string]string{"anytime": "true"}))
+	wantAnytime := []string{"anytime-1", "area-task-1", "project-task-1"}
+	if len(anytime) != len(wantAnytime) {
+		t.Fatalf("anytime = %v, want %v", anytime, wantAnytime)
+	}
+	for i := range wantAnytime {
+		if anytime[i] != wantAnytime[i] {
+			t.Fatalf("anytime = %v, want %v", anytime, wantAnytime)
+		}
+	}
+}
+
+func TestListTasksSearchAndContainerFilters(t *testing.T) {
+	state := testStateForListFilters()
+
+	requireUUIDs(t, listTasks(state, map[string]string{"search": "needle"}), "upcoming-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"search": "project"}), "project-task-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"area": "Work"}), "area-task-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"project": "Project Alpha"}), "project-task-1")
+}


### PR DESCRIPTION
## Summary

- add `things-cli` view aliases: `today`, `inbox`, `anytime`, `someday`, `upcoming`, and `search <query>`
- add matching `list` filters: `--anytime`, `--someday`, `--upcoming`, and `--search QUERY`
- make list filtering testable through `listTasks`
- fix `--project` filtering to use `ParentTaskIDs` instead of heading/action-group IDs
- document the new read commands in README files

## Context

OpenClaw-style integrations commonly expect simple Things views such as today, inbox, upcoming, someday, and search. The CLI already had `list --today` and `list --inbox`, but lacked the other views and had a project filter that checked `ActionGroupIDs` instead of the project relationship.

## Validation

- `go test ./cmd/things-cli -count=1`
- `go test ./...`