### PR TITLE
Release: sync engine fixes, CLI features, and crash-surface hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,10 @@ go generate                # Regenerate stringer methods (itemaction_string.go)
 
 ## Architecture
 
-All source code lives at the package root (`package things`), with two sub-packages:
+All source code lives at the package root (`package thingscloud`, module `github.com/arthursoares/things-cloud-sdk`), with three sub-packages:
 - `state/memory` — In-memory state aggregation (for testing/simple use)
 - `sync` — Persistent SQLite-backed sync engine with semantic change detection
+- `syncutil` — Shared utilities for sync-based CLI tools
 
 ### Core Design: Event-Sourced Sync
 
@@ -79,6 +80,17 @@ Tests use `httptest.Server` with pre-recorded JSON responses in the `tapes/` dir
 
 `types.go` contains `//go:generate stringer -type ItemAction,TaskStatus,TaskSchedule`. Run `go generate` after modifying these enum types. Do not hand-edit `itemaction_string.go`.
 
+### Wire Format Rules (Crash-Critical)
+
+Violating these corrupts the sync history and crashes Things.app during sync — and a poisoned history cannot be repaired, only abandoned:
+
+- **UUIDs must be Base58-encoded** (Bitcoin alphabet: `123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz` — no `0`, `O`, `I`, `l`). Things.app decodes with `BSIdentifierFromBase58String()`; standard UUID strings crash it.
+- **`md` (modification date) must be `null` on creates.** Set a timestamp only on updates.
+- **Headings (`tp=2`) must have `st=1`** (anytime), never `st=0` (inbox). Tasks under projects/headings/areas should also default to `st=1`.
+- **Kind strings**: `Task6`, `Tag4`, `ChecklistItem3`, `Area3`, `Tombstone2`. Using `Area2` is silently ignored by Things.app.
+
+See `docs/client-side-bugs.md` for the full crash investigations behind each rule.
+
 ### Schedule Field (`st`) Mapping
 
 The `st` JSON field maps to the `start` column in Things' SQLite DB. It represents a task's start state, **not** which UI view it belongs to. The view is determined by `st` + `sr`/`tir` dates:
@@ -90,6 +102,8 @@ The `st` JSON field maps to the `start` column in Things' SQLite DB. It represen
 | 1 | `TaskScheduleAnytime` | null | Anytime |
 | 2 | `TaskScheduleSomeday` | future date | Upcoming |
 | 2 | `TaskScheduleSomeday` | null | Someday |
+
+Don't confuse `st` (schedule) with `ss` (status): `ss` is completion state — `0` = pending, `2` = canceled, `3` = completed (with `sp` set to the completion timestamp).
 
 See `docs/client-side-bugs.md` for the full investigation.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,13 @@ go build -o things-cli ./cmd/things-cli/
 
 ```bash
 # Read
-things-cli list [--today] [--inbox] [--area NAME] [--project NAME]
+things-cli list [--today] [--inbox] [--anytime] [--someday] [--upcoming] [--search QUERY] [--area NAME] [--project NAME]
+things-cli today
+things-cli inbox
+things-cli anytime
+things-cli someday
+things-cli upcoming
+things-cli search <query>
 things-cli show <uuid>
 things-cli areas
 things-cli projects

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ things-cli areas
 things-cli projects
 things-cli tags
 
+# Optional read-state cache location
+export THINGS_CLI_CACHE=/path/to/things-cli-state.json
+
 # Create
 things-cli create "Title" [--note ...] [--when today|anytime|someday|inbox] \
   [--deadline YYYY-MM-DD] [--scheduled YYYY-MM-DD] \

--- a/README.md
+++ b/README.md
@@ -302,13 +302,22 @@ state := syncer.State()
 inbox, _ := state.TasksInInbox(sync.QueryOpts{})
 today, _ := state.TasksInToday(sync.QueryOpts{})
 anytime, _ := state.TasksInAnytime(sync.QueryOpts{})
+someday, _ := state.TasksInSomeday(sync.QueryOpts{})
+upcoming, _ := state.TasksInUpcoming(sync.QueryOpts{})
 
 // Query by container
 tasks, _ := state.TasksInProject(projectUUID, sync.QueryOpts{})
 tasks, _ := state.TasksInArea(areaUUID, sync.QueryOpts{})
+tasks, _ := state.TasksUnderHeading(headingUUID, sync.QueryOpts{})
+headings, _ := state.HeadingsInProject(projectUUID, sync.QueryOpts{})
+
+// Query by tag or text
+tasks, _ := state.TasksWithTag(tagUUID, sync.QueryOpts{})
+tasks, _ := state.SearchTasks("invoice", sync.QueryOpts{})
 
 // List all
 projects, _ := state.AllProjects(sync.QueryOpts{})
+headings, _ := state.AllHeadings(sync.QueryOpts{})
 areas, _ := state.AllAreas(sync.QueryOpts{})
 tags, _ := state.AllTags(sync.QueryOpts{})
 ```

--- a/base58.go
+++ b/base58.go
@@ -1,0 +1,85 @@
+package thingscloud
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// base58Alphabet is the Bitcoin Base58 alphabet Things.app uses for
+// identifiers (no 0, O, I, l). Things decodes identifiers with
+// BSIdentifierFromBase58String; anything it cannot decode to 16 bytes
+// permanently corrupts the sync history and crashes the client.
+const base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// EncodeUUID encodes a UUID as canonical Base58: one leading '1' per
+// leading zero byte, matching the identifiers Things.app itself emits.
+func EncodeUUID(u uuid.UUID) string {
+	zeros := 0
+	for zeros < len(u) && u[zeros] == 0 {
+		zeros++
+	}
+
+	n := new(big.Int).SetBytes(u[:])
+	base := big.NewInt(58)
+	mod := new(big.Int)
+	var encoded []byte
+	for n.Sign() > 0 {
+		n.DivMod(n, base, mod)
+		encoded = append(encoded, base58Alphabet[mod.Int64()])
+	}
+	for i := 0; i < zeros; i++ {
+		encoded = append(encoded, '1')
+	}
+	for i, j := 0, len(encoded)-1; i < j; i, j = i+1, j-1 {
+		encoded[i], encoded[j] = encoded[j], encoded[i]
+	}
+	return string(encoded)
+}
+
+// DecodeUUID decodes a canonical Base58 identifier back into a UUID.
+// It rejects strings that are not canonical encodings of exactly 16 bytes.
+func DecodeUUID(s string) (uuid.UUID, error) {
+	var u uuid.UUID
+	if s == "" {
+		return u, fmt.Errorf("thingscloud: empty identifier")
+	}
+
+	zeros := 0
+	for zeros < len(s) && s[zeros] == '1' {
+		zeros++
+	}
+
+	n := new(big.Int)
+	base := big.NewInt(58)
+	for i := zeros; i < len(s); i++ {
+		idx := strings.IndexByte(base58Alphabet, s[i])
+		if idx < 0 {
+			return u, fmt.Errorf("thingscloud: invalid Base58 character %q in identifier %q", s[i], s)
+		}
+		n.Mul(n, base)
+		n.Add(n, big.NewInt(int64(idx)))
+	}
+
+	value := n.Bytes()
+	if zeros+len(value) != len(u) {
+		return u, fmt.Errorf("thingscloud: identifier %q decodes to %d bytes, want 16 (non-canonical or wrong length)", s, zeros+len(value))
+	}
+	copy(u[len(u)-len(value):], value)
+	return u, nil
+}
+
+// ValidateUUID reports whether s is a canonical Base58-encoded 16-byte
+// identifier safe to write to Things Cloud.
+func ValidateUUID(s string) error {
+	_, err := DecodeUUID(s)
+	return err
+}
+
+// NewUUID returns a new random identifier in the canonical Base58 wire
+// format expected by Things Cloud.
+func NewUUID() string {
+	return EncodeUUID(uuid.New())
+}

