### PR TITLE
fix: four bugs surfaced by the coverage work

### DIFF
--- a/account.go
+++ b/account.go
@@ -96,7 +96,7 @@ func (s *AccountService) Confirm(code string) error {
 // SignUp creates a new thingscloud account and returns a configured client
 func (s *AccountService) SignUp(email, password string) (*Client, error) {
 	data, err := json.Marshal(accountRequestBody{
-		Password:           password,
+		Password: password,
 	})
 	if err != nil {
 		return nil, err
@@ -132,6 +132,7 @@ func (s *AccountService) ChangePassword(newPassword string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", s.client.password))
 	resp, err := s.client.do(req)
 	if err != nil {
 		return nil, err

--- a/account_coverage_test.go
+++ b/account_coverage_test.go
@@ -217,13 +217,10 @@ func TestAccountService_ChangePassword(t *testing.T) {
 		if cap.Body["password"] != "newpw" {
 			t.Errorf("password = %v, want newpw", cap.Body["password"])
 		}
-		// NOTE: current behavior — ChangePassword does NOT send an Authorization
-		// header, unlike Delete/AcceptSLA/Confirm. This test documents that; see
-		// the reported finding. If the server enforces auth this request would
-		// fail in production. If ChangePassword is fixed to authenticate, update
-		// this expectation to "Password old".
-		if cap.Authorization != "" {
-			t.Errorf("Authorization = %q, want empty (current behavior: no auth header sent)", cap.Authorization)
+		// Changing a password must be authenticated with the OLD password,
+		// like every other account mutation (Delete/AcceptSLA/Confirm).
+		if cap.Authorization != "Password old" {
+			t.Errorf("Authorization = %q, want %q", cap.Authorization, "Password old")
 		}
 	})
 

--- a/notes.go
+++ b/notes.go
@@ -37,6 +37,11 @@ func ApplyPatches(original string, patches []NotePatch) string {
 		if end > len(runes) {
 			end = len(runes)
 		}
+		if end < p.Position {
+			// Negative length in a corrupt/hostile patch: treat as a
+			// pure insertion instead of slicing out of bounds.
+			end = p.Position
+		}
 		actualLength := end - p.Position
 		replacementRunes := []rune(p.Replacement)
 		newCap := len(runes) - actualLength + len(replacementRunes)

--- a/notes_negative_patch_test.go
+++ b/notes_negative_patch_test.go
@@ -1,0 +1,19 @@
+package thingscloud
+
+import "testing"
+
+func TestApplyPatches_NegativeLengthDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// A hostile or corrupted server payload with a negative length must not
+	// crash the SDK. A negative length is treated as zero (pure insertion).
+	got := ApplyPatches("hello", []NotePatch{{Replacement: "X", Position: 0, Length: -5}})
+	if got != "Xhello" {
+		t.Errorf("ApplyPatches negative length = %q, want %q", got, "Xhello")
+	}
+
+	got = ApplyPatches("hello", []NotePatch{{Replacement: "", Position: 3, Length: -1}})
+	if got != "hello" {
+		t.Errorf("ApplyPatches negative length no-op = %q, want %q", got, "hello")
+	}
+}

--- a/state/memory/area_inheritance_test.go
+++ b/state/memory/area_inheritance_test.go
@@ -1,0 +1,48 @@
+package memory
+
+import (
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// Tasks inside an area-less project have no area — directly or inherited —
+// and must appear in TasksWithoutArea. Tasks whose parent chain reaches an
+// area inherit it and must not. This exercises hasArea's parent recursion,
+// which was previously unreachable because parented tasks were skipped.
+func TestTasksWithoutArea_ParentChainInheritance(t *testing.T) {
+	state := NewState()
+	state.Areas["area-1"] = &things.Area{UUID: "area-1", Title: "Work"}
+
+	state.Tasks["proj-with-area"] = &things.Task{
+		UUID: "proj-with-area", Title: "Homed project", AreaIDs: []string{"area-1"},
+	}
+	state.Tasks["child-of-homed"] = &things.Task{
+		UUID: "child-of-homed", Title: "inherits area", ParentTaskIDs: []string{"proj-with-area"},
+	}
+
+	state.Tasks["proj-no-area"] = &things.Task{
+		UUID: "proj-no-area", Title: "Homeless project",
+	}
+	state.Tasks["child-of-homeless"] = &things.Task{
+		UUID: "child-of-homeless", Title: "no area anywhere", ParentTaskIDs: []string{"proj-no-area"},
+	}
+
+	got := map[string]bool{}
+	for _, task := range state.TasksWithoutArea() {
+		got[task.UUID] = true
+	}
+
+	if !got["proj-no-area"] {
+		t.Error("proj-no-area missing from TasksWithoutArea")
+	}
+	if !got["child-of-homeless"] {
+		t.Error("child-of-homeless missing from TasksWithoutArea — a task in an area-less project has no area")
+	}
+	if got["proj-with-area"] {
+		t.Error("proj-with-area listed despite having an area")
+	}
+	if got["child-of-homed"] {
+		t.Error("child-of-homed listed despite inheriting its parent's area")
+	}
+}

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -339,14 +339,13 @@ func hasArea(task *things.Task, state *State) bool {
 	return false
 }
 
-// TasksWithoutArea looks up top level tasks not assigned to any area, e.g. just created and placed in today
+// TasksWithoutArea looks up tasks not assigned to any area, directly or
+// through their parent chain (a task in a project that lives in an area
+// inherits that area).
 func (s *State) TasksWithoutArea() []*things.Task {
 	tasks := []*things.Task{}
 	for _, task := range s.Tasks {
 		if task.Status == things.TaskStatusCompleted {
-			continue
-		}
-		if len(task.ParentTaskIDs) != 0 {
 			continue
 		}
 		if task.InTrash {

--- a/syncutil/dailysummary_tz_test.go
+++ b/syncutil/dailysummary_tz_test.go
@@ -1,0 +1,56 @@
+package syncutil
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arthursoares/things-cloud-sdk/sync"
+	_ "modernc.org/sqlite"
+)
+
+// BuildDailySummary's "today" must start at LOCAL midnight, not UTC
+// midnight. Fixed scenario: now = 01:00 on Jul 6 in UTC+10.
+//   - local midnight = Jul 5 14:00 UTC
+//   - UTC truncation would give Jul 5 00:00 UTC
+//
+// A change at Jul 5 10:00 UTC (= Jul 5 20:00 local — YESTERDAY evening)
+// sits between the two cutoffs: the buggy UTC truncation counts it,
+// local-midnight semantics must not.
+func TestBuildDailySummary_LocalMidnightBoundary(t *testing.T) {
+	zone := time.FixedZone("UTC+10", 10*3600)
+	now := time.Date(2026, 7, 6, 1, 0, 0, 0, zone)
+	orig := timeNow
+	timeNow = func() time.Time { return now }
+	defer func() { timeNow = orig }()
+
+	dbPath := filepath.Join(t.TempDir(), "tz.db")
+	syncer, err := sync.Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer syncer.Close()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	insert := func(syncedAt time.Time, changeType string) {
+		if _, err := db.Exec(`INSERT INTO change_log (server_index, synced_at, change_type, entity_type, entity_uuid, payload)
+			VALUES (1, ?, ?, 'Task', 'u1', '{}')`, syncedAt.Unix(), changeType); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	yesterdayLocalEvening := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC) // Jul 5 20:00 local
+	todayLocalMorning := time.Date(2026, 7, 5, 14, 30, 0, 0, time.UTC)    // Jul 6 00:30 local
+	insert(yesterdayLocalEvening, "TaskCompleted")
+	insert(todayLocalMorning, "TaskCompleted")
+
+	summary := BuildDailySummary(syncer)
+	if summary.Completed != 1 {
+		t.Errorf("Completed = %d, want 1 — yesterday's local-evening change must not count toward today", summary.Completed)
+	}
+}

--- a/syncutil/syncutil.go
+++ b/syncutil/syncutil.go
@@ -70,8 +70,14 @@ type DailySummary struct {
 }
 
 // BuildDailySummary calculates activity stats from today's changes.
+// timeNow is a test seam.
+var timeNow = time.Now
+
 func BuildDailySummary(syncer *sync.Syncer) DailySummary {
-	today := time.Now().Truncate(24 * time.Hour)
+	// Local midnight — Truncate would give midnight UTC and count part of
+	// yesterday (or miss part of today) in any other timezone.
+	now := timeNow()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	changes, _ := syncer.ChangesSince(today)
 
 	summary := DailySummary{}


### PR DESCRIPTION
## Summary

Fixes the four findings reported in #18's coverage pass, each red-green:

1. **`ChangePassword` was unauthenticated** — now sends `Authorization: Password <old>` like Delete/AcceptSLA/Confirm (same omission class as the history-endpoint fix in #6).
2. **`BuildDailySummary` counted from UTC midnight** — now local midnight (same class as the #8 fix in `sync/state.go`). Deterministic regression test uses a `timeNow` seam with a fixed UTC+10 scenario where the two cutoffs diverge.
3. **Area inheritance was dead code** — `TasksWithoutArea` skipped every parented task, so `hasArea`'s parent-chain recursion never ran. Parented tasks now flow through it: a task in an area-less project is reported area-less; a task whose project lives in an area inherits it. (Behavior change: the function is no longer top-level-only; doc comment updated.)
4. **`ApplyPatches` panicked on negative patch length** (`runes[-1:]`) — clamped to a pure insertion.

## Base

Stacked on #18 (`test/stress-suite`) because the tests documenting the old behavior live there. **Merge #18 first, without deleting its branch until this one is retargeted** (lesson from #13/#16).

## Validation

TDD throughout; `go test ./...`, `go vet ./...` green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)