### PR TITLE
fix: sync engine robustness — atomic cursor, deleted filter, timeouts, typed retries

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 const (
@@ -78,7 +79,9 @@ func New(endpoint, email, password string) *Client {
 		password:   password,
 		ClientInfo: DefaultClientInfo(),
 
-		client: &http.Client{},
+		// A stalled connection must not hang Sync forever; large initial
+		// syncs (thousands of items) still finish well within this.
+		client: &http.Client{Timeout: 60 * time.Second},
 	}
 	c.common.client = c
 	c.Accounts = (*AccountService)(&c.common)
@@ -87,6 +90,18 @@ func New(endpoint, email, password string) *Client {
 
 // ThingsUserAgent is the http user-agent header set by things for mac
 const ThingsUserAgent = "ThingsMac/32209501"
+
+// HTTPError is returned when the Things Cloud server responds with an
+// unexpected status code. Callers can inspect StatusCode with errors.As
+// to decide whether a request is worth retrying.
+type HTTPError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("http response code: %s", e.Status)
+}
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
 	if req.Host == "" {

--- a/client_test.go
+++ b/client_test.go
@@ -73,3 +73,12 @@ func TestClient_UserAgent(t *testing.T) {
 		t.Error("things-client-info header is missing or empty")
 	}
 }
+
+func TestNew_SetsHTTPTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := New("https://example.com", "user@example.com", "pw")
+	if c.client.Timeout <= 0 {
+		t.Error("New() http.Client has no Timeout — a stalled connection hangs Sync forever")
+	}
+}

--- a/histories.go
+++ b/histories.go
@@ -45,7 +45,7 @@ func (h *History) Sync() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("http response code: %s", resp.Status)
+		return &HTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	bs, err := io.ReadAll(resp.Body)
@@ -75,7 +75,7 @@ func (c *Client) History(id string) (*History, error) {
 		if resp.StatusCode == http.StatusUnauthorized {
 			return nil, ErrUnauthorized
 		}
-		return nil, fmt.Errorf("http response code: %s", resp.Status)
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 	bs, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/items.go
+++ b/items.go
@@ -55,7 +55,7 @@ func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, false, fmt.Errorf("http response code: %s", resp.Status)
+		return nil, false, &HTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	bs, err := io.ReadAll(resp.Body)

--- a/sync/process.go
+++ b/sync/process.go
@@ -54,6 +54,15 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 		allChanges = append(allChanges, changes...)
 	}
 
