### PR TITLE
fix: guard zero-time marshal, surface decode errors, deprecate Area2 writes

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -22,8 +22,12 @@ func TaskTypePtr(val TaskType) *TaskType {
 	return &val
 }
 
-// Time returns a pointer to a Time
+// Time returns a pointer to a Time. The zero time returns nil: its
+// UnixNano is out of range and would marshal to a garbage 1754 date.
 func Time(val time.Time) *Timestamp {
+	if val.IsZero() {
+		return nil
+	}
 	ts := Timestamp(val)
 	return &ts
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,29 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTime_ZeroValueReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	if got := Time(time.Time{}); got != nil {
+		bs, _ := json.Marshal(got)
+		t.Errorf("Time(zero) = %s, want nil — the zero time marshals to a garbage 1754 epoch instead of being omitted", bs)
+	}
+}
+
+func TestTime_RealValueRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	got := Time(now)
+	if got == nil {
+		t.Fatal("Time(now) = nil, want pointer")
+	}
+	if !time.Time(*got).Equal(now) {
+		t.Errorf("Time(now) = %v, want %v", time.Time(*got), now)
+	}
+}

--- a/histories.go
+++ b/histories.go
@@ -53,7 +53,9 @@ func (h *History) Sync() error {
 		return err
 	}
 	var v itemsResponse
-	json.Unmarshal(bs, &v)
+	if err := json.Unmarshal(bs, &v); err != nil {
+		return fmt.Errorf("decoding history sync response: %w", err)
+	}
 	h.LatestServerIndex = v.CurrentItemIndex
 	h.LatestSchemaVersion = v.SchemaVersion
 	h.LatestTotalContentSize = v.LatestTotalContentSize
@@ -147,7 +149,9 @@ func (c *Client) Histories() ([]*History, error) {
 		return nil, err
 	}
 	var keys []string
-	json.Unmarshal(bs, &keys)
+	if err := json.Unmarshal(bs, &keys); err != nil {
+		return nil, fmt.Errorf("decoding history keys: %w", err)
+	}
 
 	var histories = make([]*History, len(keys))
 	for i, key := range keys {
@@ -187,7 +191,9 @@ func (c *Client) CreateHistory() (*History, error) {
 		return nil, err
 	}
 	var v createHistoryResponse
-	json.Unmarshal(bs, &v)
+	if err := json.Unmarshal(bs, &v); err != nil {
+		return nil, fmt.Errorf("decoding create-history response: %w", err)
+	}
 	return &History{
 		Client: c,
 		ID:     v.Key,
@@ -263,7 +269,9 @@ func (h *History) Write(items ...Identifiable) error {
 		return err
 	}
 	var w commitResponse
-	json.Unmarshal(rs, &w)
+	if err := json.Unmarshal(rs, &w); err != nil {
+		return fmt.Errorf("decoding commit response: %w", err)
+	}
 	h.LatestServerIndex = w.ServerHeadIndex
 	return nil
 }

--- a/histories_decode_test.go
+++ b/histories_decode_test.go
@@ -1,0 +1,59 @@
+package thingscloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHistory_Sync_ErrorsOnMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"current-item-index": not-json`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+	if err := h.Sync(); err == nil {
+		t.Error("Sync with malformed JSON response: got nil error — a silently zero LatestServerIndex feeds a wrong ancestor-index into the next Write")
+	}
+}
+
+func TestHistory_Write_ErrorsOnMalformedCommitResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `not json at all`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+	item := TaskActionItem{
+		Item: Item{UUID: "VJ1edXTP9q3PmFDUuy8EQh", Kind: ItemKindTask, Action: ItemActionCreated},
+		P:    TaskActionItemPayload{Title: String("x")},
+	}
+	if err := h.Write(item); err == nil {
+		t.Error("Write with malformed commit response: got nil error — LatestServerIndex silently stays stale")
+	}
+}
+
+func TestCreateHistory_ErrorsOnMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `garbage`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	if _, err := c.CreateHistory(); err == nil {
+		t.Error("CreateHistory with malformed response: got nil error — returns a History with empty ID")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -63,7 +63,12 @@ var (
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"
 	ItemKindTaskPlain ItemKind = "Task"
-	// ItemKindArea identifies an Area
+	// ItemKindArea identifies an Area in the legacy Area2 encoding.
+	//
+	// Deprecated: never WRITE items with this kind — Things.app silently
+	// ignores Area2 creates and manufactures a duplicate area with a new
+	// UUID. Use ItemKindArea3. Reading Area2 items from old histories is
+	// still supported.
 	ItemKindArea      ItemKind = "Area2"
 	ItemKindArea3     ItemKind = "Area3"
 	ItemKindAreaPlain ItemKind = "Area"


### PR DESCRIPTION
## Summary

- `helpers.Time(time.Time{})` returns `nil` instead of a pointer that marshals to a garbage **1754** date (zero-time `UnixNano` overflow, proven empirically during the audit)
- `History.Sync` / `Histories` / `CreateHistory` / `Write` surface `json.Unmarshal` errors instead of swallowing them — a malformed or truncated response previously left `LatestServerIndex` silently at 0/stale, which then fed a wrong `ancestor-index` into the next commit
- `ItemKindArea` (`Area2`) gets a `Deprecated:` notice steering writers to `ItemKindArea3` — Things.app silently ignores `Area2` creates and manufactures a duplicate area with a new UUID (documented in docs/client-side-bugs.md); reading old histories still works

## Context

Audit findings 4, 6, and 7 from the core-SDK serialization review.

## Validation

TDD (each fix red-green with malformed-response test servers); `go test ./...`, `go vet ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)