--- a/base58_test.go
+++ b/base58_test.go
@@ -1,0 +1,121 @@
+package thingscloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestEncodeUUID_CanonicalLeadingZeros(t *testing.T) {
+	t.Parallel()
+
+	u := uuid.UUID{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+	s := EncodeUUID(u)
+	if !strings.HasPrefix(s, "1") {
+		t.Errorf("EncodeUUID(%v) = %q, want leading %q for leading zero byte", u, s, "1")
+	}
+
+	u2 := uuid.UUID{0x00, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+	s2 := EncodeUUID(u2)
+	if !strings.HasPrefix(s2, "11") {
+		t.Errorf("EncodeUUID(%v) = %q, want two leading 1s for two leading zero bytes", u2, s2)
+	}
+}
+
+func TestEncodeUUID_AllZero(t *testing.T) {
+	t.Parallel()
+
+	got := EncodeUUID(uuid.UUID{})
+	want := "1111111111111111" // one '1' per zero byte
+	if got != want {
+		t.Errorf("EncodeUUID(zero) = %q, want %q", got, want)
+	}
+}
+
+func TestEncodeDecodeUUID_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []uuid.UUID{
+		{},
+		{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee},
+		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+	}
+	for i := 0; i < 64; i++ {
+		cases = append(cases, uuid.New())
+	}
+	// Force leading-zero-byte cases, the historical corruption source.
+	for i := 0; i < 8; i++ {
+		u := uuid.New()
+		u[0] = 0x00
+		cases = append(cases, u)
+	}
+
+	for _, u := range cases {
+		s := EncodeUUID(u)
+		back, err := DecodeUUID(s)
+		if err != nil {
+			t.Fatalf("DecodeUUID(EncodeUUID(%v) = %q) failed: %v", u, s, err)
+		}
+		if back != u {
+			t.Errorf("round trip: %v -> %q -> %v", u, s, back)
+		}
+	}
+}
+
+func TestDecodeUUID_RealThingsIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	// Captured from real Things.app sync traffic (HAR).
+	for _, s := range []string{"VJ1edXTP9q3PmFDUuy8EQh", "FQxaqvLBkbR5q2Q5oRoknc", "BVU8qZ9dNjrdxLvDHPvfDS"} {
+		u, err := DecodeUUID(s)
+		if err != nil {
+			t.Fatalf("DecodeUUID(%q) failed: %v", s, err)
+		}
+		if got := EncodeUUID(u); got != s {
+			t.Errorf("re-encode of %q = %q, not canonical round trip", s, got)
+		}
+	}
+}
+
+func TestValidateUUID(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"VJ1edXTP9q3PmFDUuy8EQh",
+		"1111111111111111",
+		EncodeUUID(uuid.UUID{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}),
+	}
+	for _, s := range valid {
+		if err := ValidateUUID(s); err != nil {
+			t.Errorf("ValidateUUID(%q) = %v, want nil", s, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"standard hyphenated UUID":        "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c",
+		"contains 0":                      "VJ0edXTP9q3PmFDUuy8EQh",
+		"contains O":                      "VJOedXTP9q3PmFDUuy8EQh",
+		"contains I":                      "VJIedXTP9q3PmFDUuy8EQh",
+		"contains l":                      "VJledXTP9q3PmFDUuy8EQh",
+		"empty":                           "",
+		"value overflows 16 bytes":        "zzzzzzzzzzzzzzzzzzzzzz",
+		"non-canonical missing leading 1": strings.TrimPrefix(EncodeUUID(uuid.UUID{0x00, 0x7f, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}), "1"),
+	}
+	for name, s := range invalid {
+		if err := ValidateUUID(s); err == nil {
+			t.Errorf("ValidateUUID(%q) [%s] = nil, want error", s, name)
+		}
+	}
+}
+
+func TestNewUUID_AlwaysCanonical(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 2000; i++ {
+		s := NewUUID()
+		if err := ValidateUUID(s); err != nil {
+			t.Fatalf("NewUUID() = %q is not canonical: %v", s, err)
+		}
+	}
+}

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 const (
@@ -78,7 +79,9 @@ func New(endpoint, email, password string) *Client {
 		password:   password,
 		ClientInfo: DefaultClientInfo(),
 
-		client: &http.Client{},
+		// A stalled connection must not hang Sync forever; large initial
+		// syncs (thousands of items) still finish well within this.
+		client: &http.Client{Timeout: 60 * time.Second},
 	}
 	c.common.client = c
 	c.Accounts = (*AccountService)(&c.common)
@@ -87,6 +90,18 @@ func New(endpoint, email, password string) *Client {
 
 // ThingsUserAgent is the http user-agent header set by things for mac
 const ThingsUserAgent = "ThingsMac/32209501"
+
+// HTTPError is returned when the Things Cloud server responds with an
+// unexpected status code. Callers can inspect StatusCode with errors.As
+// to decide whether a request is worth retrying.
+type HTTPError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("http response code: %s", e.Status)
+}
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
 	if req.Host == "" {

--- a/client_test.go
+++ b/client_test.go
@@ -73,3 +73,12 @@ func TestClient_UserAgent(t *testing.T) {
 		t.Error("things-client-info header is missing or empty")
 	}
 }
+
+func TestNew_SetsHTTPTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := New("https://example.com", "user@example.com", "pw")
+	if c.client.Timeout <= 0 {
+		t.Error("New() http.Client has no Timeout — a stalled connection hangs Sync forever")
+	}
+}

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -15,7 +15,7 @@ Or create a `.env` file and source it: `source .env`
 Full-featured CLI for CRUD operations on Things Cloud.
 
 ```bash
-# Read operations (loads full state)
+# Read operations (uses an incremental local state cache)
 things-cli list [--today] [--inbox] [--area NAME] [--project NAME]
 things-cli show <uuid>
 things-cli areas
@@ -40,6 +40,9 @@ echo '[
 
 # Batch commands: create, complete, trash, purge, move-to-today,
 #                 move-to-project, move-to-area, edit
+
+# Optional read-state cache location:
+#   THINGS_CLI_CACHE=/path/to/things-cli-state.json
 
 # Create options:
 #   --note "text"           Add a note

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -16,7 +16,13 @@ Full-featured CLI for CRUD operations on Things Cloud.
 
 ```bash
 # Read operations (loads full state)
-things-cli list [--today] [--inbox] [--area NAME] [--project NAME]
+things-cli list [--today] [--inbox] [--anytime] [--someday] [--upcoming] [--search QUERY] [--area NAME] [--project NAME]
+things-cli today
+things-cli inbox
+things-cli anytime
+things-cli someday
+things-cli upcoming
+things-cli search <query>
 things-cli show <uuid>
 things-cli areas
 things-cli projects

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,15 +92,15 @@ type TaskCreatePayload struct {
 
 // ChecklistItemCreatePayload — all 9 fields for checklist item creation.
 type ChecklistItemCreatePayload struct {
-	Cd   float64       `json:"cd"`
-	Md   *float64      `json:"md"`
-	Tt   string        `json:"tt"`
-	Ss   int           `json:"ss"`
-	Sp   *float64      `json:"sp"`
-	Ix   int           `json:"ix"`
-	Ts   []string      `json:"ts"`
-	Lt   bool          `json:"lt"`
-	Xx   WireExtension `json:"xx"`
+	Cd float64       `json:"cd"`
+	Md *float64      `json:"md"`
+	Tt string        `json:"tt"`
+	Ss int           `json:"ss"`
+	Sp *float64      `json:"sp"`
+	Ix int           `json:"ix"`
+	Ts []string      `json:"ts"`
+	Lt bool          `json:"lt"`
+	Xx WireExtension `json:"xx"`
 }
 
 // TagCreatePayload — all 5 fields for tag creation.
@@ -182,6 +182,12 @@ func parseArgs(args []string) map[string]string {
 		}
 	}
 	return result
+}
+
+func hasExplicitSchedule(opts map[string]string) bool {
+	_, hasWhen := opts["when"]
+	_, hasScheduled := opts["scheduled"]
+	return hasWhen || hasScheduled
 }
 
 func fatal(op string, err error) {
@@ -407,6 +413,27 @@ func (u *taskUpdate) Schedule(st int, sr, tir any) *taskUpdate {
 	u.fields["sr"] = sr
 	u.fields["tir"] = tir
 	return u
+}
+
+func (u *taskUpdate) Today() *taskUpdate {
+	today := todayMidnightUTC()
+	return u.Schedule(1, today, today)
+}
+
+func (u *taskUpdate) Anytime() *taskUpdate {
+	return u.Schedule(1, nil, nil)
+}
+
+func (u *taskUpdate) Someday() *taskUpdate {
+	return u.Schedule(2, nil, nil)
+}
+
+func (u *taskUpdate) Inbox() *taskUpdate {
+	return u.Schedule(0, nil, nil)
+}
+
+func (u *taskUpdate) ScheduleDate(ts int64) *taskUpdate {
+	return u.Schedule(1, ts, ts)
 }
 
 func (u *taskUpdate) Deadline(dd int64) *taskUpdate {
@@ -740,14 +767,13 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 	if v, ok := opts["when"]; ok {
 		switch v {
 		case "today":
-			today := todayMidnightUTC()
-			u.Schedule(1, today, today)
+			u.Today()
 		case "anytime":
-			u.Schedule(1, nil, nil)
+			u.Anytime()
 		case "someday":
-			u.Schedule(2, nil, nil)
+			u.Someday()
 		case "inbox":
-			u.Schedule(0, nil, nil)
+			u.Inbox()
 		}
 	}
 	if v, ok := opts["deadline"]; ok {
@@ -760,29 +786,29 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 			ts := t.Unix()
 			u.Scheduled(ts, ts)
 			if _, hasWhen := opts["when"]; !hasWhen {
-				u.Schedule(1, ts, ts)
+				u.ScheduleDate(ts)
 			}
 		}
 	}
 	if v, ok := opts["area"]; ok && v != "" {
 		u.Area(v)
-		// When adding an area, also move out of Inbox (st=0 → st=1)
-		if _, hasWhen := opts["when"]; !hasWhen {
-			u.Schedule(1, 0, 0) // Anytime
+		// When adding an area, also move out of Inbox unless a schedule was explicit.
+		if !hasExplicitSchedule(opts) {
+			u.Anytime()
 		}
 	}
 	if v, ok := opts["project"]; ok && v != "" {
 		u.Project(v)
-		// When adding a project, also move out of Inbox (st=0 → st=1)
-		if _, hasWhen := opts["when"]; !hasWhen {
-			u.Schedule(1, 0, 0) // Anytime
+		// When adding a project, also move out of Inbox unless a schedule was explicit.
+		if !hasExplicitSchedule(opts) {
+			u.Anytime()
 		}
 	}
 	if v, ok := opts["heading"]; ok && v != "" {
 		u.Heading(v)
-		// When adding a heading, also move out of Inbox (st=0 → st=1)
-		if _, hasWhen := opts["when"]; !hasWhen {
-			u.Schedule(1, 0, 0) // Anytime
+		// When adding a heading, also move out of Inbox unless a schedule was explicit.
+		if !hasExplicitSchedule(opts) {
+			u.Anytime()
 		}
 	}
 	if v, ok := opts["tags"]; ok && v != "" {
@@ -836,8 +862,7 @@ func cmdPurge(history *thingscloud.History, taskUUID string) {
 }
 
 func cmdMoveToToday(history *thingscloud.History, taskUUID string) {
-	today := todayMidnightUTC()
-	u := newTaskUpdate().Schedule(1, today, today)
+	u := newTaskUpdate().Today()
 
 	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
 	if err := history.Write(env); err != nil {
@@ -1084,8 +1109,7 @@ func buildBatchMoveToToday(op BatchOp) (thingscloud.Identifiable, map[string]str
 		return nil, nil, fmt.Errorf("move-to-today requires uuid")
 	}
 
-	today := todayMidnightUTC()
-	u := newTaskUpdate().Schedule(1, today, today)
+	u := newTaskUpdate().Today()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-today", "uuid": op.UUID}, nil
@@ -1099,7 +1123,7 @@ func buildBatchMoveToProject(op BatchOp) (thingscloud.Identifiable, map[string]s
 		return nil, nil, fmt.Errorf("move-to-project requires project")
 	}
 
-	u := newTaskUpdate().Project(op.Project).Schedule(1, 0, 0)
+	u := newTaskUpdate().Project(op.Project).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-project", "uuid": op.UUID, "project": op.Project}, nil
@@ -1113,7 +1137,7 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 		return nil, nil, fmt.Errorf("move-to-area requires area")
 	}
 
-	u := newTaskUpdate().Area(op.Area).Schedule(1, 0, 0)
+	u := newTaskUpdate().Area(op.Area).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-area", "uuid": op.UUID, "area": op.Area}, nil
@@ -1135,14 +1159,13 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 	if op.When != "" {
 		switch op.When {
 		case "today":
-			today := todayMidnightUTC()
-			u.Schedule(1, today, today)
+			u.Today()
 		case "anytime":
-			u.Schedule(1, nil, nil)
+			u.Anytime()
 		case "someday":
-			u.Schedule(2, nil, nil)
+			u.Someday()
 		case "inbox":
-			u.Schedule(0, nil, nil)
+			u.Inbox()
 		}
 	}
 	if op.Deadline != "" {
@@ -1153,19 +1176,19 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 	if op.Project != "" {
 		u.Project(op.Project)
 		if op.When == "" {
-			u.Schedule(1, 0, 0)
+			u.Anytime()
 		}
 	}
 	if op.Area != "" {
 		u.Area(op.Area)
 		if op.When == "" {
-			u.Schedule(1, 0, 0)
+			u.Anytime()
 		}
 	}
 	if op.Heading != "" {
 		u.Heading(op.Heading)
 		if op.When == "" {
-			u.Schedule(1, 0, 0)
+			u.Anytime()
 		}
 	}
 	if len(op.Tags) > 0 {

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -6,12 +6,13 @@ import (
 	"hash/crc32"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,15 +93,15 @@ type TaskCreatePayload struct {
 
 // ChecklistItemCreatePayload — all 9 fields for checklist item creation.
 type ChecklistItemCreatePayload struct {
-	Cd   float64       `json:"cd"`
-	Md   *float64      `json:"md"`
-	Tt   string        `json:"tt"`
-	Ss   int           `json:"ss"`
-	Sp   *float64      `json:"sp"`
-	Ix   int           `json:"ix"`
-	Ts   []string      `json:"ts"`
-	Lt   bool          `json:"lt"`
-	Xx   WireExtension `json:"xx"`
+	Cd float64       `json:"cd"`
+	Md *float64      `json:"md"`
+	Tt string        `json:"tt"`
+	Ss int           `json:"ss"`
+	Sp *float64      `json:"sp"`
+	Ix int           `json:"ix"`
+	Ts []string      `json:"ts"`
+	Lt bool          `json:"lt"`
+	Xx WireExtension `json:"xx"`
 }
 
 // TagCreatePayload — all 5 fields for tag creation.
@@ -453,7 +454,78 @@ type cliContext struct {
 	history *thingscloud.History
 }
 
-func initCLI() *cliContext {
+type cliStateCache struct {
+	HistoryID   string        `json:"historyId"`
+	ServerIndex int           `json:"serverIndex"`
+	State       *memory.State `json:"state"`
+}
+
+func commandNeedsHistoryHead(cmd string) bool {
+	switch cmd {
+	case "create", "create-area", "create-tag", "add-checklist", "edit", "complete", "trash", "purge", "move-to-today", "batch":
+		return true
+	default:
+		return false
+	}
+}
+
+func cliStateCachePath() string {
+	if path := os.Getenv("THINGS_CLI_CACHE"); path != "" {
+		return path
+	}
+	if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "things-cloud-sdk", "things-cli-state.json")
+	}
+	return filepath.Join(os.TempDir(), "things-cloud-sdk", "things-cli-state.json")
+}
+
+func loadCLIStateCache(path string) (*cliStateCache, error) {
+	bs, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cache cliStateCache
+	if err := json.Unmarshal(bs, &cache); err != nil {
+		return nil, err
+	}
+	if cache.State == nil {
+		cache.State = memory.NewState()
+	} else {
+		normalizeMemoryState(cache.State)
+	}
+	return &cache, nil
+}
+
+func normalizeMemoryState(state *memory.State) {
+	if state.Areas == nil {
+		state.Areas = map[string]*thingscloud.Area{}
+	}
+	if state.Tasks == nil {
+		state.Tasks = map[string]*thingscloud.Task{}
+	}
+	if state.Tags == nil {
+		state.Tags = map[string]*thingscloud.Tag{}
+	}
+	if state.CheckListItems == nil {
+		state.CheckListItems = map[string]*thingscloud.CheckListItem{}
+	}
+}
+
+func saveCLIStateCache(path string, cache *cliStateCache) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	bs, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, bs, 0o600)
+}
+
+func initCLI(syncHistoryHead bool) *cliContext {
 	username := requireEnv("THINGS_USERNAME")
 	password := requireEnv("THINGS_PASSWORD")
 
@@ -470,30 +542,69 @@ func initCLI() *cliContext {
 	if err != nil {
 		fatal("get history", err)
 	}
-	if err := history.Sync(); err != nil {
-		fatal("sync history", err)
+	if syncHistoryHead {
+		if err := history.Sync(); err != nil {
+			fatal("sync history", err)
+		}
 	}
 
 	return &cliContext{client: c, history: history}
 }
 
+func (ctx *cliContext) serverIndex() int {
+	history, err := ctx.client.History(ctx.history.ID)
+	if err != nil {
+		fatal("get server index", err)
+	}
+	return history.LatestServerIndex
+}
+
 func (ctx *cliContext) loadState() *memory.State {
-	var allItems []thingscloud.Item
+	cachePath := cliStateCachePath()
+	cache, err := loadCLIStateCache(cachePath)
+	if err != nil {
+		fatal("load state cache", err)
+	}
+
+	state := memory.NewState()
 	startIndex := 0
+	if cache != nil && cache.HistoryID == ctx.history.ID {
+		state = cache.State
+		startIndex = cache.ServerIndex
+	}
+
+	latestServerIndex := ctx.serverIndex()
+	if startIndex > latestServerIndex {
+		state = memory.NewState()
+		startIndex = 0
+	}
+
 	for {
+		if startIndex >= latestServerIndex {
+			break
+		}
+		ctx.history.LoadedServerIndex = startIndex
 		items, hasMore, err := ctx.history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
 		if err != nil {
 			fatal("fetch items", err)
 		}
-		allItems = append(allItems, items...)
+		if err := state.Update(items...); err != nil {
+			fatal("update state", err)
+		}
+		startIndex = ctx.history.LoadedServerIndex
 		if !hasMore {
 			break
 		}
-		startIndex = ctx.history.LoadedServerIndex
 	}
 
-	state := memory.NewState()
-	state.Update(allItems...)
+	if err := saveCLIStateCache(cachePath, &cliStateCache{
+		HistoryID:   ctx.history.ID,
+		ServerIndex: startIndex,
+		State:       state,
+	}); err != nil {
+		fatal("save state cache", err)
+	}
+
 	return state
 }
 
@@ -1184,12 +1295,15 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: things-cli <command> [args]
 
-Read commands (load state from cloud):
+Read commands (use an incremental local state cache):
   list [--today] [--inbox] [--area NAME] [--project NAME]
   show <uuid>
   areas
   projects
   tags
+
+Environment:
+  THINGS_CLI_CACHE=/path/to/things-cli-state.json  Override read-state cache file
 
 Write commands (fast — skip state loading):
   create "Title" [--note ...] [--when today|anytime|someday|inbox]
@@ -1231,8 +1345,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := initCLI()
 	cmd := os.Args[1]
+	ctx := initCLI(commandNeedsHistoryHead(cmd))
 
 	switch cmd {
 	// Read commands — need state

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -6,12 +6,13 @@ import (
 	"hash/crc32"
 	"math/big"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,15 +93,15 @@ type TaskCreatePayload struct {
 
 // ChecklistItemCreatePayload — all 9 fields for checklist item creation.
 type ChecklistItemCreatePayload struct {
-	Cd   float64       `json:"cd"`
-	Md   *float64      `json:"md"`
-	Tt   string        `json:"tt"`
-	Ss   int           `json:"ss"`
-	Sp   *float64      `json:"sp"`
-	Ix   int           `json:"ix"`
-	Ts   []string      `json:"ts"`
-	Lt   bool          `json:"lt"`
-	Xx   WireExtension `json:"xx"`
+	Cd float64       `json:"cd"`
+	Md *float64      `json:"md"`
+	Tt string        `json:"tt"`
+	Ss int           `json:"ss"`
+	Sp *float64      `json:"sp"`
+	Ix int           `json:"ix"`
+	Ts []string      `json:"ts"`
+	Lt bool          `json:"lt"`
+	Xx WireExtension `json:"xx"`
 }
 
 // TagCreatePayload — all 5 fields for tag creation.
@@ -539,9 +540,16 @@ func taskToOutput(t *thingscloud.Task) TaskOutput {
 	return out
 }
 
-func cmdList(state *memory.State, args []string) {
-	opts := parseArgs(args)
-	todayStart := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 0, 0, 0, 0, time.UTC)
+func sameDay(a, b time.Time) bool {
+	ay, am, ad := a.Date()
+	by, bm, bd := b.Date()
+	return ay == by && am == bm && ad == bd
+}
+
+func listTasks(state *memory.State, opts map[string]string) []TaskOutput {
+	now := time.Now().UTC()
+	tomorrowStart := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+	searchQuery := strings.ToLower(strings.TrimSpace(opts["search"]))
 
 	var tasks []TaskOutput
 	for _, task := range state.Tasks {
@@ -551,12 +559,34 @@ func cmdList(state *memory.State, args []string) {
 
 		// Filters
 		if _, ok := opts["today"]; ok {
-			if task.Schedule != thingscloud.TaskScheduleAnytime || task.ScheduledDate == nil || !task.ScheduledDate.Equal(todayStart) {
+			if task.Schedule != thingscloud.TaskScheduleAnytime || task.ScheduledDate == nil || !sameDay(*task.ScheduledDate, now) {
 				continue
 			}
 		}
 		if _, ok := opts["inbox"]; ok {
 			if task.Schedule != thingscloud.TaskScheduleInbox {
+				continue
+			}
+		}
+		if _, ok := opts["anytime"]; ok {
+			if task.Schedule != thingscloud.TaskScheduleAnytime || task.ScheduledDate != nil {
+				continue
+			}
+		}
+		if _, ok := opts["someday"]; ok {
+			if task.Schedule != thingscloud.TaskScheduleSomeday || task.ScheduledDate != nil {
+				continue
+			}
+		}
+		if _, ok := opts["upcoming"]; ok {
+			if task.Schedule != thingscloud.TaskScheduleSomeday || task.ScheduledDate == nil || task.ScheduledDate.Before(tomorrowStart) {
+				continue
+			}
+		}
+		if searchQuery != "" {
+			title := strings.ToLower(task.Title)
+			note := strings.ToLower(task.Note)
+			if !strings.Contains(title, searchQuery) && !strings.Contains(note, searchQuery) {
 				continue
 			}
 		}
@@ -568,14 +598,38 @@ func cmdList(state *memory.State, args []string) {
 		}
 		if projectName, ok := opts["project"]; ok {
 			projectUUID := findProjectUUID(state, projectName)
-			if !containsStr(task.ActionGroupIDs, projectUUID) {
+			if !containsStr(task.ParentTaskIDs, projectUUID) {
 				continue
 			}
 		}
 
 		tasks = append(tasks, taskToOutput(task))
 	}
-	outputJSON(tasks)
+
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].ScheduledDate != nil && tasks[j].ScheduledDate != nil && *tasks[i].ScheduledDate != *tasks[j].ScheduledDate {
+			return *tasks[i].ScheduledDate < *tasks[j].ScheduledDate
+		}
+		if tasks[i].Title != tasks[j].Title {
+			return tasks[i].Title < tasks[j].Title
+		}
+		return tasks[i].UUID < tasks[j].UUID
+	})
+
+	return tasks
+}
+
+func cmdList(state *memory.State, args []string) {
+	outputJSON(listTasks(state, parseArgs(args)))
+}
+
+func cmdListWithOpts(state *memory.State, opts map[string]string) {
+	outputJSON(listTasks(state, opts))
+}
+
+func cmdSearch(state *memory.State, args []string) {
+	requireArgs(args, 1, "things-cli search <query>")
+	cmdListWithOpts(state, map[string]string{"search": strings.Join(args, " ")})
 }
 
 func cmdShow(state *memory.State, uuid string) {
@@ -1185,7 +1239,13 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, `Usage: things-cli <command> [args]
 
 Read commands (load state from cloud):
-  list [--today] [--inbox] [--area NAME] [--project NAME]
+  list [--today] [--inbox] [--anytime] [--someday] [--upcoming] [--search QUERY] [--area NAME] [--project NAME]
+  today
+  inbox
+  anytime
+  someday
+  upcoming
+  search <query>
   show <uuid>
   areas
   projects
@@ -1238,6 +1298,18 @@ func main() {
 	// Read commands — need state
 	case "list":
 		cmdList(ctx.loadState(), os.Args[2:])
+	case "today":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"today": "true"})
+	case "inbox":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"inbox": "true"})
+	case "anytime":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"anytime": "true"})
+	case "someday":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"someday": "true"})
+	case "upcoming":
+		cmdListWithOpts(ctx.loadState(), map[string]string{"upcoming": "true"})
+	case "search":
+		cmdSearch(ctx.loadState(), os.Args[2:])
 	case "show":
 		requireArgs(os.Args[2:], 1, "things-cli show <uuid>")
 		cmdShow(ctx.loadState(), os.Args[2])

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
-	"math/big"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,7 +12,6 @@ import (
 
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
-	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -135,22 +133,50 @@ func defaultExtension() WireExtension {
 }
 
 func generateUUID() string {
-	u := uuid.New()
-	// Base58 alphabet (Bitcoin/Flickr): no 0, O, I, l
-	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-	n := new(big.Int).SetBytes(u[:])
-	base := big.NewInt(58)
-	mod := new(big.Int)
-	var encoded []byte
-	for n.Sign() > 0 {
-		n.DivMod(n, base, mod)
-		encoded = append(encoded, alphabet[mod.Int64()])
+	return thingscloud.NewUUID()
+}
+
+// validateIdentifierOpts checks every option that carries a Things
+// identifier. Invalid identifiers written to the cloud poison the sync
+// history irreparably, so they must be rejected before any write.
+func validateIdentifierOpts(opts map[string]string) error {
+	for _, key := range []string{"uuid", "project", "heading", "area"} {
+		if v, ok := opts[key]; ok && v != "" {
+			if err := thingscloud.ValidateUUID(v); err != nil {
+				return fmt.Errorf("--%s: %w", key, err)
+			}
+		}
 	}
-	// Reverse (big-endian)
-	for i, j := 0, len(encoded)-1; i < j; i, j = i+1, j-1 {
-		encoded[i], encoded[j] = encoded[j], encoded[i]
+	if v, ok := opts["tags"]; ok && v != "" {
+		for _, tag := range strings.Split(v, ",") {
+			if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+				return fmt.Errorf("--tags: %w", err)
+			}
+		}
 	}
-	return string(encoded)
+	return nil
+}
+
+// validateBatchOpIdentifiers rejects a batch op carrying any invalid
+// Things identifier, for the same reason as validateIdentifierOpts.
+func validateBatchOpIdentifiers(op BatchOp) error {
+	check := map[string]string{
+		"uuid": op.UUID, "project": op.Project, "area": op.Area, "heading": op.Heading,
+	}
+	for name, v := range check {
+		if v == "" {
+			continue
+		}
+		if err := thingscloud.ValidateUUID(v); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	for _, tag := range op.Tags {
+		if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+			return fmt.Errorf("tags: %w", err)
+		}
+	}
+	return nil
 }
 
 func nowTs() float64 {
@@ -882,6 +908,9 @@ func cmdCreate(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("create task", err)
+	}
 
 	taskUUID := opts["uuid"]
 	if taskUUID == "" {
@@ -904,6 +933,9 @@ func cmdCreate(history *thingscloud.History, args []string) {
 
 func cmdAddChecklist(history *thingscloud.History, taskUUID string, args []string) {
 	requireArgs(args, 1, `things-cli add-checklist <task-uuid> "Item 1,Item 2,Item 3"`)
+	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
+		fatal("add-checklist", err)
+	}
 
 	items := strings.Split(args[0], ",")
 	cmdWriteChecklistItems(history, taskUUID, items)
@@ -915,6 +947,12 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 	opts := parseArgs(args)
 	if len(opts) == 0 {
 		fatalf("Usage: things-cli edit <uuid> [--title ...] [--note ...] [--when today|anytime|someday|inbox] [--deadline YYYY-MM-DD] [--scheduled YYYY-MM-DD] [--area UUID] [--project UUID] [--heading UUID] [--tags UUID,...]")
+	}
+	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
+		fatal("edit", err)
+	}
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("edit", err)
 	}
 
 	u := newTaskUpdate()
@@ -1189,6 +1227,9 @@ func buildBatchCreate(op BatchOp) (thingscloud.Identifiable, map[string]string, 
 	if op.Title == "" {
 		return nil, nil, fmt.Errorf("create requires title")
 	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
 
 	taskUUID := op.UUID
 	if taskUUID == "" {
@@ -1287,6 +1328,9 @@ func buildBatchMoveToProject(op BatchOp) (thingscloud.Identifiable, map[string]s
 	if op.Project == "" {
 		return nil, nil, fmt.Errorf("move-to-project requires project")
 	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
 
 	u := newTaskUpdate().Project(op.Project).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
@@ -1301,6 +1345,9 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 	if op.Area == "" {
 		return nil, nil, fmt.Errorf("move-to-area requires area")
 	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
 
 	u := newTaskUpdate().Area(op.Area).Anytime()
 	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
@@ -1311,6 +1358,9 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, error) {
 	if op.UUID == "" {
 		return nil, nil, fmt.Errorf("edit requires uuid")
+	}
+	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
 	}
 
 	u := newTaskUpdate()

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -274,7 +274,6 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 			tp = 1
 		case "heading":
 			tp = 2
-			st = 1 // headings are structural — always "started" (anytime), never inbox
 		}
 	}
 
@@ -293,6 +292,12 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 		case "inbox":
 			st = 0
 		}
+	}
+
+	// Projects and headings are structural — never inbox (st=0). A heading
+	// with st=0 crashes Things.app; this must win over any --when value.
+	if tp != 0 && st == 0 {
+		st = 1
 	}
 
 	// --note

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func requirePayloadMap(t *testing.T, env any) map[string]any {
+	t.Helper()
+	envelope, ok := env.(writeEnvelope)
+	if !ok {
+		t.Fatalf("expected writeEnvelope, got %T", env)
+	}
+	payload, ok := envelope.payload.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map payload, got %T", envelope.payload)
+	}
+	return payload
+}
+
+func assertAnytimeSchedule(t *testing.T, payload map[string]any) {
+	t.Helper()
+	if payload["st"] != 1 {
+		t.Fatalf("st = %v, want 1", payload["st"])
+	}
+	if payload["sr"] != nil {
+		t.Fatalf("sr = %v, want nil", payload["sr"])
+	}
+	if payload["tir"] != nil {
+		t.Fatalf("tir = %v, want nil", payload["tir"])
+	}
+}
+
+func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
+	payload := newTaskUpdate().Project("project-1").Anytime().build()
+
+	assertAnytimeSchedule(t, payload)
+	if got := payload["pr"]; got == nil {
+		t.Fatal("project field was not set")
+	}
+}
+
+func TestHasExplicitSchedule(t *testing.T) {
+	tests := []struct {
+		name string
+		opts map[string]string
+		want bool
+	}{
+		{
+			name: "none",
+			opts: map[string]string{},
+			want: false,
+		},
+		{
+			name: "when",
+			opts: map[string]string{"when": "today"},
+			want: true,
+		},
+		{
+			name: "scheduled",
+			opts: map[string]string{"scheduled": "2026-05-20"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasExplicitSchedule(tt.opts); got != tt.want {
+				t.Fatalf("hasExplicitSchedule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
+	env, _, err := buildBatchMoveToProject(BatchOp{
+		UUID:    "task-1",
+		Project: "project-1",
+	})
+	if err != nil {
+		t.Fatalf("buildBatchMoveToProject failed: %v", err)
+	}
+
+	payload := requirePayloadMap(t, env)
+	assertAnytimeSchedule(t, payload)
+
+	bs, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+	var wire struct {
+		P map[string]any `json:"p"`
+	}
+	if err := json.Unmarshal(bs, &wire); err != nil {
+		t.Fatalf("unmarshal wire payload failed: %v", err)
+	}
+	if wire.P["sr"] != nil {
+		t.Fatalf("wire sr = %v, want null", wire.P["sr"])
+	}
+	if wire.P["tir"] != nil {
+		t.Fatalf("wire tir = %v, want null", wire.P["tir"])
+	}
+}
+
+func TestBatchMoveToAreaUsesNullScheduleDates(t *testing.T) {
+	env, _, err := buildBatchMoveToArea(BatchOp{
+		UUID: "task-1",
+		Area: "area-1",
+	})
+	if err != nil {
+		t.Fatalf("buildBatchMoveToArea failed: %v", err)
+	}
+
+	assertAnytimeSchedule(t, requirePayloadMap(t, env))
+}
+
+func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
+	tests := []struct {
+		name string
+		op   BatchOp
+	}{
+		{
+			name: "project",
+			op:   BatchOp{UUID: "task-1", Project: "project-1"},
+		},
+		{
+			name: "area",
+			op:   BatchOp{UUID: "task-1", Area: "area-1"},
+		},
+		{
+			name: "heading",
+			op:   BatchOp{UUID: "task-1", Heading: "heading-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, _, err := buildBatchEdit(tt.op)
+			if err != nil {
+				t.Fatalf("buildBatchEdit failed: %v", err)
+			}
+			assertAnytimeSchedule(t, requirePayloadMap(t, env))
+		})
+	}
+}
+
+func TestBatchEditExplicitWhenWinsOverAutoAnytime(t *testing.T) {
+	env, _, err := buildBatchEdit(BatchOp{
+		UUID:    "task-1",
+		Project: "project-1",
+		When:    "someday",
+	})
+	if err != nil {
+		t.Fatalf("buildBatchEdit failed: %v", err)
+	}
+
+	payload := requirePayloadMap(t, env)
+	if payload["st"] != 2 {
+		t.Fatalf("st = %v, want 2", payload["st"])
+	}
+	if payload["sr"] != nil {
+		t.Fatalf("sr = %v, want nil", payload["sr"])
+	}
+	if payload["tir"] != nil {
+		t.Fatalf("tir = %v, want nil", payload["tir"])
+	}
+}

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+)
+
+func testStateForListFilters() *memory.State {
+	state := memory.NewState()
+	today := time.Now().UTC()
+	tomorrow := today.Add(24 * time.Hour)
+
+	state.Areas["area-1"] = &thingscloud.Area{UUID: "area-1", Title: "Work"}
+	state.Tasks["project-1"] = &thingscloud.Task{
+		UUID:  "project-1",
+		Title: "Project Alpha",
+		Type:  thingscloud.TaskTypeProject,
+	}
+	state.Tasks["inbox-1"] = &thingscloud.Task{
+		UUID:     "inbox-1",
+		Title:    "Inbox Task",
+		Schedule: thingscloud.TaskScheduleInbox,
+	}
+	state.Tasks["today-1"] = &thingscloud.Task{
+		UUID:          "today-1",
+		Title:         "Today Task",
+		Schedule:      thingscloud.TaskScheduleAnytime,
+		ScheduledDate: &today,
+	}
+	state.Tasks["anytime-1"] = &thingscloud.Task{
+		UUID:     "anytime-1",
+		Title:    "Anytime Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+	}
+	state.Tasks["someday-1"] = &thingscloud.Task{
+		UUID:     "someday-1",
+		Title:    "Someday Task",
+		Schedule: thingscloud.TaskScheduleSomeday,
+	}
+	state.Tasks["upcoming-1"] = &thingscloud.Task{
+		UUID:          "upcoming-1",
+		Title:         "Upcoming Task",
+		Note:          "needle in note",
+		Schedule:      thingscloud.TaskScheduleSomeday,
+		ScheduledDate: &tomorrow,
+	}
+	state.Tasks["project-task-1"] = &thingscloud.Task{
+		UUID:          "project-task-1",
+		Title:         "Project Task",
+		Schedule:      thingscloud.TaskScheduleAnytime,
+		ParentTaskIDs: []string{"project-1"},
+	}
+	state.Tasks["area-task-1"] = &thingscloud.Task{
+		UUID:     "area-task-1",
+		Title:    "Area Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+		AreaIDs:  []string{"area-1"},
+	}
+	state.Tasks["completed-1"] = &thingscloud.Task{
+		UUID:     "completed-1",
+		Title:    "Completed Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+		Status:   thingscloud.TaskStatusCompleted,
+	}
+	state.Tasks["trashed-1"] = &thingscloud.Task{
+		UUID:     "trashed-1",
+		Title:    "Trashed Task",
+		Schedule: thingscloud.TaskScheduleAnytime,
+		InTrash:  true,
+	}
+	return state
+}
+
+func outputUUIDs(tasks []TaskOutput) []string {
+	uuids := make([]string, len(tasks))
+	for i, task := range tasks {
+		uuids[i] = task.UUID
+	}
+	return uuids
+}
+
+func requireUUIDs(t *testing.T, tasks []TaskOutput, want ...string) {
+	t.Helper()
+	got := outputUUIDs(tasks)
+	if len(got) != len(want) {
+		t.Fatalf("uuids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("uuids = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestListTasksLocationFilters(t *testing.T) {
+	state := testStateForListFilters()
+
+	requireUUIDs(t, listTasks(state, map[string]string{"today": "true"}), "today-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"inbox": "true"}), "inbox-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"someday": "true"}), "someday-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"upcoming": "true"}), "upcoming-1")
+
+	anytime := outputUUIDs(listTasks(state, map[string]string{"anytime": "true"}))
+	wantAnytime := []string{"anytime-1", "area-task-1", "project-task-1"}
+	if len(anytime) != len(wantAnytime) {
+		t.Fatalf("anytime = %v, want %v", anytime, wantAnytime)
+	}
+	for i := range wantAnytime {
+		if anytime[i] != wantAnytime[i] {
+			t.Fatalf("anytime = %v, want %v", anytime, wantAnytime)
+		}
+	}
+}
+
+func TestListTasksSearchAndContainerFilters(t *testing.T) {
+	state := testStateForListFilters()
+
+	requireUUIDs(t, listTasks(state, map[string]string{"search": "needle"}), "upcoming-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"search": "project"}), "project-task-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"area": "Work"}), "area-task-1")
+	requireUUIDs(t, listTasks(state, map[string]string{"project": "Project Alpha"}), "project-task-1")
+}

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
+)
+
+func TestCommandNeedsHistoryHead(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"list", false},
+		{"show", false},
+		{"areas", false},
+		{"projects", false},
+		{"tags", false},
+		{"create", true},
+		{"edit", true},
+		{"complete", true},
+		{"trash", true},
+		{"batch", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			if got := commandNeedsHistoryHead(tt.cmd); got != tt.want {
+				t.Fatalf("commandNeedsHistoryHead(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCLIStateCachePathUsesEnvOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	t.Setenv("THINGS_CLI_CACHE", path)
+
+	if got := cliStateCachePath(); got != path {
+		t.Fatalf("cliStateCachePath() = %q, want %q", got, path)
+	}
+}
+
+func TestCLIStateCacheMissingFile(t *testing.T) {
+	cache, err := loadCLIStateCache(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if cache != nil {
+		t.Fatalf("cache = %#v, want nil", cache)
+	}
+}
+
+func TestCLIStateCacheRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "state.json")
+	state := memory.NewState()
+	state.Tasks["task-1"] = &thingscloud.Task{
+		UUID:  "task-1",
+		Title: "Cached Task",
+	}
+	state.Areas["area-1"] = &thingscloud.Area{
+		UUID:  "area-1",
+		Title: "Cached Area",
+	}
+
+	cache := &cliStateCache{
+		HistoryID:   "history-1",
+		ServerIndex: 42,
+		State:       state,
+	}
+	if err := saveCLIStateCache(path, cache); err != nil {
+		t.Fatalf("saveCLIStateCache failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat cache failed: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatal("cache path is a directory")
+	}
+
+	loaded, err := loadCLIStateCache(path)
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if loaded.HistoryID != "history-1" {
+		t.Fatalf("HistoryID = %q, want history-1", loaded.HistoryID)
+	}
+	if loaded.ServerIndex != 42 {
+		t.Fatalf("ServerIndex = %d, want 42", loaded.ServerIndex)
+	}
+	if loaded.State.Tasks["task-1"].Title != "Cached Task" {
+		t.Fatalf("task title = %q, want Cached Task", loaded.State.Tasks["task-1"].Title)
+	}
+	if loaded.State.Areas["area-1"].Title != "Cached Area" {
+		t.Fatalf("area title = %q, want Cached Area", loaded.State.Areas["area-1"].Title)
+	}
+}
+
+func TestCLIStateCacheNormalizesEmptyState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	cache := &cliStateCache{
+		HistoryID:   "history-1",
+		ServerIndex: 7,
+		State:       &memory.State{},
+	}
+	if err := saveCLIStateCache(path, cache); err != nil {
+		t.Fatalf("saveCLIStateCache failed: %v", err)
+	}
+
+	loaded, err := loadCLIStateCache(path)
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if loaded.State.Tasks == nil {
+		t.Fatal("Tasks map was not initialized")
+	}
+	if loaded.State.Areas == nil {
+		t.Fatal("Areas map was not initialized")
+	}
+	if loaded.State.Tags == nil {
+		t.Fatal("Tags map was not initialized")
+	}
+	if loaded.State.CheckListItems == nil {
+		t.Fatal("CheckListItems map was not initialized")
+	}
+}

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -472,3 +472,23 @@ func TestBuildBatchEditRejectsInvalidRef(t *testing.T) {
 		t.Error("buildBatchEdit with invalid target UUID: got nil error, want validation error")
 	}
 }
+
+func TestNewTaskCreatePayloadStructuralTypesNeverInbox(t *testing.T) {
+	cases := []struct {
+		name string
+		opts map[string]string
+	}{
+		{"project default", map[string]string{"type": "project"}},
+		{"project explicit inbox", map[string]string{"type": "project", "when": "inbox"}},
+		{"heading default", map[string]string{"type": "heading"}},
+		{"heading explicit inbox", map[string]string{"type": "heading", "when": "inbox"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := newTaskCreatePayload("x", tc.opts)
+			if payload.St != 1 {
+				t.Errorf("st = %d, want 1 — structural items (tp=%d) in inbox corrupt the sync history", payload.St, payload.Tp)
+			}
+		})
+	}
+}

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -11,6 +11,13 @@ import (
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
 )
 
+var (
+	testTaskID    = thingscloud.NewUUID()
+	testProjectID = thingscloud.NewUUID()
+	testAreaID    = thingscloud.NewUUID()
+	testHeadingID = thingscloud.NewUUID()
+)
+
 func requirePayloadMap(t *testing.T, env any) map[string]any {
 	t.Helper()
 	envelope, ok := env.(writeEnvelope)
@@ -38,7 +45,7 @@ func assertAnytimeSchedule(t *testing.T, payload map[string]any) {
 }
 
 func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
-	payload := newTaskUpdate().Project("project-1").Anytime().build()
+	payload := newTaskUpdate().Project(testProjectID).Anytime().build()
 
 	assertAnytimeSchedule(t, payload)
 	if got := payload["pr"]; got == nil {
@@ -106,8 +113,8 @@ func TestCommandNeedsHistoryHead(t *testing.T) {
 
 func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
 	env, _, err := buildBatchMoveToProject(BatchOp{
-		UUID:    "task-1",
-		Project: "project-1",
+		UUID:    testTaskID,
+		Project: testProjectID,
 	})
 	if err != nil {
 		t.Fatalf("buildBatchMoveToProject failed: %v", err)
@@ -136,8 +143,8 @@ func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
 
 func TestBatchMoveToAreaUsesNullScheduleDates(t *testing.T) {
 	env, _, err := buildBatchMoveToArea(BatchOp{
-		UUID: "task-1",
-		Area: "area-1",
+		UUID: testTaskID,
+		Area: testAreaID,
 	})
 	if err != nil {
 		t.Fatalf("buildBatchMoveToArea failed: %v", err)
@@ -153,15 +160,15 @@ func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
 	}{
 		{
 			name: "project",
-			op:   BatchOp{UUID: "task-1", Project: "project-1"},
+			op:   BatchOp{UUID: testTaskID, Project: testProjectID},
 		},
 		{
 			name: "area",
-			op:   BatchOp{UUID: "task-1", Area: "area-1"},
+			op:   BatchOp{UUID: testTaskID, Area: testAreaID},
 		},
 		{
 			name: "heading",
-			op:   BatchOp{UUID: "task-1", Heading: "heading-1"},
+			op:   BatchOp{UUID: testTaskID, Heading: testHeadingID},
 		},
 	}
 
@@ -178,8 +185,8 @@ func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
 
 func TestBatchEditExplicitWhenWinsOverAutoAnytime(t *testing.T) {
 	env, _, err := buildBatchEdit(BatchOp{
-		UUID:    "task-1",
-		Project: "project-1",
+		UUID:    testTaskID,
+		Project: testProjectID,
 		When:    "someday",
 	})
 	if err != nil {
@@ -220,12 +227,12 @@ func TestCLIStateCacheMissingFile(t *testing.T) {
 func TestCLIStateCacheRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "state.json")
 	state := memory.NewState()
-	state.Tasks["task-1"] = &thingscloud.Task{
-		UUID:  "task-1",
+	state.Tasks[testTaskID] = &thingscloud.Task{
+		UUID:  testTaskID,
 		Title: "Cached Task",
 	}
-	state.Areas["area-1"] = &thingscloud.Area{
-		UUID:  "area-1",
+	state.Areas[testAreaID] = &thingscloud.Area{
+		UUID:  testAreaID,
 		Title: "Cached Area",
 	}
 
@@ -256,11 +263,11 @@ func TestCLIStateCacheRoundTrip(t *testing.T) {
 	if loaded.ServerIndex != 42 {
 		t.Fatalf("ServerIndex = %d, want 42", loaded.ServerIndex)
 	}
-	if loaded.State.Tasks["task-1"].Title != "Cached Task" {
-		t.Fatalf("task title = %q, want Cached Task", loaded.State.Tasks["task-1"].Title)
+	if loaded.State.Tasks[testTaskID].Title != "Cached Task" {
+		t.Fatalf("task title = %q, want Cached Task", loaded.State.Tasks[testTaskID].Title)
 	}
-	if loaded.State.Areas["area-1"].Title != "Cached Area" {
-		t.Fatalf("area title = %q, want Cached Area", loaded.State.Areas["area-1"].Title)
+	if loaded.State.Areas[testAreaID].Title != "Cached Area" {
+		t.Fatalf("area title = %q, want Cached Area", loaded.State.Areas[testAreaID].Title)
 	}
 }
 
@@ -298,9 +305,9 @@ func testStateForListFilters() *memory.State {
 	today := time.Now().UTC()
 	tomorrow := today.Add(24 * time.Hour)
 
-	state.Areas["area-1"] = &thingscloud.Area{UUID: "area-1", Title: "Work"}
-	state.Tasks["project-1"] = &thingscloud.Task{
-		UUID:  "project-1",
+	state.Areas[testAreaID] = &thingscloud.Area{UUID: testAreaID, Title: "Work"}
+	state.Tasks[testProjectID] = &thingscloud.Task{
+		UUID:  testProjectID,
 		Title: "Project Alpha",
 		Type:  thingscloud.TaskTypeProject,
 	}
@@ -336,13 +343,13 @@ func testStateForListFilters() *memory.State {
 		UUID:          "project-task-1",
 		Title:         "Project Task",
 		Schedule:      thingscloud.TaskScheduleAnytime,
-		ParentTaskIDs: []string{"project-1"},
+		ParentTaskIDs: []string{testProjectID},
 	}
 	state.Tasks["area-task-1"] = &thingscloud.Task{
 		UUID:     "area-task-1",
 		Title:    "Area Task",
 		Schedule: thingscloud.TaskScheduleAnytime,
-		AreaIDs:  []string{"area-1"},
+		AreaIDs:  []string{testAreaID},
 	}
 	state.Tasks["completed-1"] = &thingscloud.Task{
 		UUID:     "completed-1",
@@ -407,4 +414,61 @@ func TestListTasksSearchAndContainerFilters(t *testing.T) {
 	requireUUIDs(t, listTasks(state, map[string]string{"search": "project"}), "project-task-1")
 	requireUUIDs(t, listTasks(state, map[string]string{"area": "Work"}), "area-task-1")
 	requireUUIDs(t, listTasks(state, map[string]string{"project": "Project Alpha"}), "project-task-1")
+}
+
+func TestGenerateUUIDAlwaysCanonical(t *testing.T) {
+	for i := 0; i < 2000; i++ {
+		s := generateUUID()
+		if err := thingscloud.ValidateUUID(s); err != nil {
+			t.Fatalf("generateUUID() = %q is not canonical Base58: %v", s, err)
+		}
+	}
+}
+
+func TestValidateIdentifierOpts(t *testing.T) {
+	good := thingscloud.NewUUID()
+
+	if err := validateIdentifierOpts(map[string]string{
+		"uuid": good, "project": good, "area": good, "heading": good, "tags": good + "," + good,
+	}); err != nil {
+		t.Errorf("all-valid opts: %v, want nil", err)
+	}
+	if err := validateIdentifierOpts(map[string]string{"when": "today", "note": "free text"}); err != nil {
+		t.Errorf("no identifier opts: %v, want nil", err)
+	}
+
+	bad := map[string]map[string]string{
+		"hyphenated uuid": {"uuid": "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c"},
+		"bad project":     {"project": "not-base58-0OIl"},
+		"bad area":        {"area": "abc def"},
+		"bad heading":     {"heading": "VJ0edXTP9q3PmFDUuy8EQh"},
+		"one bad tag":     {"tags": good + ",bad-tag-uuid"},
+	}
+	for name, opts := range bad {
+		if err := validateIdentifierOpts(opts); err == nil {
+			t.Errorf("%s: got nil error, want validation error", name)
+		}
+	}
+}
+
+func TestBuildBatchCreateRejectsInvalidRef(t *testing.T) {
+	_, _, err := buildBatchCreate(BatchOp{Title: "x", Project: "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c"})
+	if err == nil {
+		t.Error("buildBatchCreate with hyphenated project UUID: got nil error, want validation error")
+	}
+	_, _, err = buildBatchCreate(BatchOp{Title: "x", UUID: "not!base58"})
+	if err == nil {
+		t.Error("buildBatchCreate with invalid explicit UUID: got nil error, want validation error")
+	}
+}
+
+func TestBuildBatchEditRejectsInvalidRef(t *testing.T) {
+	_, _, err := buildBatchEdit(BatchOp{UUID: thingscloud.NewUUID(), Heading: "6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c"})
+	if err == nil {
+		t.Error("buildBatchEdit with hyphenated heading UUID: got nil error, want validation error")
+	}
+	_, _, err = buildBatchEdit(BatchOp{UUID: "bad uuid", Title: "y"})
+	if err == nil {
+		t.Error("buildBatchEdit with invalid target UUID: got nil error, want validation error")
+	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -3,32 +3,12 @@ package main
 import (
 	"fmt"
 	"log"
-	"math/big"
 	"os"
 	"time"
 
-	"github.com/google/uuid"
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
 	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
 )
-
-// base58Encode encodes a UUID as a Base58 string using the Bitcoin alphabet.
-// Things.app requires Base58-encoded UUIDs — standard UUID strings will crash the client.
-func base58Encode(u uuid.UUID) string {
-	const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-	n := new(big.Int).SetBytes(u[:])
-	base := big.NewInt(58)
-	mod := new(big.Int)
-	var encoded []byte
-	for n.Sign() > 0 {
-		n.DivMod(n, base, mod)
-		encoded = append(encoded, alphabet[mod.Int64()])
-	}
-	for i, j := 0, len(encoded)-1; i < j; i, j = i+1, j-1 {
-		encoded[i], encoded[j] = encoded[j], encoded[i]
-	}
-	return string(encoded)
-}
 
 func printTag(tag *thingscloud.Tag, state *memory.State, indent string) {
 	fmt.Printf("%s-\t%s\n", indent, tag.Title)
@@ -114,7 +94,7 @@ func main() {
 
 	pending := thingscloud.TaskStatusPending
 	anytime := thingscloud.TaskScheduleAnytime
-	taskUUID := base58Encode(uuid.New())
+	taskUUID := thingscloud.NewUUID()
 	now := thingscloud.Timestamp(time.Now())
 	date := thingscloud.Timestamp(time.Now().Truncate(24 * time.Hour))
 	todayIdx := 0

--- a/helpers.go
+++ b/helpers.go
@@ -22,8 +22,12 @@ func TaskTypePtr(val TaskType) *TaskType {
 	return &val
 }
 
-// Time returns a pointer to a Time
+// Time returns a pointer to a Time. The zero time returns nil: its
+// UnixNano is out of range and would marshal to a garbage 1754 date.
 func Time(val time.Time) *Timestamp {
+	if val.IsZero() {
+		return nil
+	}
 	ts := Timestamp(val)
 	return &ts
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,29 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTime_ZeroValueReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	if got := Time(time.Time{}); got != nil {
+		bs, _ := json.Marshal(got)
+		t.Errorf("Time(zero) = %s, want nil — the zero time marshals to a garbage 1754 epoch instead of being omitted", bs)
+	}
+}
+
+func TestTime_RealValueRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	got := Time(now)
+	if got == nil {
+		t.Fatal("Time(now) = nil, want pointer")
+	}
+	if !time.Time(*got).Equal(now) {
+		t.Errorf("Time(now) = %v, want %v", time.Time(*got), now)
+	}
+}

--- a/histories.go
+++ b/histories.go
@@ -130,6 +130,7 @@ func (c *Client) Histories() ([]*History, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err
@@ -168,6 +169,7 @@ func (c *Client) CreateHistory() (*History, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err
@@ -199,6 +201,7 @@ func (h *History) Delete() error {
 	if err != nil {
 		return err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", h.Client.password))
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return err

--- a/histories.go
+++ b/histories.go
@@ -53,7 +53,9 @@ func (h *History) Sync() error {
 		return err
 	}
 	var v itemsResponse
-	json.Unmarshal(bs, &v)
+	if err := json.Unmarshal(bs, &v); err != nil {
+		return fmt.Errorf("decoding history sync response: %w", err)
+	}
 	h.LatestServerIndex = v.CurrentItemIndex
 	h.LatestSchemaVersion = v.SchemaVersion
 	h.LatestTotalContentSize = v.LatestTotalContentSize
@@ -147,7 +149,9 @@ func (c *Client) Histories() ([]*History, error) {
 		return nil, err
 	}
 	var keys []string
-	json.Unmarshal(bs, &keys)
+	if err := json.Unmarshal(bs, &keys); err != nil {
+		return nil, fmt.Errorf("decoding history keys: %w", err)
+	}
 
 	var histories = make([]*History, len(keys))
 	for i, key := range keys {
@@ -187,7 +191,9 @@ func (c *Client) CreateHistory() (*History, error) {
 		return nil, err
 	}
 	var v createHistoryResponse
-	json.Unmarshal(bs, &v)
+	if err := json.Unmarshal(bs, &v); err != nil {
+		return nil, fmt.Errorf("decoding create-history response: %w", err)
+	}
 	return &History{
 		Client: c,
 		ID:     v.Key,
@@ -263,7 +269,9 @@ func (h *History) Write(items ...Identifiable) error {
 		return err
 	}
 	var w commitResponse
-	json.Unmarshal(rs, &w)
+	if err := json.Unmarshal(rs, &w); err != nil {
+		return fmt.Errorf("decoding commit response: %w", err)
+	}
 	h.LatestServerIndex = w.ServerHeadIndex
 	return nil
 }

--- a/histories.go
+++ b/histories.go
@@ -226,6 +226,12 @@ type Identifiable interface {
 func (h *History) Write(items ...Identifiable) error {
 	m := map[string]interface{}{}
 	for _, item := range items {
+		// A non-canonical identifier permanently corrupts the sync
+		// history: Things.app crashes decoding it and the item cannot
+		// be removed. Refuse it before anything reaches the server.
+		if err := ValidateUUID(item.UUID()); err != nil {
+			return fmt.Errorf("refusing to write item: %w", err)
+		}
 		m[item.UUID()] = item
 	}
 	bs, err := json.Marshal(m)

--- a/histories.go
+++ b/histories.go
@@ -45,7 +45,7 @@ func (h *History) Sync() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("http response code: %s", resp.Status)
+		return &HTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	bs, err := io.ReadAll(resp.Body)
@@ -75,7 +75,7 @@ func (c *Client) History(id string) (*History, error) {
 		if resp.StatusCode == http.StatusUnauthorized {
 			return nil, ErrUnauthorized
 		}
-		return nil, fmt.Errorf("http response code: %s", resp.Status)
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 	bs, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/histories.go
+++ b/histories.go
@@ -232,6 +232,11 @@ func (h *History) Write(items ...Identifiable) error {
 		if err := ValidateUUID(item.UUID()); err != nil {
 			return fmt.Errorf("refusing to write item: %w", err)
 		}
+		// The commit body is a map keyed by UUID, so a second op on the
+		// same item would silently replace the first. Reject instead.
+		if _, dup := m[item.UUID()]; dup {
+			return fmt.Errorf("refusing to write items: duplicate UUID %s in one commit — split into separate Write calls", item.UUID())
+		}
 		m[item.UUID()] = item
 	}
 	bs, err := json.Marshal(m)

--- a/histories_decode_test.go
+++ b/histories_decode_test.go
@@ -1,0 +1,59 @@
+package thingscloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHistory_Sync_ErrorsOnMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"current-item-index": not-json`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+	if err := h.Sync(); err == nil {
+		t.Error("Sync with malformed JSON response: got nil error — a silently zero LatestServerIndex feeds a wrong ancestor-index into the next Write")
+	}
+}
+
+func TestHistory_Write_ErrorsOnMalformedCommitResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `not json at all`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+	item := TaskActionItem{
+		Item: Item{UUID: "VJ1edXTP9q3PmFDUuy8EQh", Kind: ItemKindTask, Action: ItemActionCreated},
+		P:    TaskActionItemPayload{Title: String("x")},
+	}
+	if err := h.Write(item); err == nil {
+		t.Error("Write with malformed commit response: got nil error — LatestServerIndex silently stays stale")
+	}
+}
+
+func TestCreateHistory_ErrorsOnMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `garbage`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	if _, err := c.CreateHistory(); err == nil {
+		t.Error("CreateHistory with malformed response: got nil error — returns a History with empty ID")
+	}
+}

--- a/histories_test.go
+++ b/histories_test.go
@@ -2,8 +2,21 @@ package thingscloud
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func authCapturingServer(statusCode int, body string) (*httptest.Server, *http.Header) {
+	var captured http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		fmt.Fprintln(w, body)
+	}))
+	return server, &captured
+}
 
 func TestClient_Histories(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
@@ -18,6 +31,20 @@ func TestClient_Histories(t *testing.T) {
 		}
 		if len(hs) != 1 {
 			t.Errorf("Expected to receive %d histories, but got %d", 1, len(hs))
+		}
+	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(http.StatusOK, `[]`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if _, err := c.Histories(); err != nil {
+			t.Fatalf("Histories failed: %v", err)
+		}
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
 		}
 	})
 
@@ -49,6 +76,20 @@ func TestClient_CreateHistory(t *testing.T) {
 			t.Fatalf("Expected key %s but got %s", "33333abb-bfe4-4b03-a5c9-106d42220c72", h.ID)
 		}
 	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(http.StatusOK, `{}`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if _, err := c.CreateHistory(); err != nil {
+			t.Fatalf("CreateHistory failed: %v", err)
+		}
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
+		}
+	})
 }
 
 func TestHistory_Delete(t *testing.T) {
@@ -62,6 +103,21 @@ func TestHistory_Delete(t *testing.T) {
 		err := h.Delete()
 		if err != nil {
 			t.Fatalf("Expected request to succeed, but didn't: %q", err.Error())
+		}
+	})
+
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		t.Parallel()
+		server, captured := authCapturingServer(http.StatusAccepted, `{}`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		h := History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+		if err := h.Delete(); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+		if got := (*captured).Get("Authorization"); got != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", got, "Password secret")
 		}
 	})
 }

