### PR TITLE
fix: canonical Base58 UUID encoding and validation

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -1,0 +1,85 @@
+package thingscloud
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// base58Alphabet is the Bitcoin Base58 alphabet Things.app uses for
+// identifiers (no 0, O, I, l). Things decodes identifiers with
+// BSIdentifierFromBase58String; anything it cannot decode to 16 bytes
+// permanently corrupts the sync history and crashes the client.
+const base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// EncodeUUID encodes a UUID as canonical Base58: one leading '1' per
+// leading zero byte, matching the identifiers Things.app itself emits.
+func EncodeUUID(u uuid.UUID) string {
+	zeros := 0
+	for zeros < len(u) && u[zeros] == 0 {
+		zeros++
+	}
+
+	n := new(big.Int).SetBytes(u[:])
+	base := big.NewInt(58)
+	mod := new(big.Int)
+	var encoded []byte
+	for n.Sign() > 0 {
+		n.DivMod(n, base, mod)
+		encoded = append(encoded, base58Alphabet[mod.Int64()])
+	}
+	for i := 0; i < zeros; i++ {
+		encoded = append(encoded, '1')
+	}
+	for i, j := 0, len(encoded)-1; i < j; i, j = i+1, j-1 {
+		encoded[i], encoded[j] = encoded[j], encoded[i]
+	}
+	return string(encoded)
+}
+
+// DecodeUUID decodes a canonical Base58 identifier back into a UUID.
+// It rejects strings that are not canonical encodings of exactly 16 bytes.
+func DecodeUUID(s string) (uuid.UUID, error) {
+	var u uuid.UUID
+	if s == "" {
+		return u, fmt.Errorf("thingscloud: empty identifier")
+	}
+
+	zeros := 0
+	for zeros < len(s) && s[zeros] == '1' {
+		zeros++
+	}
+
+	n := new(big.Int)
+	base := big.NewInt(58)
+	for i := zeros; i < len(s); i++ {
+		idx := strings.IndexByte(base58Alphabet, s[i])
+		if idx < 0 {
+			return u, fmt.Errorf("thingscloud: invalid Base58 character %q in identifier %q", s[i], s)
+		}
+		n.Mul(n, base)
+		n.Add(n, big.NewInt(int64(idx)))
+	}
+
+	value := n.Bytes()
+	if zeros+len(value) != len(u) {
+		return u, fmt.Errorf("thingscloud: identifier %q decodes to %d bytes, want 16 (non-canonical or wrong length)", s, zeros+len(value))
+	}
+	copy(u[len(u)-len(value):], value)
+	return u, nil
+}
+
+// ValidateUUID reports whether s is a canonical Base58-encoded 16-byte
+// identifier safe to write to Things Cloud.
+func ValidateUUID(s string) error {
+	_, err := DecodeUUID(s)
+	return err
+}
+
+// NewUUID returns a new random identifier in the canonical Base58 wire
+// format expected by Things Cloud.
+func NewUUID() string {
+	return EncodeUUID(uuid.New())
+}

