### PR TITLE
fix: never write structural items with st=0; reject duplicate UUIDs per commit

### DIFF
--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -274,7 +274,6 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 			tp = 1
 		case "heading":
 			tp = 2
-			st = 1 // headings are structural — always "started" (anytime), never inbox
 		}
 	}
 
@@ -293,6 +292,12 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 		case "inbox":
 			st = 0
 		}
+	}
+
+	// Projects and headings are structural — never inbox (st=0). A heading
+	// with st=0 crashes Things.app; this must win over any --when value.
+	if tp != 0 && st == 0 {
+		st = 1
 	}
 
 	// --note

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -472,3 +472,23 @@ func TestBuildBatchEditRejectsInvalidRef(t *testing.T) {
 		t.Error("buildBatchEdit with invalid target UUID: got nil error, want validation error")
 	}
 }
+
+func TestNewTaskCreatePayloadStructuralTypesNeverInbox(t *testing.T) {
+	cases := []struct {
+		name string
+		opts map[string]string
+	}{
+		{"project default", map[string]string{"type": "project"}},
+		{"project explicit inbox", map[string]string{"type": "project", "when": "inbox"}},
+		{"heading default", map[string]string{"type": "heading"}},
+		{"heading explicit inbox", map[string]string{"type": "heading", "when": "inbox"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := newTaskCreatePayload("x", tc.opts)
+			if payload.St != 1 {
+				t.Errorf("st = %d, want 1 — structural items (tp=%d) in inbox corrupt the sync history", payload.St, payload.Tp)
+			}
+		})
+	}
+}

--- a/histories.go
+++ b/histories.go
@@ -232,6 +232,11 @@ func (h *History) Write(items ...Identifiable) error {
 		if err := ValidateUUID(item.UUID()); err != nil {
 			return fmt.Errorf("refusing to write item: %w", err)
 		}
+		// The commit body is a map keyed by UUID, so a second op on the
+		// same item would silently replace the first. Reject instead.
+		if _, dup := m[item.UUID()]; dup {
+			return fmt.Errorf("refusing to write items: duplicate UUID %s in one commit — split into separate Write calls", item.UUID())
+		}
 		m[item.UUID()] = item
 	}
 	bs, err := json.Marshal(m)

--- a/histories_write_test.go
+++ b/histories_write_test.go
@@ -60,3 +60,34 @@ func TestHistory_Write_AcceptsCanonicalUUID(t *testing.T) {
 		t.Errorf("Write with canonical UUID: %v, want nil", err)
 	}
 }
+
+func TestHistory_Write_RejectsDuplicateUUIDs(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+
+	id := NewUUID()
+	a := TaskActionItem{
+		Item: Item{UUID: id, Kind: ItemKindTask, Action: ItemActionModified},
+		P:    TaskActionItemPayload{Title: String("renamed")},
+	}
+	b := TaskActionItem{
+		Item: Item{UUID: id, Kind: ItemKindTask, Action: ItemActionModified},
+		P:    TaskActionItemPayload{Status: Status(TaskStatusCompleted)},
+	}
+	if err := h.Write(a, b); err == nil {
+		t.Error("Write with two items sharing a UUID: got nil error, want duplicate error — the commit map silently drops one op")
+	}
+	if requests != 0 {
+		t.Errorf("server received %d requests, want 0", requests)
+	}
+}


### PR DESCRIPTION
Recreation of #13, which was auto-closed when its stacked base branch (#12) was deleted on merge. Same commit, now based on `develop` (which contains #12).

See #13 for the original description and context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)