--- a/histories_write_test.go
+++ b/histories_write_test.go
@@ -60,3 +60,34 @@ func TestHistory_Write_AcceptsCanonicalUUID(t *testing.T) {
 		t.Errorf("Write with canonical UUID: %v, want nil", err)
 	}
 }
+
+func TestHistory_Write_RejectsDuplicateUUIDs(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+
+	id := NewUUID()
+	a := TaskActionItem{
+		Item: Item{UUID: id, Kind: ItemKindTask, Action: ItemActionModified},
+		P:    TaskActionItemPayload{Title: String("renamed")},
+	}
+	b := TaskActionItem{
+		Item: Item{UUID: id, Kind: ItemKindTask, Action: ItemActionModified},
+		P:    TaskActionItemPayload{Status: Status(TaskStatusCompleted)},
+	}
+	if err := h.Write(a, b); err == nil {
+		t.Error("Write with two items sharing a UUID: got nil error, want duplicate error — the commit map silently drops one op")
+	}
+	if requests != 0 {
+		t.Errorf("server received %d requests, want 0", requests)
+	}
+}

--- a/histories_write_test.go
+++ b/histories_write_test.go
@@ -1,0 +1,62 @@
+package thingscloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHistory_Write_RejectsInvalidUUID(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+
+	bad := []string{
+		"6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c", // standard hyphenated UUID
+		"",                                     // empty
+		"VJ0edXTP9q3PmFDUuy8EQh",               // '0' not in Base58 alphabet
+	}
+	for _, id := range bad {
+		item := TaskActionItem{
+			Item: Item{UUID: id, Kind: ItemKindTask, Action: ItemActionCreated},
+			P:    TaskActionItemPayload{Title: String("x")},
+		}
+		if err := h.Write(item); err == nil {
+			t.Errorf("Write with UUID %q: got nil error, want validation error", id)
+		}
+	}
+	if requests != 0 {
+		t.Errorf("server received %d requests, want 0 — invalid items must be rejected before POST", requests)
+	}
+}
+
+func TestHistory_Write_AcceptsCanonicalUUID(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := &History{Client: c, ID: "33333abb-bfe4-4b03-a5c9-106d42220c72"}
+
+	item := TaskActionItem{
+		Item: Item{UUID: NewUUID(), Kind: ItemKindTask, Action: ItemActionCreated},
+		P:    TaskActionItemPayload{Title: String("x")},
+	}
+	if err := h.Write(item); err != nil {
+		t.Errorf("Write with canonical UUID: %v, want nil", err)
+	}
+}