--- a/base58_test.go
+++ b/base58_test.go
@@ -1,0 +1,121 @@
+package thingscloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestEncodeUUID_CanonicalLeadingZeros(t *testing.T) {
+	t.Parallel()
+
+	u := uuid.UUID{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+	s := EncodeUUID(u)
+	if !strings.HasPrefix(s, "1") {
+		t.Errorf("EncodeUUID(%v) = %q, want leading %q for leading zero byte", u, s, "1")
+	}
+
+	u2 := uuid.UUID{0x00, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+	s2 := EncodeUUID(u2)
+	if !strings.HasPrefix(s2, "11") {
+		t.Errorf("EncodeUUID(%v) = %q, want two leading 1s for two leading zero bytes", u2, s2)
+	}
+}
+
+func TestEncodeUUID_AllZero(t *testing.T) {
+	t.Parallel()
+
+	got := EncodeUUID(uuid.UUID{})
+	want := "1111111111111111" // one '1' per zero byte
+	if got != want {
+		t.Errorf("EncodeUUID(zero) = %q, want %q", got, want)
+	}
+}
+
+func TestEncodeDecodeUUID_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []uuid.UUID{
+		{},
+		{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee},
+		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+	}
+	for i := 0; i < 64; i++ {
+		cases = append(cases, uuid.New())
+	}
+	// Force leading-zero-byte cases, the historical corruption source.
+	for i := 0; i < 8; i++ {
+		u := uuid.New()
+		u[0] = 0x00
+		cases = append(cases, u)
+	}
+
+	for _, u := range cases {
+		s := EncodeUUID(u)
+		back, err := DecodeUUID(s)
+		if err != nil {
+			t.Fatalf("DecodeUUID(EncodeUUID(%v) = %q) failed: %v", u, s, err)
+		}
+		if back != u {
+			t.Errorf("round trip: %v -> %q -> %v", u, s, back)
+		}
+	}
+}
+
+func TestDecodeUUID_RealThingsIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	// Captured from real Things.app sync traffic (HAR).
+	for _, s := range []string{"VJ1edXTP9q3PmFDUuy8EQh", "FQxaqvLBkbR5q2Q5oRoknc", "BVU8qZ9dNjrdxLvDHPvfDS"} {
+		u, err := DecodeUUID(s)
+		if err != nil {
+			t.Fatalf("DecodeUUID(%q) failed: %v", s, err)
+		}
+		if got := EncodeUUID(u); got != s {
+			t.Errorf("re-encode of %q = %q, not canonical round trip", s, got)
+		}
+	}
+}
+
+func TestValidateUUID(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"VJ1edXTP9q3PmFDUuy8EQh",
+		"1111111111111111",
+		EncodeUUID(uuid.UUID{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}),
+	}
+	for _, s := range valid {
+		if err := ValidateUUID(s); err != nil {
+			t.Errorf("ValidateUUID(%q) = %v, want nil", s, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"standard hyphenated UUID":        "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c",
+		"contains 0":                      "VJ0edXTP9q3PmFDUuy8EQh",
+		"contains O":                      "VJOedXTP9q3PmFDUuy8EQh",
+		"contains I":                      "VJIedXTP9q3PmFDUuy8EQh",
+		"contains l":                      "VJledXTP9q3PmFDUuy8EQh",
+		"empty":                           "",
+		"value overflows 16 bytes":        "zzzzzzzzzzzzzzzzzzzzzz",
+		"non-canonical missing leading 1": strings.TrimPrefix(EncodeUUID(uuid.UUID{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}), "1"),
+	}
+	for name, s := range invalid {
+		if err := ValidateUUID(s); err == nil {
+			t.Errorf("ValidateUUID(%q) [%s] = nil, want error", s, name)
+		}
+	}
+}
+
+func TestNewUUID_AlwaysCanonical(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 2000; i++ {
+		s := NewUUID()
+		if err := ValidateUUID(s); err != nil {
+			t.Fatalf("NewUUID() = %q is not canonical: %v", s, err)
+		}
+	}
+}

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
-	"math/big"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,7 +12,6 @@ import (
 
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
-	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -135,22 +133,50 @@ func defaultExtension() WireExtension {
 }
 
 func generateUUID() string {
-	u := uuid.New()
-	// Base58 alphabet (Bitcoin/Flickr): no 0, O, I, l
-	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-	n := new(big.Int).SetBytes(u[:])
-	base := big.NewInt(58)
-	mod := new(big.Int)
-	var encoded []byte
-	for n.Sign() > 0 {
-		n.DivMod(n, base, mod)
-		encoded = append(encoded, alphabet[mod.Int64()])
+	return thingscloud.NewUUID()
+}
+
+// validateIdentifierOpts checks every option that carries a Things
+// identifier. Invalid identifiers written to the cloud poison the sync
+// history irreparably, so they must be rejected before any write.
+func validateIdentifierOpts(opts map[string]string) error {
+	for _, key := range []string{"uuid", "project", "heading", "area"} {
+		if v, ok := opts[key]; ok && v != "" {
+			if err := thingscloud.ValidateUUID(v); err != nil {
+				return fmt.Errorf("--%s: %w", key, err)
+			}
+		}
 	}
-	// Reverse (big-endian)
-	for i, j := 0, len(encoded)-1; i < j; i, j = i+1, j-1 {
-		encoded[i], encoded[j] = encoded[j], encoded[i]
+	if v, ok := opts["tags"]; ok && v != "" {
+		for _, tag := range strings.Split(v, ",") {
+			if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+				return fmt.Errorf("--tags: %w", err)
+			}
+		}
 	}
-	return string(encoded)
+	return nil
+}
+
+// validateBatchOpIdentifiers rejects a batch op carrying any invalid
+// Things identifier, for the same reason as validateIdentifierOpts.
+func validateBatchOpIdentifiers(op BatchOp) error {
+	check := map[string]string{
+		"uuid": op.UUID, "project": op.Project, "area": op.Area, "heading": op.Heading,
+	}
+	for name, v := range check {
+		if v == "" {
+			continue
+		}
+		if err := thingscloud.ValidateUUID(v); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	for _, tag := range op.Tags {
+		if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+			return fmt.Errorf("tags: %w", err)
+		}
+	}
+	return nil
 }
 
 func nowTs() float64 {
@@ -882,6 +908,9 @@ func cmdCreate(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("create task", err)
+	}
 
 	taskUUID := opts["uuid"]
 	if taskUUID == "" {
@@ -904,6 +933,9 @@ func cmdCreate(history *thingscloud.History, args []string) {
 
 func cmdAddChecklist(history *thingscloud.History, taskUUID string, args []string) {
 	requireArgs(args, 1, `things-cli add-checklist <task-uuid> "Item 1,Item 2,Item 3"`)
+	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
+		fatal("add-checklist", err)
+	}
 
 	items := strings.Split(args[0], ",")
 	cmdWriteChecklistItems(history, taskUUID, items)
@@ -915,6 +947,12 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 	opts := parseArgs(args)
 	if len(opts) == 0 {
 		fatalf("Usage: things-cli edit <uuid> [--title ...] [--note ...] [--when today|anytime|someday|inbox] [--deadline YYYY-MM-DD] [--scheduled YYYY-MM-DD] [--area UUID] [--project UUID] [--heading UUID] [--tags UUID,...]")
+	}
+	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
+		fatal("edit", err)
+	}
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("edit", err)
 	}
 
 	u := newTaskUpdate()
@@ -1189,6 +1227,9 @@ func buildBatchCreate(op BatchOp) (thingscloud.Identifiable, map[string]string, 
 	if op.Title == "" {
 		return nil, nil, fmt.Errorf("create requires title")
 	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
 
 	taskUUID := op.UUID
 	if taskUUID == "" {
@@ -1287,6 +1328,9 @@ func buildBatchMoveToProject(op BatchOp) (thingscloud.Identifiable, map[string]s
 	if op.Project == "" {
 		return nil, nil, fmt.Errorf("move-to-project requires project")
 	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
 
 	u := newTaskUpdate().Project(op.Project).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
@@ -1301,6 +1345,9 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 	if op.Area == "" {
 		return nil, nil, fmt.Errorf("move-to-area requires area")
 	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
 
 	u := newTaskUpdate().Area(op.Area).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
@@ -1311,6 +1358,9 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, error) {
 	if op.UUID == "" {
 		return nil, nil, fmt.Errorf("edit requires uuid")
+	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
 	}
 
 	u := newTaskUpdate()

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -11,6 +11,13 @@ import (
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
 )
 
+var (
+	testTaskID    = thingscloud.NewUUID()
+	testProjectID = thingscloud.NewUUID()
+	testAreaID    = thingscloud.NewUUID()
+	testHeadingID = thingscloud.NewUUID()
+)
+
 func requirePayloadMap(t *testing.T, env any) map[string]any {
 	t.Helper()
 	envelope, ok := env.(writeEnvelope)
@@ -38,7 +45,7 @@ func assertAnytimeSchedule(t *testing.T, payload map[string]any) {
 }
 
 func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
-	payload := newTaskUpdate().Project("project-1").Anytime().build()
+	payload := newTaskUpdate().Project(testProjectID).Anytime().build()
 
 	assertAnytimeSchedule(t, payload)
 	if got := payload["pr"]; got == nil {
@@ -106,8 +113,8 @@ func TestCommandNeedsHistoryHead(t *testing.T) {
 
 func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
 	env, _, err := buildBatchMoveToProject(BatchOp{
-		UUID:    "task-1",
-		Project: "project-1",
+		UUID:    testTaskID,
+		Project: testProjectID,
 	})
 	if err != nil {
 		t.Fatalf("buildBatchMoveToProject failed: %v", err)
@@ -136,8 +143,8 @@ func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
 
 func TestBatchMoveToAreaUsesNullScheduleDates(t *testing.T) {
 	env, _, err := buildBatchMoveToArea(BatchOp{
-		UUID: "task-1",
-		Area: "area-1",
+		UUID: testTaskID,
+		Area: testAreaID,
 	})
 	if err != nil {
 		t.Fatalf("buildBatchMoveToArea failed: %v", err)
@@ -153,15 +160,15 @@ func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
 	}{
 		{
 			name: "project",
-			op:   BatchOp{UUID: "task-1", Project: "project-1"},
+			op:   BatchOp{UUID: testTaskID, Project: testProjectID},
 		},
 		{
 			name: "area",
-			op:   BatchOp{UUID: "task-1", Area: "area-1"},
+			op:   BatchOp{UUID: testTaskID, Area: testAreaID},
 		},
 		{
 			name: "heading",
-			op:   BatchOp{UUID: "task-1", Heading: "heading-1"},
+			op:   BatchOp{UUID: testTaskID, Heading: testHeadingID},
 		},
 	}
 
@@ -178,8 +185,8 @@ func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
 
 func TestBatchEditExplicitWhenWinsOverAutoAnytime(t *testing.T) {
 	env, _, err := buildBatchEdit(BatchOp{
-		UUID:    "task-1",
-		Project: "project-1",
+		UUID:    testTaskID,
+		Project: testProjectID,
 		When:    "someday",
 	})
 	if err != nil {
@@ -220,12 +227,12 @@ func TestCLIStateCacheMissingFile(t *testing.T) {
 func TestCLIStateCacheRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "state.json")
 	state := memory.NewState()
-	state.Tasks["task-1"] = &thingscloud.Task{
-		UUID:  "task-1",
+	state.Tasks[testTaskID] = &thingscloud.Task{
+		UUID:  testTaskID,
 		Title: "Cached Task",
 	}
-	state.Areas["area-1"] = &thingscloud.Area{
-		UUID:  "area-1",
+	state.Areas[testAreaID] = &thingscloud.Area{
+		UUID:  testAreaID,
 		Title: "Cached Area",
 	}
 
@@ -256,11 +263,11 @@ func TestCLIStateCacheRoundTrip(t *testing.T) {
 	if loaded.ServerIndex != 42 {
 		t.Fatalf("ServerIndex = %d, want 42", loaded.ServerIndex)
 	}
-	if loaded.State.Tasks["task-1"].Title != "Cached Task" {
-		t.Fatalf("task title = %q, want Cached Task", loaded.State.Tasks["task-1"].Title)
+	if loaded.State.Tasks[testTaskID].Title != "Cached Task" {
+		t.Fatalf("task title = %q, want Cached Task", loaded.State.Tasks[testTaskID].Title)
 	}
-	if loaded.State.Areas["area-1"].Title != "Cached Area" {
-		t.Fatalf("area title = %q, want Cached Area", loaded.State.Areas["area-1"].Title)
+	if loaded.State.Areas[testAreaID].Title != "Cached Area" {
+		t.Fatalf("area title = %q, want Cached Area", loaded.State.Areas[testAreaID].Title)
 	}
 }
 
@@ -298,9 +305,9 @@ func testStateForListFilters() *memory.State {
 	today := time.Now().UTC()
 	tomorrow := today.Add(24 * time.Hour)
 
-	state.Areas["area-1"] = &thingscloud.Area{UUID: "area-1", Title: "Work"}
-	state.Tasks["project-1"] = &thingscloud.Task{
-		UUID:  "project-1",
+	state.Areas[testAreaID] = &thingscloud.Area{UUID: testAreaID, Title: "Work"}
+	state.Tasks[testProjectID] = &thingscloud.Task{
+		UUID:  testProjectID,
 		Title: "Project Alpha",
 		Type:  thingscloud.TaskTypeProject,
 	}
@@ -336,13 +343,13 @@ func testStateForListFilters() *memory.State {
 		UUID:          "project-task-1",
 		Title:         "Project Task",
 		Schedule:      thingscloud.TaskScheduleAnytime,
-		ParentTaskIDs: []string{"project-1"},
+		ParentTaskIDs: []string{testProjectID},
 	}
 	state.Tasks["area-task-1"] = &thingscloud.Task{
 		UUID:     "area-task-1",
 		Title:    "Area Task",
 		Schedule: thingscloud.TaskScheduleAnytime,
-		AreaIDs:  []string{"area-1"},
+		AreaIDs:  []string{testAreaID},
 	}
 	state.Tasks["completed-1"] = &thingscloud.Task{
 		UUID:     "completed-1",
@@ -407,4 +414,61 @@ func TestListTasksSearchAndContainerFilters(t *testing.T) {
 	requireUUIDs(t, listTasks(state, map[string]string{"search": "project"}), "project-task-1")
 	requireUUIDs(t, listTasks(state, map[string]string{"area": "Work"}), "area-task-1")
 	requireUUIDs(t, listTasks(state, map[string]string{"project": "Project Alpha"}), "project-task-1")
+}
+
+func TestGenerateUUIDAlwaysCanonical(t *testing.T) {
+	for i := 0; i < 2000; i++ {
+		s := generateUUID()
+		if err := thingscloud.ValidateUUID(s); err != nil {
+			t.Fatalf("generateUUID() = %q is not canonical Base58: %v", s, err)
+		}
+	}
+}
+
+func TestValidateIdentifierOpts(t *testing.T) {
+	good := thingscloud.NewUUID()
+
+	if err := validateIdentifierOpts(map[string]string{
+		"uuid": good, "project": good, "area": good, "heading": good, "tags": good + "," + good,
+	}); err != nil {
+		t.Errorf("all-valid opts: %v, want nil", err)
+	}
+	if err := validateIdentifierOpts(map[string]string{"when": "today", "note": "free text"}); err != nil {
+		t.Errorf("no identifier opts: %v, want nil", err)
+	}
+
+	bad := map[string]map[string]string{
+		"hyphenated uuid": {"uuid": "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c"},
+		"bad project":     {"project": "not-base58-0OIl"},
+		"bad area":        {"area": "abc def"},
+		"bad heading":     {"heading": "VJ0edXTP9q3PmFDUuy8EQh"},
+		"one bad tag":     {"tags": good + ",bad-tag-uuid"},
+	}
+	for name, opts := range bad {
+		if err := validateIdentifierOpts(opts); err == nil {
+			t.Errorf("%s: got nil error, want validation error", name)
+		}
+	}
+}
+
+func TestBuildBatchCreateRejectsInvalidRef(t *testing.T) {
+	_, _, err := buildBatchCreate(BatchOp{Title: "x", Project: "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c"})
+	if err == nil {
+		t.Error("buildBatchCreate with hyphenated project UUID: got nil error, want validation error")
+	}
+	_, _, err = buildBatchCreate(BatchOp{Title: "x", UUID: "not!base58"})
+	if err == nil {
+		t.Error("buildBatchCreate with invalid explicit UUID: got nil error, want validation error")
+	}
+}
+
+func TestBuildBatchEditRejectsInvalidRef(t *testing.T) {
+	_, _, err := buildBatchEdit(BatchOp{UUID: thingscloud.NewUUID(), Heading: "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c"})
+	if err == nil {
+		t.Error("buildBatchEdit with hyphenated heading UUID: got nil error, want validation error")
+	}
+	_, _, err = buildBatchEdit(BatchOp{UUID: "bad uuid", Title: "y"})
+	if err == nil {
+		t.Error("buildBatchEdit with invalid target UUID: got nil error, want validation error")
+	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -3,32 +3,12 @@ package main
 import (
 	"fmt"
 	"log"
-	"math/big"
 	"os"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
 )
-
-// base58Encode encodes a UUID as a Base58 string using the Bitcoin alphabet.
-// Things.app requires Base58-encoded UUIDs — standard UUID strings will crash the client.
-func base58Encode(u uuid.UUID) string {
-	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-	n := new(big.Int).SetBytes(u[:])
-	base := big.NewInt(58)
-	mod := new(big.Int)
-	var encoded []byte
-	for n.Sign() > 0 {
-		n.DivMod(n, base, mod)
-		encoded = append(encoded, alphabet[mod.Int64()])
-	}
-	for i, j := 0, len(encoded)-1; i < j; i, j = i+1, j-1 {
-		encoded[i], encoded[j] = encoded[j], encoded[i]
-	}
-	return string(encoded)
-}
 
 func printTag(tag *thingscloud.Tag, state *memory.State, indent string) {
 	fmt.Printf("%s-\t%s\n", indent, tag.Title)
@@ -114,7 +94,7 @@ func main() {
 
 	pending := thingscloud.TaskStatusPending
 	anytime := thingscloud.TaskScheduleAnytime
-	taskUUID := base58Encode(uuid.New())
+	taskUUID := thingscloud.NewUUID()
 	now := thingscloud.Timestamp(time.Now())
 	date := thingscloud.Timestamp(time.Now().Truncate(24 * time.Hour))
 	todayIdx := 0

--- a/histories.go
+++ b/histories.go
@@ -226,6 +226,12 @@ type Identifiable interface {
 func (h *History) Write(items ...Identifiable) error {
 	m := map[string]interface{}{}
 	for _, item := range items {
+		// A non-canonical identifier permanently corrupts the sync
+		// history: Things.app crashes decoding it and the item cannot
+		// be removed. Refuse it before anything reaches the server.
+		if err := ValidateUUID(item.UUID()); err != nil {
+			return fmt.Errorf("refusing to write item: %w", err)
+		}
 		m[item.UUID()] = item
 	}
 	bs, err := json.Marshal(m)

--- a/histories_write_test.go
+++ b/histories_write_test.go
@@ -1,0 +1,62 @@
+package thingscloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHistory_Write_RejectsInvalidUUID(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+
+	bad := []string{
+		"6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c", // standard hyphenated UUID
+		"",                                     // empty
+		"VJ0edXTP9q3PmFDUuy8EQh",               // '0' not in Base58 alphabet
+	}
+	for _, id := range bad {
+		item := TaskActionItem{
+			Item: Item{UUID: id, Kind: ItemKindTask, Action: ItemActionCreated},
+			P:    TaskActionItemPayload{Title: String("x")},
+		}
+		if err := h.Write(item); err == nil {
+			t.Errorf("Write with UUID %q: got nil error, want validation error", id)
+		}
+	}
+	if requests != 0 {
+		t.Errorf("server received %d requests, want 0 — invalid items must be rejected before POST", requests)
+	}
+}
+
+func TestHistory_Write_AcceptsCanonicalUUID(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+
+	item := TaskActionItem{
+		Item: Item{UUID: NewUUID(), Kind: ItemKindTask, Action: ItemActionCreated},
+		P:    TaskActionItemPayload{Title: String("x")},
+	}
+	if err := h.Write(item); err != nil {
+		t.Errorf("Write with canonical UUID: %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `EncodeUUID` / `DecodeUUID` / `ValidateUUID` / `NewUUID` to the core SDK — canonical Base58 (one leading `1` per leading zero byte), round-trip-tested against identifiers captured from real Things.app sync traffic
- `History.Write()` now refuses any item whose UUID is not canonical Base58, before anything reaches the server
- `things-cli` delegates UUID generation to the SDK and validates every user-supplied identifier (`--uuid`, `--project`, `--area`, `--heading`, `--tags`, edit/add-checklist targets, all batch ops)
- `example/` uses the SDK encoder; both duplicated broken encoders are gone

## Context

Audit finding: the duplicated Base58 encoders dropped leading zero bytes. ~1 in 256 generated v4 UUIDs (random byte 0 == 0x00) encoded one character short without the canonical leading `1`. Things.app decodes identifiers with `BSIdentifierFromBase58String` — the exact function implicated in the historical sync crashes — and a poisoned history cannot be repaired. This intermittent, cumulative failure profile matches why the SDK was abandoned: it worked for weeks, then one random create corrupted the account.

Defense in depth: even if a caller builds items by hand, the `Write()` boundary now rejects non-canonical identifiers with a clear error instead of poisoning the history.

## Validation

- TDD throughout (every change red-green)
- `go test ./...`, `go vet ./...`, `gofmt` clean
- Real-traffic vectors: `VJ1edXTP9q3PmFDUuy8EQh`, `FQxaqvLBkbR5q2Q5oRoknc`, `BVU8qZ9dNjrdxLvDHPvfDS` all round-trip canonically

🤖 Generated with [Claude Code](https://claude.com/claude-code)