+	// Persist the cursor in the same transaction as the batch it covers:
+	// either both land or neither does, so a resume never replays a
+	// committed batch or skips an uncommitted one.
+	if s.history != nil {
+		if err := s.saveSyncState(s.history.ID, s.history.LoadedServerIndex); err != nil {
+			return nil, fmt.Errorf("saving sync state: %w", err)
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("committing transaction: %w", err)
 	}

--- a/sync/robustness_test.go
+++ b/sync/robustness_test.go
@@ -1,0 +1,148 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// TestSync_CursorSurvivesMidSyncFailure: each successfully committed batch
+// must persist its cursor. If a later batch fails, resuming must not replay
+// the committed batches (replays double-apply note delta patches and
+// duplicate change_log rows).
+func TestSync_CursorSurvivesMidSyncFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			switch r.URL.Query().Get("start-index") {
+			case "0":
+				// Batch 1: one valid task create.
+				fmt.Fprint(w, `{"items":[{"VJ1edXTP9q3PmFDUuy8EQh":{"e":"Task6","t":0,"p":{"tt":"good task","tp":0,"st":1}}}],"current-item-index":2,"schema":301}`)
+			case "1":
+				// Batch 2: payload is a bare string — unmarshal into the
+				// task payload struct fails, so this batch errors.
+				fmt.Fprint(w, `{"items":[{"FQxaqvLBkbR5q2Q5oRoknc":{"e":"Task6","t":0,"p":"garbage"}}],"current-item-index":2,"schema":301}`)
+			default:
+				fmt.Fprint(w, `{"items":[],"current-item-index":2,"schema":301}`)
+			}
+			return
+		}
+		fmt.Fprint(w, `{"latest-server-index":2,"latest-schema-version":301}`)
+	}))
+	defer server.Close()
+
+	client := things.New(server.URL, "test@example.com", "password")
+	syncer, err := Open(filepath.Join(t.TempDir(), "test.db"), client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	if err := syncer.saveSyncState("h1", 0); err != nil {
+		t.Fatalf("saveSyncState failed: %v", err)
+	}
+
+	if _, err := syncer.Sync(); err == nil {
+		t.Fatal("Sync: want error from corrupt batch 2, got nil")
+	}
+
+	if got := syncer.LastSyncedIndex(); got != 1 {
+		t.Errorf("cursor after mid-sync failure = %d, want 1 (end of committed batch 1); a wrong cursor replays or skips items on the next sync", got)
+	}
+}
+
+// TestGetTask_ExcludesSoftDeleted: getTask must filter deleted rows like
+// every other entity, otherwise delete replays emit duplicate TaskDeleted
+// events and State.Task returns tasks the user deleted.
+func TestGetTask_ExcludesSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	syncer, err := Open(filepath.Join(t.TempDir(), "test.db"), nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	createPayload, _ := json.Marshal(map[string]any{"tt": "victim", "tp": 0, "st": 1})
+	create := things.Item{UUID: "VJ1edXTP9q3PmFDUuy8EQh", Kind: things.ItemKindTask, Action: things.ItemActionCreated, P: createPayload}
+	deleteItem := things.Item{UUID: "VJ1edXTP9q3PmFDUuy8EQh", Kind: things.ItemKindTask, Action: things.ItemActionDeleted, P: json.RawMessage(`{}`)}
+
+	if _, err := syncer.processItems([]things.Item{create}, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	changes, err := syncer.processItems([]things.Item{deleteItem}, 1)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if n := countByType(changes, "TaskDeleted"); n != 1 {
+		t.Fatalf("first delete: %d TaskDeleted changes, want 1", n)
+	}
+
+	task, err := syncer.getTask("VJ1edXTP9q3PmFDUuy8EQh")
+	if err != nil {
+		t.Fatalf("getTask: %v", err)
+	}
+	if task != nil {
+		t.Errorf("getTask returned soft-deleted task %q, want nil", task.Title)
+	}
+
+	// Replaying the same delete (e.g. after a crash) must not emit another
+	// TaskDeleted event.
+	changes, err = syncer.processItems([]things.Item{deleteItem}, 1)
+	if err != nil {
+		t.Fatalf("replayed delete: %v", err)
+	}
+	if n := countByType(changes, "TaskDeleted"); n != 0 {
+		t.Errorf("replayed delete: %d TaskDeleted changes, want 0", n)
+	}
+}
+
+func countByType(changes []Change, changeType string) int {
+	n := 0
+	for _, c := range changes {
+		if c.ChangeType() == changeType {
+			n++
+		}
+	}
+	return n
+}
+
+// TestIsRetryableError: retry decisions must come from the HTTP status
+// code, not substring-matching digits in arbitrary error text.
+func TestIsRetryableError(t *testing.T) {
+	t.Parallel()
+
+	retryable := []error{
+		&things.HTTPError{StatusCode: 500, Status: "500 Internal Server Error"},
+		&things.HTTPError{StatusCode: 502, Status: "502 Bad Gateway"},
+		&things.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"},
+		&things.HTTPError{StatusCode: 504, Status: "504 Gateway Timeout"},
+		fmt.Errorf("fetching items: %w", &things.HTTPError{StatusCode: 500, Status: "500 Internal Server Error"}),
+	}
+	for _, err := range retryable {
+		if !isRetryableError(err) {
+			t.Errorf("isRetryableError(%v) = false, want true", err)
+		}
+	}
+
+	notRetryable := []error{
+		nil,
+		&things.HTTPError{StatusCode: 404, Status: "404 Not Found"},
+		&things.HTTPError{StatusCode: 401, Status: "401 Unauthorized"},
+		fmt.Errorf("request took 1504ms and was cancelled"), // digits are not a status
+		fmt.Errorf("connect: connection refused on port 5001"),
+	}
+	for _, err := range notRetryable {
+		if isRetryableError(err) {
+			t.Errorf("isRetryableError(%v) = true, want false", err)
+		}
+	}
+}

--- a/sync/store.go
+++ b/sync/store.go
@@ -17,7 +17,7 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 			"index", today_index, in_trash, area_uuid, project_uuid, heading_uuid,
 			alarm_time_offset, recurrence_rule, deleted
 		FROM tasks
-		WHERE uuid = ?
+		WHERE uuid = ? AND deleted = 0
 	`, uuid)
 
 	var (

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -4,7 +4,7 @@ package sync
 
 import (
 	"database/sql"
-	"strings"
+	"errors"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -65,14 +65,11 @@ func (s *Syncer) Close() error {
 
 // isRetryableError returns true if the error is a temporary server error worth retrying.
 func isRetryableError(err error) bool {
-	if err == nil {
-		return false
+	var httpErr *things.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500 && httpErr.StatusCode <= 504
 	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "500") ||
-		strings.Contains(errStr, "502") ||
-		strings.Contains(errStr, "503") ||
-		strings.Contains(errStr, "504")
+	return false
 }
 
 // Sync fetches new items from Things Cloud, updates local state,
@@ -169,10 +166,10 @@ func (s *Syncer) Sync() ([]Change, error) {
 		hasMore = more
 	}
 
-	// Save sync state
-	if err := s.saveSyncState(s.history.ID, s.history.LatestServerIndex); err != nil {
-		return nil, err
-	}
+	// Sync state is persisted per batch inside processItems' transaction,
+	// so a mid-sync failure resumes exactly after the last committed batch
+	// instead of replaying it (replays double-apply note delta patches and
+	// duplicate change_log rows).
 
 	return allChanges, nil
 }


### PR DESCRIPTION
## Summary

- **Atomic cursor:** `processItems` persists the sync cursor inside the same SQLite transaction as the batch it covers. Previously the cursor saved once after the whole loop, so a mid-sync failure replayed every committed batch on resume — double-applying note delta patches (corrupted note text) and duplicating `change_log` rows.
- **`getTask` filters `deleted = 0`** like `getArea`/`getTag`/`getChecklistItem` already did. Fixes soft-deleted tasks surfacing via `State.Task` and duplicate `TaskDeleted` events on delete replay.
- **HTTP timeout (60s):** `New()` built `&http.Client{}` with no timeout; a stalled TCP read hung `Sync()` and every CLI command forever.
- **Typed retry errors:** new `things.HTTPError` returned by `Items()`, `History()`, and `History.Sync()`; `isRetryableError` uses `errors.As` on the status code (500–504) instead of substring-matching digits — `"request took 1504ms"` no longer triggers a retry.

## Context

Findings H1, M2, M4, L6 from the codebase audit (sync/read layer). H1 and M2 interact: the missing deleted-filter compounded replay damage.

## Validation

TDD (each fix red-green): a two-batch fake server proves the cursor lands at the end of the last committed batch when a later batch fails; delete-replay test proves single `TaskDeleted` emission; `go test ./...`, `go vet ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)