--- a/items.go
+++ b/items.go
@@ -12,10 +12,12 @@ import (
 // Common items are the creation of a task, area or checklist, as well as modifying attributes
 // or marking things as done.
 type Item struct {
-	UUID   string          `json:"-"`
-	P      json.RawMessage `json:"p"`
-	Kind   ItemKind        `json:"e"`
-	Action ItemAction      `json:"t"`
+	UUID           string          `json:"-"`
+	P              json.RawMessage `json:"p"`
+	Kind           ItemKind        `json:"e"`
+	Action         ItemAction      `json:"t"`
+	ServerIndex    int             `json:"-"`
+	HasServerIndex bool            `json:"-"`
 }
 
 type itemsResponse struct {
@@ -65,9 +67,12 @@ func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 		return nil, false, err
 	}
 	var items = []Item{}
-	for _, m := range v.Items {
+	for offset, m := range v.Items {
+		serverIndex := opts.StartIndex + offset
 		for id, item := range m {
 			item.UUID = id
+			item.ServerIndex = serverIndex
+			item.HasServerIndex = true
 			items = append(items, item)
 		}
 	}

--- a/items.go
+++ b/items.go
@@ -71,7 +71,7 @@ func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 			items = append(items, item)
 		}
 	}
-	h.LoadedServerIndex = h.LoadedServerIndex + len(v.Items)
+	h.LoadedServerIndex = opts.StartIndex + len(v.Items)
 	h.LatestServerIndex = v.CurrentItemIndex
 	h.EndTotalContentSize = v.EndTotalContentSize
 	h.LatestTotalContentSize = v.LatestTotalContentSize

--- a/items.go
+++ b/items.go
@@ -55,7 +55,7 @@ func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, false, fmt.Errorf("http response code: %s", resp.Status)
+		return nil, false, &HTTPError{StatusCode: resp.StatusCode, Status: resp.Status}
 	}
 
 	bs, err := io.ReadAll(resp.Body)

--- a/items_test.go
+++ b/items_test.go
@@ -2,6 +2,8 @@ package thingscloud
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -23,6 +25,46 @@ func TestHistory_Items(t *testing.T) {
 
 		if len(items) < 1 {
 			t.Fatalf("Expected items, but got none: %#v", items)
+		}
+	})
+
+	t.Run("SetsServerIndexFromOuterItems", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"items":[{"task-a":{"e":"Task6","t":0,"p":{"tt":"Task A"}},"task-b":{"e":"Task6","t":0,"p":{"tt":"Task B"}}},{"task-c":{"e":"Task6","t":0,"p":{"tt":"Task C"}}}],"current-item-index":12,"schema":301}`)
+		}))
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		h := &History{
+			Client: c,
+			ID:     "33333abb-bfe4-4b03-a5c9-106d42220c72",
+		}
+
+		items, _, err := h.Items(ItemsOptions{StartIndex: 10})
+		if err != nil {
+			t.Fatalf("Items failed: %v", err)
+		}
+		if len(items) != 3 {
+			t.Fatalf("expected 3 flattened items, got %d", len(items))
+		}
+
+		indexByUUID := make(map[string]int)
+		for _, item := range items {
+			if !item.HasServerIndex {
+				t.Fatalf("item %s is missing server index metadata", item.UUID)
+			}
+			indexByUUID[item.UUID] = item.ServerIndex
+		}
+
+		for _, uuid := range []string{"task-a", "task-b"} {
+			if indexByUUID[uuid] != 10 {
+				t.Errorf("%s ServerIndex = %d, want 10", uuid, indexByUUID[uuid])
+			}
+		}
+		if indexByUUID["task-c"] != 11 {
+			t.Errorf("task-c ServerIndex = %d, want 11", indexByUUID["task-c"])
 		}
 	})
 }

--- a/items_test.go
+++ b/items_test.go
@@ -2,6 +2,8 @@ package thingscloud
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -23,6 +25,37 @@ func TestHistory_Items(t *testing.T) {
 
 		if len(items) < 1 {
 			t.Fatalf("Expected items, but got none: %#v", items)
+		}
+	})
+
+	t.Run("TracksLoadedServerIndexFromStartIndex", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("start-index"); got != "100" {
+				t.Errorf("start-index = %q, want %q", got, "100")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"items":[{"task-101":{"e":"Task6","t":0,"p":{"tt":"Task 101","tp":0}}},{"task-102":{"e":"Task6","t":0,"p":{"tt":"Task 102","tp":0}}}],"current-item-index":105,"schema":301}`)
+		}))
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		h := &History{
+			Client: c,
+			ID:     "33333abb-bfe4-4b03-a5c9-106d42220c72",
+		}
+		_, more, err := h.Items(ItemsOptions{StartIndex: 100})
+		if err != nil {
+			t.Fatalf("Items failed: %v", err)
+		}
+		if h.LoadedServerIndex != 102 {
+			t.Errorf("LoadedServerIndex = %d, want %d", h.LoadedServerIndex, 102)
+		}
+		if h.LatestServerIndex != 105 {
+			t.Errorf("LatestServerIndex = %d, want %d", h.LatestServerIndex, 105)
+		}
+		if !more {
+			t.Error("Expected more items")
 		}
 	})
 }

--- a/sync/changes.go
+++ b/sync/changes.go
@@ -621,6 +621,37 @@ func (c UnknownChange) EntityUUID() string {
 	return c.entityUUID
 }
 
+// LoggedChange represents a semantic change restored from the persisted change log.
+// It preserves the stored change type and metadata, but not type-specific fields
+// that are not persisted in the current schema.
+type LoggedChange struct {
+	baseChange
+	changeType string
+	entityType string
+	entityUUID string
+	payload    string
+}
+
+// ChangeType returns the persisted semantic change type.
+func (c LoggedChange) ChangeType() string {
+	return c.changeType
+}
+
+// EntityType returns the persisted entity type.
+func (c LoggedChange) EntityType() string {
+	return c.entityType
+}
+
+// EntityUUID returns the persisted entity UUID.
+func (c LoggedChange) EntityUUID() string {
+	return c.entityUUID
+}
+
+// Payload returns the raw item payload stored with the change log entry.
+func (c LoggedChange) Payload() string {
+	return c.payload
+}
+
 // Compile-time interface implementation checks
 var (
 	_ Change = (*TaskCreated)(nil)
@@ -669,4 +700,5 @@ var (
 	_ Change = (*ChecklistItemTitleChanged)(nil)
 
 	_ Change = (*UnknownChange)(nil)
+	_ Change = (*LoggedChange)(nil)
 )

--- a/sync/integration_test.go
+++ b/sync/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"testing"
+	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
 )
@@ -158,11 +159,21 @@ func TestStateQueries(t *testing.T) {
 	defer syncer.Close()
 
 	// Create test data directly
+	today := startOfDay(time.Now())
+	tomorrow := today.Add(24 * time.Hour)
+
 	syncer.saveTask(&things.Task{UUID: "inbox-1", Title: "Inbox Task", Schedule: things.TaskScheduleInbox, Status: things.TaskStatusPending})
 	syncer.saveTask(&things.Task{UUID: "anytime-1", Title: "Anytime Task", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "today-1", Title: "Today Task", Schedule: things.TaskScheduleAnytime, ScheduledDate: &today, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "someday-1", Title: "Someday Task", Schedule: things.TaskScheduleSomeday, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "upcoming-1", Title: "Upcoming Task", Schedule: things.TaskScheduleSomeday, ScheduledDate: &tomorrow, Status: things.TaskStatusPending})
 	syncer.saveTask(&things.Task{UUID: "completed-1", Title: "Completed Task", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusCompleted})
 	syncer.saveTask(&things.Task{UUID: "trashed-1", Title: "Trashed Task", InTrash: true})
 	syncer.saveTask(&things.Task{UUID: "project-1", Title: "Test Project", Type: things.TaskTypeProject})
+	syncer.saveTask(&things.Task{UUID: "heading-1", Title: "Test Heading", Type: things.TaskTypeHeading, ParentTaskIDs: []string{"project-1"}})
+	syncer.saveTask(&things.Task{UUID: "under-heading-1", Title: "Under Heading Task", ActionGroupIDs: []string{"heading-1"}, Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "tagged-1", Title: "Tagged Task", TagIDs: []string{"tag-1"}, Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "search-1", Title: "Needle Task", Note: "hidden haystack", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
 
 	state := syncer.State()
 
@@ -217,4 +228,132 @@ func TestStateQueries(t *testing.T) {
 			t.Error("returned task is not a project")
 		}
 	})
+
+	t.Run("TasksInToday returns tasks scheduled today", func(t *testing.T) {
+		tasks, err := state.TasksInToday(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInToday failed: %v", err)
+		}
+		if !hasTask(tasks, "today-1") {
+			t.Error("today task should be returned")
+		}
+		if hasTask(tasks, "anytime-1") {
+			t.Error("unscheduled anytime task should not be returned in Today")
+		}
+	})
+
+	t.Run("TasksInAnytime returns unscheduled anytime tasks", func(t *testing.T) {
+		tasks, err := state.TasksInAnytime(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInAnytime failed: %v", err)
+		}
+		if !hasTask(tasks, "anytime-1") {
+			t.Error("anytime task should be returned")
+		}
+		if hasTask(tasks, "today-1") {
+			t.Error("today task should not be returned in Anytime")
+		}
+		if hasTask(tasks, "completed-1") {
+			t.Error("completed task should be excluded by default")
+		}
+	})
+
+	t.Run("TasksInAnytime includes completed when requested", func(t *testing.T) {
+		tasks, err := state.TasksInAnytime(QueryOpts{IncludeCompleted: true})
+		if err != nil {
+			t.Fatalf("TasksInAnytime failed: %v", err)
+		}
+		if !hasTask(tasks, "completed-1") {
+			t.Error("completed task should be included")
+		}
+	})
+
+	t.Run("TasksInSomeday returns unscheduled someday tasks", func(t *testing.T) {
+		tasks, err := state.TasksInSomeday(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInSomeday failed: %v", err)
+		}
+		if !hasTask(tasks, "someday-1") {
+			t.Error("someday task should be returned")
+		}
+		if hasTask(tasks, "upcoming-1") {
+			t.Error("scheduled someday task should not be returned in Someday")
+		}
+	})
+
+	t.Run("TasksInUpcoming returns future scheduled tasks", func(t *testing.T) {
+		tasks, err := state.TasksInUpcoming(QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInUpcoming failed: %v", err)
+		}
+		if !hasTask(tasks, "upcoming-1") {
+			t.Error("upcoming task should be returned")
+		}
+		if hasTask(tasks, "someday-1") {
+			t.Error("unscheduled someday task should not be returned in Upcoming")
+		}
+	})
+
+	t.Run("Heading queries return headings and child tasks", func(t *testing.T) {
+		headings, err := state.AllHeadings(QueryOpts{})
+		if err != nil {
+			t.Fatalf("AllHeadings failed: %v", err)
+		}
+		if !hasTask(headings, "heading-1") {
+			t.Error("heading should be returned")
+		}
+
+		projectHeadings, err := state.HeadingsInProject("project-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("HeadingsInProject failed: %v", err)
+		}
+		if !hasTask(projectHeadings, "heading-1") {
+			t.Error("project heading should be returned")
+		}
+
+		tasks, err := state.TasksUnderHeading("heading-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksUnderHeading failed: %v", err)
+		}
+		if !hasTask(tasks, "under-heading-1") {
+			t.Error("task under heading should be returned")
+		}
+	})
+
+	t.Run("TasksWithTag returns tagged tasks", func(t *testing.T) {
+		tasks, err := state.TasksWithTag("tag-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksWithTag failed: %v", err)
+		}
+		if !hasTask(tasks, "tagged-1") {
+			t.Error("tagged task should be returned")
+		}
+	})
+
+	t.Run("SearchTasks returns matching tasks", func(t *testing.T) {
+		tasks, err := state.SearchTasks("needle", QueryOpts{})
+		if err != nil {
+			t.Fatalf("SearchTasks failed: %v", err)
+		}
+		if !hasTask(tasks, "search-1") {
+			t.Error("matching task title should be returned")
+		}
+
+		tasks, err = state.SearchTasks("haystack", QueryOpts{})
+		if err != nil {
+			t.Fatalf("SearchTasks failed: %v", err)
+		}
+		if !hasTask(tasks, "search-1") {
+			t.Error("matching task note should be returned")
+		}
+	})
+}
+
+func hasTask(tasks []*things.Task, uuid string) bool {
+	for _, task := range tasks {
+		if task.UUID == uuid {
+			return true
+		}
+	}
+	return false
 }

--- a/sync/integration_test.go
+++ b/sync/integration_test.go
@@ -144,7 +144,95 @@ func TestIntegration(t *testing.T) {
 		if len(allChanges) != 3 {
 			t.Errorf("expected 3 total changes, got %d", len(allChanges))
 		}
+		if allChanges[0].ChangeType() != "TaskCreated" {
+			t.Errorf("expected first logged change type TaskCreated, got %s", allChanges[0].ChangeType())
+		}
+		if _, ok := allChanges[0].(LoggedChange); !ok {
+			t.Errorf("expected persisted change to be LoggedChange, got %T", allChanges[0])
+		}
 	})
+}
+
+func TestProcessItemsUsesItemServerIndex(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	syncer, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	payload := things.TaskActionItemPayload{}
+	title := "Indexed task"
+	payload.Title = &title
+	tp := things.TaskTypeTask
+	payload.Type = &tp
+	payloadBytes, _ := json.Marshal(payload)
+
+	items := []things.Item{
+		{
+			UUID:           "task-a",
+			Kind:           things.ItemKindTask,
+			Action:         things.ItemActionCreated,
+			P:              payloadBytes,
+			ServerIndex:    7,
+			HasServerIndex: true,
+		},
+		{
+			UUID:           "task-b",
+			Kind:           things.ItemKindTask,
+			Action:         things.ItemActionCreated,
+			P:              payloadBytes,
+			ServerIndex:    7,
+			HasServerIndex: true,
+		},
+		{
+			UUID:           "task-c",
+			Kind:           things.ItemKindTask,
+			Action:         things.ItemActionCreated,
+			P:              payloadBytes,
+			ServerIndex:    8,
+			HasServerIndex: true,
+		},
+	}
+
+	changes, err := syncer.processItems(items, 100)
+	if err != nil {
+		t.Fatalf("processItems failed: %v", err)
+	}
+	if len(changes) != 3 {
+		t.Fatalf("expected 3 changes, got %d", len(changes))
+	}
+
+	rows, err := syncer.db.Query(`SELECT entity_uuid, server_index FROM change_log`)
+	if err != nil {
+		t.Fatalf("querying change_log failed: %v", err)
+	}
+	defer rows.Close()
+
+	indexByUUID := make(map[string]int)
+	for rows.Next() {
+		var uuid string
+		var serverIndex int
+		if err := rows.Scan(&uuid, &serverIndex); err != nil {
+			t.Fatalf("scanning change_log failed: %v", err)
+		}
+		indexByUUID[uuid] = serverIndex
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("reading change_log failed: %v", err)
+	}
+
+	if indexByUUID["task-a"] != 7 {
+		t.Errorf("task-a server_index = %d, want 7", indexByUUID["task-a"])
+	}
+	if indexByUUID["task-b"] != 7 {
+		t.Errorf("task-b server_index = %d, want 7", indexByUUID["task-b"])
+	}
+	if indexByUUID["task-c"] != 8 {
+		t.Errorf("task-c server_index = %d, want 8", indexByUUID["task-c"])
+	}
 }
 
 func TestStateQueries(t *testing.T) {

--- a/sync/process.go
+++ b/sync/process.go
@@ -33,6 +33,9 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 
 	for i, item := range items {
 		serverIndex := baseIndex + i
+		if item.HasServerIndex {
+			serverIndex = item.ServerIndex
+		}
 		ts := time.Now()
 
 		changes, err := s.processItem(item, serverIndex, ts)

--- a/sync/process.go
+++ b/sync/process.go
@@ -54,6 +54,15 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 		allChanges = append(allChanges, changes...)
 	}
 
+	// Persist the cursor in the same transaction as the batch it covers:
+	// either both land or neither does, so a resume never replays a
+	// committed batch or skips an uncommitted one.
+	if s.history != nil {
+		if err := s.saveSyncState(s.history.ID, s.history.LoadedServerIndex); err != nil {
+			return nil, fmt.Errorf("saving sync state: %w", err)
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("committing transaction: %w", err)
 	}

--- a/sync/robustness_test.go
+++ b/sync/robustness_test.go
@@ -1,0 +1,148 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// TestSync_CursorSurvivesMidSyncFailure: each successfully committed batch
+// must persist its cursor. If a later batch fails, resuming must not replay
+// the committed batches (replays double-apply note delta patches and
+// duplicate change_log rows).
+func TestSync_CursorSurvivesMidSyncFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			switch r.URL.Query().Get("start-index") {
+			case "0":
+				// Batch 1: one valid task create.
+				fmt.Fprint(w, `{"items":[{"VJ1edXTP9q3PmFDUuy8EQh":{"e":"Task6","t":0,"p":{"tt":"good task","tp":0,"st":1}}}],"current-item-index":2,"schema":301}`)
+			case "1":
+				// Batch 2: payload is a bare string — unmarshal into the
+				// task payload struct fails, so this batch errors.
+				fmt.Fprint(w, `{"items":[{"FQxaqvLBkbR5q2Q5oRoknc":{"e":"Task6","t":0,"p":"garbage"}}],"current-item-index":2,"schema":301}`)
+			default:
+				fmt.Fprint(w, `{"items":[],"current-item-index":2,"schema":301}`)
+			}
+			return
+		}
+		fmt.Fprint(w, `{"latest-server-index":2,"latest-schema-version":301}`)
+	}))
+	defer server.Close()
+
+	client := things.New(server.URL, "test@example.com", "password")
+	syncer, err := Open(filepath.Join(t.TempDir(), "test.db"), client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	if err := syncer.saveSyncState("h1", 0); err != nil {
+		t.Fatalf("saveSyncState failed: %v", err)
+	}
+
+	if _, err := syncer.Sync(); err == nil {
+		t.Fatal("Sync: want error from corrupt batch 2, got nil")
+	}
+
+	if got := syncer.LastSyncedIndex(); got != 1 {
+		t.Errorf("cursor after mid-sync failure = %d, want 1 (end of committed batch 1); a wrong cursor replays or skips items on the next sync", got)
+	}
+}
+
+// TestGetTask_ExcludesSoftDeleted: getTask must filter deleted rows like
+// every other entity, otherwise delete replays emit duplicate TaskDeleted
+// events and State.Task returns tasks the user deleted.
+func TestGetTask_ExcludesSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	syncer, err := Open(filepath.Join(t.TempDir(), "test.db"), nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	createPayload, _ := json.Marshal(map[string]any{"tt": "victim", "tp": 0, "st": 1})
+	create := things.Item{UUID: "VJ1edXTP9q3PmFDUuy8EQh", Kind: things.ItemKindTask, Action: things.ItemActionCreated, P: createPayload}
+	deleteItem := things.Item{UUID: "VJ1edXTP9q3PmFDUuy8EQh", Kind: things.ItemKindTask, Action: things.ItemActionDeleted, P: json.RawMessage(`{}`)}
+
+	if _, err := syncer.processItems([]things.Item{create}, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	changes, err := syncer.processItems([]things.Item{deleteItem}, 1)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if n := countByType(changes, "TaskDeleted"); n != 1 {
+		t.Fatalf("first delete: %d TaskDeleted changes, want 1", n)
+	}
+
+	task, err := syncer.getTask("VJ1edXTP9q3PmFDUuy8EQh")
+	if err != nil {
+		t.Fatalf("getTask: %v", err)
+	}
+	if task != nil {
+		t.Errorf("getTask returned soft-deleted task %q, want nil", task.Title)
+	}
+
+	// Replaying the same delete (e.g. after a crash) must not emit another
+	// TaskDeleted event.
+	changes, err = syncer.processItems([]things.Item{deleteItem}, 1)
+	if err != nil {
+		t.Fatalf("replayed delete: %v", err)
+	}
+	if n := countByType(changes, "TaskDeleted"); n != 0 {
+		t.Errorf("replayed delete: %d TaskDeleted changes, want 0", n)
+	}
+}
+
+func countByType(changes []Change, changeType string) int {
+	n := 0
+	for _, c := range changes {
+		if c.ChangeType() == changeType {
+			n++
+		}
+	}
+	return n
+}
+
+// TestIsRetryableError: retry decisions must come from the HTTP status
+// code, not substring-matching digits in arbitrary error text.
+func TestIsRetryableError(t *testing.T) {
+	t.Parallel()
+
+	retryable := []error{
+		&things.HTTPError{StatusCode: 500, Status: "500 Internal Server Error"},
+		&things.HTTPError{StatusCode: 502, Status: "502 Bad Gateway"},
+		&things.HTTPError{StatusCode: 503, Status: "503 Service Unavailable"},
+		&things.HTTPError{StatusCode: 504, Status: "504 Gateway Timeout"},
+		fmt.Errorf("fetching items: %w", &things.HTTPError{StatusCode: 500, Status: "500 Internal Server Error"}),
+	}
+	for _, err := range retryable {
+		if !isRetryableError(err) {
+			t.Errorf("isRetryableError(%v) = false, want true", err)
+		}
+	}
+
+	notRetryable := []error{
+		nil,
+		&things.HTTPError{StatusCode: 404, Status: "404 Not Found"},
+		&things.HTTPError{StatusCode: 401, Status: "401 Unauthorized"},
+		fmt.Errorf("request took 1504ms and was cancelled"), // digits are not a status
+		fmt.Errorf("connect: connection refused on port 5001"),
+	}
+	for _, err := range notRetryable {
+		if isRetryableError(err) {
+			t.Errorf("isRetryableError(%v) = true, want false", err)
+		}
+	}
+}

--- a/sync/state.go
+++ b/sync/state.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -117,7 +118,7 @@ func (st *State) TasksInInbox(opts QueryOpts) ([]*things.Task, error) {
 
 // TasksInToday returns tasks scheduled for today
 func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
-	today := time.Now().Truncate(24 * time.Hour)
+	today := startOfDay(time.Now())
 	tomorrow := today.Add(24 * time.Hour)
 
 	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1
@@ -131,6 +132,39 @@ func (st *State) TasksInToday(opts QueryOpts) ([]*things.Task, error) {
 	query += ` ORDER BY today_index, "index"`
 
 	rows, err := st.db.Query(query, today.Unix(), tomorrow.Unix())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return st.scanTaskUUIDs(rows)
+}
+
+// TasksInAnytime returns tasks in Anytime.
+func (st *State) TasksInAnytime(opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 1 AND scheduled_date IS NULL AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query)
+}
+
+// TasksInSomeday returns tasks in Someday.
+func (st *State) TasksInSomeday(opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 2 AND scheduled_date IS NULL AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query)
+}
+
+// TasksInUpcoming returns tasks scheduled for future dates.
+func (st *State) TasksInUpcoming(opts QueryOpts) ([]*things.Task, error) {
+	tomorrow := startOfDay(time.Now()).Add(24 * time.Hour)
+
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND schedule = 2
+		AND scheduled_date >= ? AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY scheduled_date, "index"`
+
+	rows, err := st.db.Query(query, tomorrow.Unix())
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +210,61 @@ func (st *State) TasksInArea(areaUUID string, opts QueryOpts) ([]*things.Task, e
 	return st.scanTaskUUIDs(rows)
 }
 
+// AllHeadings returns all headings.
+func (st *State) AllHeadings(opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 2 AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query)
+}
+
+// HeadingsInProject returns headings belonging to a project.
+func (st *State) HeadingsInProject(projectUUID string, opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 2 AND project_uuid = ? AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query, projectUUID)
+}
+
+// TasksUnderHeading returns tasks belonging to a heading.
+func (st *State) TasksUnderHeading(headingUUID string, opts QueryOpts) ([]*things.Task, error) {
+	query := `SELECT uuid FROM tasks WHERE type = 0 AND heading_uuid = ? AND deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY "index"`
+	return st.queryTasks(query, headingUUID)
+}
+
+// TasksWithTag returns tasks tagged with the given tag UUID.
+func (st *State) TasksWithTag(tagUUID string, opts QueryOpts) ([]*things.Task, error) {
+	query := `
+		SELECT t.uuid
+		FROM tasks t
+		INNER JOIN task_tags tt ON tt.task_uuid = t.uuid
+		WHERE t.type = 0 AND tt.tag_uuid = ? AND t.deleted = 0`
+	query = applyTaskQueryOpts(query, opts)
+	query += ` ORDER BY t."index"`
+	return st.queryTasks(query, tagUUID)
+}
+
+// SearchTasks returns tasks whose title or note contains query.
+func (st *State) SearchTasks(query string, opts QueryOpts) ([]*things.Task, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return []*things.Task{}, nil
+	}
+
+	sqlQuery := `
+		SELECT uuid
+		FROM tasks
+		WHERE type = 0 AND deleted = 0
+			AND (title LIKE ? ESCAPE '\' OR note LIKE ? ESCAPE '\')`
+	sqlQuery = applyTaskQueryOpts(sqlQuery, opts)
+	sqlQuery += ` ORDER BY "index"`
+
+	pattern := likePattern(query)
+	return st.queryTasks(sqlQuery, pattern, pattern)
+}
+
 // ChecklistItems returns checklist items for a task
 func (st *State) ChecklistItems(taskUUID string) ([]*things.CheckListItem, error) {
 	rows, err := st.db.Query(`
@@ -205,8 +294,8 @@ func (st *State) ChecklistItems(taskUUID string) ([]*things.CheckListItem, error
 
 // Helper methods
 
-func (st *State) queryTasks(query string) ([]*things.Task, error) {
-	rows, err := st.db.Query(query)
+func (st *State) queryTasks(query string, args ...any) ([]*things.Task, error) {
+	rows, err := st.db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -231,5 +320,27 @@ func (st *State) scanTaskUUIDs(rows *sql.Rows) ([]*things.Task, error) {
 			tasks = append(tasks, task)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return tasks, nil
+}
+
+func applyTaskQueryOpts(query string, opts QueryOpts) string {
+	if !opts.IncludeCompleted {
+		query += " AND status != 3"
+	}
+	if !opts.IncludeTrashed {
+		query += " AND in_trash = 0"
+	}
+	return query
+}
+
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+func likePattern(query string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return "%" + replacer.Replace(query) + "%"
 }

--- a/sync/store.go
+++ b/sync/store.go
@@ -17,7 +17,7 @@ func (s *Syncer) getTask(uuid string) (*things.Task, error) {
 			"index", today_index, in_trash, area_uuid, project_uuid, heading_uuid,
 			alarm_time_offset, recurrence_rule, deleted
 		FROM tasks
-		WHERE uuid = ?
+		WHERE uuid = ? AND deleted = 0
 	`, uuid)
 
 	var (

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -25,8 +25,8 @@ type dbExecutor interface {
 
 // Syncer manages persistent sync with Things Cloud
 type Syncer struct {
-	rawDB   *sql.DB     // underlying connection for Close() and Begin()
-	db      dbExecutor  // current executor (db or tx)
+	rawDB   *sql.DB    // underlying connection for Close() and Begin()
+	db      dbExecutor // current executor (db or tx)
 	client  *things.Client
 	history *things.History
 }
@@ -163,9 +163,9 @@ func (s *Syncer) Sync() ([]Change, error) {
 		}
 		allChanges = append(allChanges, changes...)
 
-		// Use server's current-item-index as next start position
-		// (not len(items) - items get expanded from nested structure)
-		startIndex = s.history.LatestServerIndex
+		// Use loaded server item-batches as the next start position.
+		// The expanded item count can differ from the server batch count.
+		startIndex = s.history.LoadedServerIndex
 		hasMore = more
 	}
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -25,8 +25,8 @@ type dbExecutor interface {
 
 // Syncer manages persistent sync with Things Cloud
 type Syncer struct {
-	rawDB   *sql.DB     // underlying connection for Close() and Begin()
-	db      dbExecutor  // current executor (db or tx)
+	rawDB   *sql.DB    // underlying connection for Close() and Begin()
+	db      dbExecutor // current executor (db or tx)
 	client  *things.Client
 	history *things.History
 }
@@ -250,14 +250,22 @@ func (s *Syncer) scanChangeLog(rows *sql.Rows) ([]Change, error) {
 			timestamp:   time.Unix(syncedAt, 0),
 		}
 
-		// Return UnknownChange with the change type as details
-		// A more complete implementation would reconstruct full typed changes
-		changes = append(changes, UnknownChange{
+		var rawPayload string
+		if payload.Valid {
+			rawPayload = payload.String
+		}
+
+		changes = append(changes, LoggedChange{
 			baseChange: base,
+			changeType: changeType,
 			entityType: entityType,
 			entityUUID: entityUUID,
-			Details:    changeType,
+			payload:    rawPayload,
 		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return changes, nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -4,7 +4,7 @@ package sync
 
 import (
 	"database/sql"
-	"strings"
+	"errors"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -65,14 +65,11 @@ func (s *Syncer) Close() error {
 
 // isRetryableError returns true if the error is a temporary server error worth retrying.
 func isRetryableError(err error) bool {
-	if err == nil {
-		return false
+	var httpErr *things.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500 && httpErr.StatusCode <= 504
 	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "500") ||
-		strings.Contains(errStr, "502") ||
-		strings.Contains(errStr, "503") ||
-		strings.Contains(errStr, "504")
+	return false
 }
 
 // Sync fetches new items from Things Cloud, updates local state,
@@ -169,10 +166,10 @@ func (s *Syncer) Sync() ([]Change, error) {
 		hasMore = more
 	}
 
-	// Save sync state
-	if err := s.saveSyncState(s.history.ID, s.history.LatestServerIndex); err != nil {
-		return nil, err
-	}
+	// Sync state is persisted per batch inside processItems' transaction,
+	// so a mid-sync failure resumes exactly after the last committed batch
+	// instead of replaying it (replays double-apply note delta patches and
+	// duplicate change_log rows).
 
 	return allChanges, nil
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -1,10 +1,66 @@
 package sync
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
 )
+
+func TestSync_PaginatesFromStoredCursor(t *testing.T) {
+	t.Parallel()
+
+	const historyID = "test-history-id"
+
+	page101 := `{"items":[{"task-page101":{"e":"Task6","t":0,"p":{"tt":"Page 101 Task","tp":0}}}],"current-item-index":102,"schema":301}`
+	page102 := `{"items":[{"task-page102":{"e":"Task6","t":0,"p":{"tt":"Page 102 Task","tp":0}}}],"current-item-index":102,"schema":301}`
+	historyMeta := `{"latest-server-index":102,"latest-schema-version":301,"is-empty":false,"latest-total-content-size":0}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			switch r.URL.Query().Get("start-index") {
+			case "100":
+				fmt.Fprint(w, page101)
+			case "101":
+				fmt.Fprint(w, page102)
+			default:
+				fmt.Fprint(w, `{"items":[],"current-item-index":102,"schema":301}`)
+			}
+			return
+		}
+		fmt.Fprint(w, historyMeta)
+	}))
+	defer ts.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	client := things.New(ts.URL, "test@example.com", "password")
+	syncer, err := Open(dbPath, client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	if err := syncer.saveSyncState(historyID, 100); err != nil {
+		t.Fatalf("saveSyncState failed: %v", err)
+	}
+
+	changes, err := syncer.Sync()
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Errorf("changes = %d, want %d", len(changes), 2)
+	}
+	if got := syncer.LastSyncedIndex(); got != 102 {
+		t.Errorf("LastSyncedIndex = %d, want %d", got, 102)
+	}
+}
 
 func TestOpen(t *testing.T) {
 	t.Parallel()

--- a/types.go
+++ b/types.go
@@ -63,7 +63,12 @@ var (
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"
 	ItemKindTaskPlain ItemKind = "Task"
-	// ItemKindArea identifies an Area
+	// ItemKindArea identifies an Area in the legacy Area2 encoding.
+	//
+	// Deprecated: never WRITE items with this kind — Things.app silently
+	// ignores Area2 creates and manufactures a duplicate area with a new
+	// UUID. Use ItemKindArea3. Reading Area2 items from old histories is
+	// still supported.
 	ItemKindArea      ItemKind = "Area2"
 	ItemKindArea3     ItemKind = "Area3"
 	ItemKindAreaPlain ItemKind = "Area"


### PR DESCRIPTION
## Summary

Promotes `develop` to `main`. This integrates the six community PRs and the four audit-fix PRs that close every known path for writing client-crashing data to Things Cloud.

### Community contributions
- #6 — missing `Authorization` header on history endpoints; sync pagination fix (`current-item-index` is the server's **total** item count — `main` currently silently syncs only the first page of large histories)
- #7 — persisted change log returns typed `LoggedChange` instead of discarding the change type
- #8 — state queries: `TasksInAnytime`/`TasksInSomeday`/`TasksInUpcoming`, heading queries, local-midnight fix
- #9 — CLI scheduling payloads use explicit `null` dates instead of ambiguous `sr: 0`
- #10 — incremental local state cache for CLI read commands
- #11 — CLI view commands: `today`/`inbox`/`anytime`/`someday`/`upcoming`/`search`

(#4 and #5 were closed as superseded by #6.)

### Audit fixes (crash surface)
- #12 — canonical Base58 UUID encoding in the SDK (`EncodeUUID`/`DecodeUUID`/`ValidateUUID`/`NewUUID`), `Write()` boundary validation, CLI input validation. The old duplicated encoders dropped leading zero bytes: ~1 in 256 generated UUIDs was undecodable by Things.app — the likely cause of the historical intermittent history corruption.
- #16 — projects and headings can never be written with `st=0` (including via `--when inbox`); `Write()` rejects duplicate UUIDs per commit instead of silently dropping ops
- #14 — sync engine: per-batch atomic cursor (no replay corruption), `getTask` deleted-filter, 60s HTTP timeout, typed `HTTPError` retries
- #15 — zero-time marshal guard (garbage 1754 dates), surfaced JSON decode errors, `Area2` deprecation

### Docs
- CLAUDE.md: corrected package name, documented crash-critical wire-format rules

## Validation

`go build ./...`, `go vet ./...`, and the full test suite pass on the merged `develop`. All fixes were developed test-first.

## After merging

Tag `v0.1.0` on `main`. Merging this also flips #6–#11 to Merged automatically (their commits become reachable from their base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)