### PR TITLE
Release: stress-test suite, coverage to 69–100%, five bug fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,3 @@
-
 name: Go
 
 on:
@@ -10,15 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...
+
+    - name: Vet
+      run: go vet ./...
 
     - name: Test
       run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@
 # HAR files (may contain credentials)
 *.har
 docs/blog-post.md
+
+# Built binaries
+/soak
+/things-cli
+/example
+/cmd/things-cli/things-cli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ All source code lives at the package root (`package thingscloud`, module `github
 
 The SDK models all changes as immutable **Items** (events). A **History** is a sync stream identified by a UUID. The client pushes/pulls Items through Histories to stay in sync with the Things Cloud server.
 
-- **`client.go`** — HTTP client with `ClientInfo` header and configurable `Debug` logging, base endpoint `https://cloud.culturedcode.com`
-- **`histories.go`** — History CRUD and sync operations (list, create, delete, read/write items with ancestor indices). The `Write()` method accepts multiple items for batching.
+- **`client.go`** — HTTP client with `ClientInfo` header, configurable `Debug` logging, 60s timeout, and typed `HTTPError` for non-OK responses; base endpoint `https://cloud.culturedcode.com`
+- **`base58.go`** — Canonical Base58 identifier handling: `NewUUID()`, `EncodeUUID`/`DecodeUUID`, `ValidateUUID`. Always generate identifiers through this API.
+- **`histories.go`** — History CRUD and sync operations (list, create, delete, read/write items with ancestor indices). `Write()` accepts multiple items for batching and rejects invalid or duplicate UUIDs before POSTing.
 - **`items.go`** — Item construction: every mutation (create/modify/delete) on a Task, Area, Tag, CheckListItem, or Tombstone produces an Item
 - **`types.go`** — Domain types: `Task` (with `TaskType` enum: Task/Project/Heading), `Area`, `Tag`, `CheckListItem`, `Tombstone`, plus custom JSON types (`Timestamp`, `Boolean`)
 - **`notes.go`** — Structured `Note` type with full-text and delta patch support (`ApplyPatches`)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ package main
 import (
     "fmt"
     "os"
+    "time"
+
     things "github.com/arthursoares/things-cloud-sdk"
 )
 
@@ -49,27 +51,42 @@ func main() {
     }
     fmt.Printf("✓ Connected: %s\n", resp.Email)
 
-    // Get or create a history
-    histories, _ := client.Histories()
-    var historyID string
-    if len(histories) > 0 {
-        historyID = histories[0].ID
-    } else {
-        hist, _ := client.CreateHistory()
-        historyID = hist.ID
+    // Get your account's history and sync it (required before writing —
+    // the commit's ancestor-index comes from the synced head)
+    history, err := client.OwnHistory()
+    if err != nil {
+        panic(err)
+    }
+    if err := history.Sync(); err != nil {
+        panic(err)
     }
 
-    // Create a task
-    task := things.Task{
-        UUID:  things.GenerateUUID(),
-        Title: things.String("My first task from the SDK!"),
+    // Create a task. NewUUID() produces the canonical Base58 identifier
+    // format Things requires; Write rejects anything else.
+    task := things.TaskActionItem{
+        Item: things.Item{
+            UUID:   things.NewUUID(),
+            Kind:   things.ItemKindTask,
+            Action: things.ItemActionCreated,
+        },
+        P: things.TaskActionItemPayload{
+            Title:        things.String("My first task from the SDK!"),
+            Status:       things.Status(things.TaskStatusPending),
+            Schedule:     things.Schedule(things.TaskScheduleInbox),
+            CreationDate: things.Time(time.Now()),
+        },
     }
 
-    items := []things.Item{things.NewCreateTaskItem(task)}
-    client.Write(historyID, items, -1)
-    fmt.Printf("✓ Created task: %s\n", *task.Title)
+    if err := history.Write(task); err != nil {
+        panic(err)
+    }
+    fmt.Println("✓ Created task")
 }
 ```
+
+> **Tip:** for writes, prefer `things-cli` (below) — its payloads replicate
+> real Things.app traffic field-for-field and are verified against HAR
+> captures. The raw SDK write API is lower-level and sends sparse payloads.
 
 **3. Run it:**
 
@@ -157,7 +174,8 @@ things-cli purge <uuid>
 things-cli move-to-today <uuid>
 
 # Batch (all operations in one HTTP request - much faster!)
-echo '[{"cmd":"complete","uuid":"abc"},{"cmd":"trash","uuid":"def"}]' | things-cli batch
+# UUIDs must be canonical Base58 identifiers, as returned by create/list
+echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":"VJ1edXTP9q3PmFDUuy8EQh"}]' | things-cli batch
 ```
 
 ### Examples
@@ -177,8 +195,8 @@ things-cli create "Review PR" --area <area-uuid> --when today --deadline 2026-02
 echo '[
   {"cmd": "create", "title": "Task 1"},
   {"cmd": "create", "title": "Task 2"},
-  {"cmd": "move-to-project", "uuid": "abc123", "project": "proj-uuid"},
-  {"cmd": "complete", "uuid": "def456"}
+  {"cmd": "move-to-project", "uuid": "VJ1edXTP9q3PmFDUuy8EQh", "project": "BXmAcvS6yK1eDhW31MuZrL"},
+  {"cmd": "complete", "uuid": "FQxaqvLBkbR5q2Q5oRoknc"}
 ]' | things-cli batch
 ```
 
@@ -192,6 +210,7 @@ package main
 import (
     "fmt"
     "os"
+
     things "github.com/arthursoares/things-cloud-sdk"
 )
 
@@ -202,41 +221,36 @@ func main() {
         os.Getenv("THINGS_PASSWORD"),
     )
 
-    // Create a history
-    history, _ := client.CreateHistory()
+    history, _ := client.OwnHistory()
+    _ = history.Sync()
 
-    // Create a project with tasks
-    project := things.Task{
-        UUID:     things.GenerateUUID(),
-        Title:    things.String("My Project"),
-        TaskType: things.TaskTypePtr(things.TaskTypeProject),
-        Status:   things.Status(things.TaskStatusPending),
-        Schedule: things.Schedule(things.TaskScheduleAnytime),
+    // Create a project, then a task referencing it
+    projectID := things.NewUUID()
+    project := things.TaskActionItem{
+        Item: things.Item{UUID: projectID, Kind: things.ItemKindTask, Action: things.ItemActionCreated},
+        P: things.TaskActionItemPayload{
+            Title:    things.String("My Project"),
+            Type:     things.TaskTypePtr(things.TaskTypeProject),
+            Schedule: things.Schedule(things.TaskScheduleAnytime),
+        },
     }
 
-    task1 := things.Task{
-        UUID:      things.GenerateUUID(),
-        Title:     things.String("First task"),
-        ProjectID: things.String(project.UUID),
-        Schedule:  things.Schedule(things.TaskScheduleAnytime),
+    task := things.TaskActionItem{
+        Item: things.Item{UUID: things.NewUUID(), Kind: things.ItemKindTask, Action: things.ItemActionCreated},
+        P: things.TaskActionItemPayload{
+            Title:         things.String("First task"),
+            ParentTaskIDs: &[]string{projectID},
+            Schedule:      things.Schedule(things.TaskScheduleAnytime),
+        },
     }
 
-    task2 := things.Task{
-        UUID:      things.GenerateUUID(),
-        Title:     things.String("Second task"),
-        ProjectID: things.String(project.UUID),
-        Schedule:  things.Schedule(things.TaskScheduleAnytime),
+    // One commit per Write; each item needs a unique canonical UUID —
+    // Write() validates both and refuses anything that would corrupt
+    // the sync history.
+    if err := history.Write(project, task); err != nil {
+        panic(err)
     }
-
-    // Write all items in one batch
-    items := []things.Item{
-        things.NewCreateTaskItem(project),
-        things.NewCreateTaskItem(task1),
-        things.NewCreateTaskItem(task2),
-    }
-
-    client.Write(history.ID, items, -1)
-    fmt.Println("✓ Created project with 2 tasks")
+    fmt.Println("✓ Created project with a task")
 }
 ```
 
@@ -355,6 +369,8 @@ Key findings from reverse engineering the Things Cloud sync protocol:
 - **Headings (`tp=2`) must have `st=1`** (anytime). `st=0` (inbox) crashes Things.app.
 - **Tasks in projects, headings, or areas** should default to `st=1` (anytime) — they've been triaged out of inbox.
 - **Kind strings**: `Task6`, `Tag4`, `ChecklistItem3`, `Area3`, `Tombstone2`
+
+Since v0.3.0 the SDK enforces the identifier rules instead of trusting callers: `things.NewUUID()` generates canonical Base58 identifiers (one leading `1` per leading zero byte — a subtlety whose absence used to corrupt ~1 in 256 creates), `things.ValidateUUID()` checks any identifier, and `History.Write()` refuses items with invalid or duplicate UUIDs before anything reaches the server.
 
 See `docs/client-side-bugs.md` for the full investigation and crash analysis.
 

--- a/account.go
+++ b/account.go
@@ -96,7 +96,7 @@ func (s *AccountService) Confirm(code string) error {
 // SignUp creates a new thingscloud account and returns a configured client
 func (s *AccountService) SignUp(email, password string) (*Client, error) {
 	data, err := json.Marshal(accountRequestBody{
-		Password:           password,
+		Password: password,
 	})
 	if err != nil {
 		return nil, err
@@ -132,6 +132,7 @@ func (s *AccountService) ChangePassword(newPassword string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", s.client.password))
 	resp, err := s.client.do(req)
 	if err != nil {
 		return nil, err

--- a/account_coverage_test.go
+++ b/account_coverage_test.go
@@ -1,0 +1,251 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captureServer records the method, path, Authorization header and decoded JSON
+// body of the single request it receives, and replies with statusCode/respBody.
+func captureServer(statusCode int, respBody string) (*httptest.Server, *capturedRequest) {
+	cap := &capturedRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.Method = r.Method
+		cap.Path = r.URL.Path
+		cap.Authorization = r.Header.Get("Authorization")
+		bs, _ := io.ReadAll(r.Body)
+		cap.RawBody = string(bs)
+		json.Unmarshal(bs, &cap.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		if respBody != "" {
+			w.Write([]byte(respBody))
+		}
+	}))
+	return server, cap
+}
+
+type capturedRequest struct {
+	Method        string
+	Path          string
+	Authorization string
+	RawBody       string
+	Body          map[string]interface{}
+}
+
+func TestAccountService_Delete(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		server, cap := captureServer(http.StatusAccepted, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if err := c.Accounts.Delete(); err != nil {
+			t.Fatalf("Delete failed: %v", err)
+		}
+		if cap.Method != "DELETE" {
+			t.Errorf("Method = %q, want DELETE", cap.Method)
+		}
+		if cap.Path != "/version/1/account/martin@example.com" {
+			t.Errorf("Path = %q", cap.Path)
+		}
+		if cap.Authorization != "Password secret" {
+			t.Errorf("Authorization = %q, want %q", cap.Authorization, "Password secret")
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusUnauthorized, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "wrong")
+		if err := c.Accounts.Delete(); err != ErrUnauthorized {
+			t.Errorf("Delete err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("OtherStatus", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusInternalServerError, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		err := c.Accounts.Delete()
+		if err == nil || err == ErrUnauthorized {
+			t.Errorf("Delete err = %v, want generic http error", err)
+		}
+	})
+}
+
+func TestAccountService_AcceptSLA(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		server, cap := captureServer(http.StatusOK, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if err := c.Accounts.AcceptSLA(); err != nil {
+			t.Fatalf("AcceptSLA failed: %v", err)
+		}
+		if cap.Method != "PUT" {
+			t.Errorf("Method = %q, want PUT", cap.Method)
+		}
+		if _, ok := cap.Body["SLA-version-accepted"]; !ok {
+			t.Errorf("body missing SLA-version-accepted: %s", cap.RawBody)
+		}
+		if cap.Authorization != "Password secret" {
+			t.Errorf("Authorization = %q", cap.Authorization)
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusUnauthorized, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "wrong")
+		if err := c.Accounts.AcceptSLA(); err != ErrUnauthorized {
+			t.Errorf("AcceptSLA err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("OtherStatus", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusBadGateway, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if err := c.Accounts.AcceptSLA(); err == nil || err == ErrUnauthorized {
+			t.Errorf("AcceptSLA err = %v, want generic http error", err)
+		}
+	})
+}
+
+func TestAccountService_Confirm(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		server, cap := captureServer(http.StatusOK, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if err := c.Accounts.Confirm("code-123"); err != nil {
+			t.Fatalf("Confirm failed: %v", err)
+		}
+		if cap.Body["confirmation-code"] != "code-123" {
+			t.Errorf("confirmation-code = %v, want code-123", cap.Body["confirmation-code"])
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusUnauthorized, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "wrong")
+		if err := c.Accounts.Confirm("code"); err != ErrUnauthorized {
+			t.Errorf("Confirm err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("OtherStatus", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusForbidden, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "secret")
+		if err := c.Accounts.Confirm("code"); err == nil || err == ErrUnauthorized {
+			t.Errorf("Confirm err = %v, want generic http error", err)
+		}
+	})
+}
+
+func TestAccountService_SignUp(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		server, cap := captureServer(http.StatusCreated, "")
+		defer server.Close()
+
+		c := New(server.URL, "", "")
+		newClient, err := c.Accounts.SignUp("new@example.com", "pw123")
+		if err != nil {
+			t.Fatalf("SignUp failed: %v", err)
+		}
+		if newClient == nil {
+			t.Fatal("SignUp returned nil client")
+		}
+		if newClient.EMail != "new@example.com" {
+			t.Errorf("client EMail = %q, want new@example.com", newClient.EMail)
+		}
+		if cap.Path != "/version/1/account/new@example.com" {
+			t.Errorf("Path = %q", cap.Path)
+		}
+		if cap.Body["password"] != "pw123" {
+			t.Errorf("password = %v, want pw123", cap.Body["password"])
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusConflict, "")
+		defer server.Close()
+
+		c := New(server.URL, "", "")
+		if _, err := c.Accounts.SignUp("taken@example.com", "pw"); err == nil {
+			t.Error("expected SignUp to fail on non-201, but it succeeded")
+		}
+	})
+}
+
+func TestAccountService_ChangePassword(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		server, cap := captureServer(http.StatusOK, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "old")
+		newClient, err := c.Accounts.ChangePassword("newpw")
+		if err != nil {
+			t.Fatalf("ChangePassword failed: %v", err)
+		}
+		if newClient == nil {
+			t.Fatal("ChangePassword returned nil client")
+		}
+		if cap.Body["password"] != "newpw" {
+			t.Errorf("password = %v, want newpw", cap.Body["password"])
+		}
+		// NOTE: current behavior — ChangePassword does NOT send an Authorization
+		// header, unlike Delete/AcceptSLA/Confirm. This test documents that; see
+		// the reported finding. If the server enforces auth this request would
+		// fail in production. If ChangePassword is fixed to authenticate, update
+		// this expectation to "Password old".
+		if cap.Authorization != "" {
+			t.Errorf("Authorization = %q, want empty (current behavior: no auth header sent)", cap.Authorization)
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusUnauthorized, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "old")
+		if _, err := c.Accounts.ChangePassword("newpw"); err != ErrUnauthorized {
+			t.Errorf("ChangePassword err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("OtherStatus", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusInternalServerError, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "old")
+		if _, err := c.Accounts.ChangePassword("newpw"); err == nil || err == ErrUnauthorized {
+			t.Errorf("ChangePassword err = %v, want generic http error", err)
+		}
+	})
+}

--- a/account_coverage_test.go
+++ b/account_coverage_test.go
@@ -217,13 +217,10 @@ func TestAccountService_ChangePassword(t *testing.T) {
 		if cap.Body["password"] != "newpw" {
 			t.Errorf("password = %v, want newpw", cap.Body["password"])
 		}
-		// NOTE: current behavior — ChangePassword does NOT send an Authorization
-		// header, unlike Delete/AcceptSLA/Confirm. This test documents that; see
-		// the reported finding. If the server enforces auth this request would
-		// fail in production. If ChangePassword is fixed to authenticate, update
-		// this expectation to "Password old".
-		if cap.Authorization != "" {
-			t.Errorf("Authorization = %q, want empty (current behavior: no auth header sent)", cap.Authorization)
+		// Changing a password must be authenticated with the OLD password,
+		// like every other account mutation (Delete/AcceptSLA/Confirm).
+		if cap.Authorization != "Password old" {
+			t.Errorf("Authorization = %q, want %q", cap.Authorization, "Password old")
 		}
 	})
 

--- a/app_instance_coverage_test.go
+++ b/app_instance_coverage_test.go
@@ -1,0 +1,31 @@
+package thingscloud
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClient_RegisterAppInstance_ErrorStatus(t *testing.T) {
+	t.Parallel()
+	server, _ := captureServer(http.StatusInternalServerError, "")
+	defer server.Close()
+
+	c := New(server.URL, "test@test.com", "password")
+	err := c.RegisterAppInstance(AppInstanceRequest{
+		AppInstanceID: "hash1-com.culturedcode.ThingsMac-hash2",
+		HistoryKey:    "251943ab-63b5-45d1-8f9d-828a8d92fc15",
+	})
+	if err == nil {
+		t.Error("expected RegisterAppInstance to fail on non-200, got nil")
+	}
+}
+
+func TestClient_RegisterAppInstance_TransportError(t *testing.T) {
+	t.Parallel()
+	// Closed port -> the underlying request fails inside do().
+	c := New("http://127.0.0.1:1", "test@test.com", "password")
+	err := c.RegisterAppInstance(AppInstanceRequest{AppInstanceID: "x"})
+	if err == nil {
+		t.Error("expected RegisterAppInstance to surface a transport error, got nil")
+	}
+}

--- a/base58_fuzz_test.go
+++ b/base58_fuzz_test.go
@@ -1,0 +1,88 @@
+package thingscloud
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// FuzzUUIDRoundTrip drives random 16-byte identifiers through
+// EncodeUUID -> DecodeUUID and asserts identity. This is the property the
+// old encoder violated: a UUID with a leading zero byte encoded one
+// character short and decoded back to fewer than 16 bytes. The fuzzer
+// reaches the ~1/256 leading-zero case within a handful of iterations.
+func FuzzUUIDRoundTrip(f *testing.F) {
+	f.Add(make([]byte, 16)) // all zero — worst case
+	f.Add([]byte{0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13})
+	f.Add([]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255})
+	seed := uuid.New()
+	f.Add(seed[:])
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		if len(b) != 16 {
+			return // only 16-byte inputs are valid UUIDs
+		}
+		var u uuid.UUID
+		copy(u[:], b)
+
+		s := EncodeUUID(u)
+
+		// A canonical Things identifier is Base58 of 16 bytes: never
+		// empty, and at most 22 characters (log_58(2^128) < 22).
+		if len(s) == 0 || len(s) > 22 {
+			t.Fatalf("EncodeUUID(% x) = %q has invalid length %d", b, s, len(s))
+		}
+
+		back, err := DecodeUUID(s)
+		if err != nil {
+			t.Fatalf("DecodeUUID(%q) from % x failed: %v", s, b, err)
+		}
+		if back != u {
+			t.Fatalf("round trip broke: % x -> %q -> % x", b, s, back[:])
+		}
+
+		// The encoding must be the unique canonical form: re-encoding the
+		// decoded value reproduces the same string.
+		if again := EncodeUUID(back); again != s {
+			t.Fatalf("encoding not canonical: %q re-encodes to %q", s, again)
+		}
+	})
+}
+
+// FuzzValidateUUIDIsSound treats ValidateUUID as the security boundary
+// that keeps history-corrupting identifiers off the wire: whatever it
+// accepts MUST decode to exactly 16 bytes and survive a re-encode. If it
+// ever green-lights a string that doesn't, Write() would poison a history.
+func FuzzValidateUUIDIsSound(f *testing.F) {
+	f.Add("VJ1edXTP9q3PmFDUuy8EQh")               // real Things id
+	f.Add("6f9b2c1e-8a4d-4e5f-9c3b-2a1d0e9f8b7c") // hyphenated
+	f.Add("")                                     // empty
+	f.Add("1111111111111111")                     // all-zero canonical
+	f.Add("0OIl")                                 // non-alphabet chars
+
+	f.Fuzz(func(t *testing.T, s string) {
+		if err := ValidateUUID(s); err != nil {
+			return // rejected — nothing to prove
+		}
+		// Accepted: it must be a canonical encoding of exactly 16 bytes.
+		u, err := DecodeUUID(s)
+		if err != nil {
+			t.Fatalf("ValidateUUID accepted %q but DecodeUUID rejects it: %v", s, err)
+		}
+		if got := EncodeUUID(u); got != s {
+			t.Fatalf("ValidateUUID accepted non-canonical %q (canonical form is %q)", s, got)
+		}
+	})
+}
+
+// FuzzDecodeUUIDNeverPanics ensures arbitrary caller/server-supplied
+// strings can be validated without crashing the SDK.
+func FuzzDecodeUUIDNeverPanics(f *testing.F) {
+	f.Add("VJ1edXTP9q3PmFDUuy8EQh")
+	f.Add("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+	f.Add("\x00\xff")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		_, _ = DecodeUUID(s) // must not panic for any input
+	})
+}

--- a/client_coverage_test.go
+++ b/client_coverage_test.go
@@ -1,0 +1,95 @@
+package thingscloud
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHTTPError_Error(t *testing.T) {
+	t.Parallel()
+	err := &HTTPError{StatusCode: 500, Status: "500 Internal Server Error"}
+	got := err.Error()
+	want := "http response code: 500 Internal Server Error"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestClient_do_ConnectionError(t *testing.T) {
+	t.Parallel()
+	// Point at a closed port so the underlying RoundTrip fails; do() should
+	// surface the transport error rather than a response.
+	c := New("http://127.0.0.1:1", "martin@example.com", "")
+	req, err := http.NewRequest("GET", "/version/1/account/x", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.do(req); err == nil {
+		t.Error("expected do() to return a transport error, got nil")
+	}
+}
+
+func TestClient_do_InvalidEndpoint(t *testing.T) {
+	t.Parallel()
+	// A control character in the endpoint makes url.Parse fail inside do().
+	c := New("http://\x7f invalid", "martin@example.com", "")
+	req, err := http.NewRequest("GET", "/path", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.do(req); err == nil {
+		t.Error("expected do() to fail parsing a malformed endpoint, got nil")
+	}
+}
+
+func TestClient_do_SetsContentTypeForBodyMethods(t *testing.T) {
+	t.Parallel()
+	var captured http.Header
+	server, _ := captureServer(http.StatusOK, "")
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+
+	// GET must NOT carry a Content-Type/Encoding.
+	getReq, _ := http.NewRequest("GET", "/x", nil)
+	resp, err := c.do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if ct := getReq.Header.Get("Content-Type"); ct != "" {
+		t.Errorf("GET Content-Type = %q, want empty", ct)
+	}
+
+	// PUT must carry Content-Type/Encoding.
+	putReq, _ := http.NewRequest("PUT", "/x", nil)
+	resp, err = c.do(putReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	captured = putReq.Header
+	if ct := captured.Get("Content-Type"); ct == "" {
+		t.Error("PUT Content-Type is empty, want it set")
+	}
+	if ce := captured.Get("Content-Encoding"); ce != "UTF-8" {
+		t.Errorf("PUT Content-Encoding = %q, want UTF-8", ce)
+	}
+}
+
+func TestClient_do_DebugLogging(t *testing.T) {
+	t.Parallel()
+	// Exercise the Debug branch that dumps request/response; we only assert it
+	// does not panic and still performs the request.
+	server, _ := captureServer(http.StatusOK, `{}`)
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	c.Debug = true
+	req, _ := http.NewRequest("GET", "/x", nil)
+	resp, err := c.do(req)
+	if err != nil {
+		t.Fatalf("do() with Debug failed: %v", err)
+	}
+	resp.Body.Close()
+}

--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -1,0 +1,255 @@
+// Command soak stress-tests the write path against a REAL Things Cloud
+// account by driving the things-cli binary through many create/edit/move/
+// complete/trash cycles, including identifiers deliberately built from
+// UUIDs with leading zero bytes — the ~1/256 case that used to corrupt
+// sync histories before the canonical Base58 fix.
+//
+// It then verifies every write landed by reading the account back through
+// the sync engine, and finally trashes and purges everything it created.
+//
+// SAFETY: this writes to a live account. Point it ONLY at a throwaway test
+// account. It refuses to run without an explicit confirmation env var.
+//
+//	THINGS_USERNAME=test@example.com \
+//	THINGS_PASSWORD=... \
+//	THINGS_SOAK_CONFIRM=yes-throwaway-account \
+//	go run ./cmd/soak --cycles 50
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+	"github.com/arthursoares/things-cloud-sdk/sync"
+	"github.com/google/uuid"
+)
+
+type stats struct {
+	creates      int
+	forcedLeadZ  int
+	edits        int
+	moves        int
+	completes    int
+	trashed      int
+	purged       int
+	rejections   int
+	verifyChecks int
+	verifyFails  int
+}
+
+func main() {
+	cycles := flag.Int("cycles", 25, "number of create/edit/move/complete/trash cycles")
+	cliPath := flag.String("cli", "", "path to things-cli binary (built automatically if empty)")
+	keep := flag.Bool("keep", false, "skip cleanup (leave created items in the account)")
+	flag.Parse()
+
+	if os.Getenv("THINGS_SOAK_CONFIRM") != "yes-throwaway-account" {
+		fatal("refusing to run: set THINGS_SOAK_CONFIRM=yes-throwaway-account and use a DISPOSABLE test account only")
+	}
+	user := requireEnv("THINGS_USERNAME")
+	requireEnv("THINGS_PASSWORD")
+
+	cli := *cliPath
+	if cli == "" {
+		cli = buildCLI()
+	}
+
+	fmt.Printf("Soak test → account %s, %d cycles\n", user, *cycles)
+	fmt.Println("This writes to a LIVE account. Ctrl-C now if it is not disposable.")
+	time.Sleep(3 * time.Second)
+
+	var st stats
+	created := runCycles(cli, *cycles, &st)
+
+	verify(created, &st)
+
+	if !*keep {
+		cleanup(cli, created, &st)
+	}
+
+	fmt.Println("\n=== Soak summary ===")
+	fmt.Printf("creates:        %d (of which forced leading-zero UUID: %d)\n", st.creates, st.forcedLeadZ)
+	fmt.Printf("edits:          %d\n", st.edits)
+	fmt.Printf("moves:          %d\n", st.moves)
+	fmt.Printf("completes:      %d\n", st.completes)
+	fmt.Printf("trashed/purged: %d / %d\n", st.trashed, st.purged)
+	fmt.Printf("Write rejections (unexpected): %d\n", st.rejections)
+	fmt.Printf("verification checks: %d, failures: %d\n", st.verifyChecks, st.verifyFails)
+
+	if st.rejections > 0 || st.verifyFails > 0 {
+		fmt.Println("\nRESULT: FAIL — the account may hold data Things.app cannot decode. Inspect before syncing a real client.")
+		os.Exit(1)
+	}
+	fmt.Println("\nRESULT: PASS — every write was accepted and verified. Now open Things.app on this account and confirm it syncs cleanly.")
+}
+
+type createdItem struct {
+	uuid  string
+	title string
+	kind  string // "task" | "project" | "area" | "tag"
+}
+
+// forcedLeadingZeroUUID returns a canonical Base58 identifier whose
+// underlying UUID starts with one or two zero bytes — the historical
+// corruption trigger. With the fix this is a perfectly valid identifier.
+func forcedLeadingZeroUUID(two bool) string {
+	u := uuid.New()
+	u[0] = 0x00
+	if two {
+		u[1] = 0x00
+	}
+	return things.EncodeUUID(u)
+}
+
+func runCycles(cli string, cycles int, st *stats) []createdItem {
+	var created []createdItem
+
+	for i := 0; i < cycles; i++ {
+		// Project (structural — must never land in inbox)
+		projID := things.NewUUID()
+		runCLI(cli, st, "create", fmt.Sprintf("Soak project %d", i), "--type", "project", "--uuid", projID)
+		st.creates++
+		created = append(created, createdItem{projID, fmt.Sprintf("Soak project %d", i), "project"})
+
+		// Heading under the project, explicitly requested inbox to prove
+		// the structural st=1 override holds on the real server.
+		headID := things.NewUUID()
+		runCLI(cli, st, "create", fmt.Sprintf("Soak heading %d", i), "--type", "heading", "--project", projID, "--when", "inbox", "--uuid", headID)
+		st.creates++
+		created = append(created, createdItem{headID, fmt.Sprintf("Soak heading %d", i), "task"})
+
+		// A batch of tasks under the heading. Every 4th task is forced to
+		// use a leading-zero-byte UUID.
+		for j := 0; j < 4; j++ {
+			var taskID string
+			if j == 0 {
+				taskID = forcedLeadingZeroUUID(j == 0 && i%8 == 0)
+				st.forcedLeadZ++
+			} else {
+				taskID = things.NewUUID()
+			}
+			title := fmt.Sprintf("Soak task %d.%d", i, j)
+			runCLI(cli, st, "create", title, "--heading", headID, "--project", projID, "--uuid", taskID)
+			st.creates++
+			created = append(created, createdItem{taskID, title, "task"})
+
+			// Edit, then complete the first, move the second to today.
+			runCLI(cli, st, "edit", taskID, "--note", fmt.Sprintf("soak note %d.%d", i, j))
+			st.edits++
+			switch j {
+			case 0:
+				runCLI(cli, st, "complete", taskID)
+				st.completes++
+			case 1:
+				runCLI(cli, st, "move-to-today", taskID)
+				st.moves++
+			}
+		}
+	}
+	return created
+}
+
+func verify(created []createdItem, st *stats) {
+	fmt.Println("\nVerifying via sync engine …")
+	client := things.New(things.APIEndpoint, os.Getenv("THINGS_USERNAME"), os.Getenv("THINGS_PASSWORD"))
+	dbPath := filepath.Join(os.TempDir(), "soak-verify.db")
+	_ = os.Remove(dbPath)
+	syncer, err := sync.Open(dbPath, client)
+	if err != nil {
+		fatal("open verify db: " + err.Error())
+	}
+	defer syncer.Close()
+
+	if _, err := syncer.Sync(); err != nil {
+		fatal("verify sync failed: " + err.Error())
+	}
+	state := syncer.State()
+	all, err := state.AllTasks(sync.QueryOpts{IncludeCompleted: true, IncludeTrashed: true})
+	if err != nil {
+		fatal("query tasks: " + err.Error())
+	}
+	present := map[string]bool{}
+	for _, task := range all {
+		present[task.UUID] = true
+	}
+	for _, c := range created {
+		if c.kind != "task" && c.kind != "project" {
+			continue
+		}
+		st.verifyChecks++
+		if !present[c.uuid] {
+			st.verifyFails++
+			fmt.Printf("  MISSING after sync: %s %q (%s)\n", c.kind, c.title, c.uuid)
+		}
+	}
+	fmt.Printf("  %d/%d created task/project items found in synced state\n", st.verifyChecks-st.verifyFails, st.verifyChecks)
+}
+
+func cleanup(cli string, created []createdItem, st *stats) {
+	fmt.Println("\nCleaning up (trash + purge) …")
+	// Trash then purge in reverse creation order so children go before parents.
+	for i := len(created) - 1; i >= 0; i-- {
+		c := created[i]
+		if c.kind == "area" || c.kind == "tag" {
+			continue // areas/tags are not created by this soak yet
+		}
+		if runCLIQuiet(cli, "trash", c.uuid) {
+			st.trashed++
+		}
+		if runCLIQuiet(cli, "purge", c.uuid) {
+			st.purged++
+		}
+	}
+}
+
+// --- process helpers ---
+
+func runCLI(cli string, st *stats, args ...string) map[string]string {
+	out, err := exec.Command(cli, args...).CombinedOutput()
+	if err != nil {
+		st.rejections++
+		fmt.Printf("  REJECTED: %s → %v\n    %s\n", strings.Join(args, " "), err, bytes.TrimSpace(out))
+		return nil
+	}
+	var res map[string]string
+	_ = json.Unmarshal(out, &res)
+	return res
+}
+
+func runCLIQuiet(cli string, args ...string) bool {
+	return exec.Command(cli, args...).Run() == nil
+}
+
+func buildCLI() string {
+	fmt.Println("Building things-cli …")
+	bin := filepath.Join(os.TempDir(), "things-cli-soak")
+	out, err := exec.Command("go", "build", "-o", bin, "./cmd/things-cli").CombinedOutput()
+	if err != nil {
+		fatal(fmt.Sprintf("building things-cli: %v\n%s", err, out))
+	}
+	return bin
+}
+
+func requireEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		fatal(k + " is required")
+	}
+	return v
+}
+
+func fatal(msg string) {
+	fmt.Fprintln(os.Stderr, "soak: "+msg)
+	os.Exit(1)
+}
+
+var _ = bufio.NewReader // reserved for future interactive confirm

--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -125,7 +125,7 @@ func runCycles(cli string, cycles int, st *stats) []createdItem {
 		headID := things.NewUUID()
 		runCLI(cli, st, "create", fmt.Sprintf("Soak heading %d", i), "--type", "heading", "--project", projID, "--when", "inbox", "--uuid", headID)
 		st.creates++
-		created = append(created, createdItem{headID, fmt.Sprintf("Soak heading %d", i), "task"})
+		created = append(created, createdItem{headID, fmt.Sprintf("Soak heading %d", i), "heading"})
 
 		// A batch of tasks under the heading. Every 4th task is forced to
 		// use a leading-zero-byte UUID.
@@ -172,17 +172,24 @@ func verify(created []createdItem, st *stats) {
 	if _, err := syncer.Sync(); err != nil {
 		fatal("verify sync failed: " + err.Error())
 	}
+	// Tasks, projects, and headings all live in the tasks table but are
+	// returned by different queries (type 0/1/2), so gather all three.
 	state := syncer.State()
-	all, err := state.AllTasks(sync.QueryOpts{IncludeCompleted: true, IncludeTrashed: true})
-	if err != nil {
-		fatal("query tasks: " + err.Error())
-	}
+	opts := sync.QueryOpts{IncludeCompleted: true, IncludeTrashed: true}
 	present := map[string]bool{}
-	for _, task := range all {
-		present[task.UUID] = true
+	for _, q := range []func(sync.QueryOpts) ([]*things.Task, error){
+		state.AllTasks, state.AllProjects, state.AllHeadings,
+	} {
+		items, err := q(opts)
+		if err != nil {
+			fatal("query state: " + err.Error())
+		}
+		for _, it := range items {
+			present[it.UUID] = true
+		}
 	}
 	for _, c := range created {
-		if c.kind != "task" && c.kind != "project" {
+		if c.kind == "area" || c.kind == "tag" {
 			continue
 		}
 		st.verifyChecks++

--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -39,6 +39,7 @@ type stats struct {
 	edits        int
 	moves        int
 	completes    int
+	checklists   int
 	trashed      int
 	purged       int
 	rejections   int
@@ -81,6 +82,7 @@ func main() {
 	fmt.Printf("edits:          %d\n", st.edits)
 	fmt.Printf("moves:          %d\n", st.moves)
 	fmt.Printf("completes:      %d\n", st.completes)
+	fmt.Printf("checklists:     %d\n", st.checklists)
 	fmt.Printf("trashed/purged: %d / %d\n", st.trashed, st.purged)
 	fmt.Printf("Write rejections (unexpected): %d\n", st.rejections)
 	fmt.Printf("verification checks: %d, failures: %d\n", st.verifyChecks, st.verifyFails)
@@ -152,10 +154,62 @@ func runCycles(cli string, cycles int, st *stats) []createdItem {
 			case 1:
 				runCLI(cli, st, "move-to-today", taskID)
 				st.moves++
+			case 2:
+				runCLI(cli, st, "add-checklist", taskID, fmt.Sprintf("check %d.a,check %d.b", i, i))
+				st.checklists += 2
 			}
+		}
+
+		// Area + tag, exercised every cycle so their kinds (Area3, Tag4)
+		// get live-server acceptance too.
+		areaID := things.NewUUID()
+		runCLI(cli, st, "create-area", fmt.Sprintf("Soak area %d", i), "--uuid", areaID)
+		st.creates++
+		created = append(created, createdItem{areaID, fmt.Sprintf("Soak area %d", i), "area"})
+
+		tagID := things.NewUUID()
+		runCLI(cli, st, "create-tag", fmt.Sprintf("soak-tag-%d", i), "--uuid", tagID)
+		st.creates++
+		created = append(created, createdItem{tagID, fmt.Sprintf("soak-tag-%d", i), "tag"})
+
+		// Batch: two creates (one with a forced leading-zero UUID, one
+		// carrying refs) plus a move of an EARLIER task — three distinct
+		// UUIDs in one HTTP commit. Two ops on the same UUID in one
+		// commit are impossible on this wire format (the body is a JSON
+		// object keyed by UUID) and Write() rejects them by design.
+		b1, b2 := forcedLeadingZeroUUID(false), things.NewUUID()
+		st.forcedLeadZ++
+		moveTarget := created[len(created)-3].uuid // a task from this cycle
+		batch := []map[string]any{
+			{"cmd": "create", "title": fmt.Sprintf("Soak batch task %d.1", i), "uuid": b1, "area": areaID},
+			{"cmd": "create", "title": fmt.Sprintf("Soak batch task %d.2", i), "uuid": b2, "project": projID, "tags": []string{tagID}},
+			{"cmd": "move-to-project", "uuid": moveTarget, "project": projID},
+		}
+		if runBatch(cli, st, batch) {
+			st.creates += 2
+			st.moves++
+			created = append(created,
+				createdItem{b1, fmt.Sprintf("Soak batch task %d.1", i), "task"},
+				createdItem{b2, fmt.Sprintf("Soak batch task %d.2", i), "task"})
 		}
 	}
 	return created
+}
+
+func runBatch(cli string, st *stats, ops []map[string]any) bool {
+	payload, err := json.Marshal(ops)
+	if err != nil {
+		fatal("marshal batch: " + err.Error())
+	}
+	cmd := exec.Command(cli, "batch")
+	cmd.Stdin = bytes.NewReader(payload)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		st.rejections++
+		fmt.Printf("  BATCH REJECTED: %v\n    %s\n", err, bytes.TrimSpace(out))
+		return false
+	}
+	return true
 }
 
 func verify(created []createdItem, st *stats) {
@@ -188,10 +242,21 @@ func verify(created []createdItem, st *stats) {
 			present[it.UUID] = true
 		}
 	}
+	areas, err := state.AllAreas()
+	if err != nil {
+		fatal("query areas: " + err.Error())
+	}
+	for _, a := range areas {
+		present[a.UUID] = true
+	}
+	tags, err := state.AllTags()
+	if err != nil {
+		fatal("query tags: " + err.Error())
+	}
+	for _, tg := range tags {
+		present[tg.UUID] = true
+	}
 	for _, c := range created {
-		if c.kind == "area" || c.kind == "tag" {
-			continue
-		}
 		st.verifyChecks++
 		if !present[c.uuid] {
 			st.verifyFails++
@@ -206,11 +271,12 @@ func cleanup(cli string, created []createdItem, st *stats) {
 	// Trash then purge in reverse creation order so children go before parents.
 	for i := len(created) - 1; i >= 0; i-- {
 		c := created[i]
-		if c.kind == "area" || c.kind == "tag" {
-			continue // areas/tags are not created by this soak yet
-		}
-		if runCLIQuiet(cli, "trash", c.uuid) {
-			st.trashed++
+		// Areas and tags are not tasks — trash doesn't apply, but a
+		// tombstone (purge) removes any object kind.
+		if c.kind != "area" && c.kind != "tag" {
+			if runCLIQuiet(cli, "trash", c.uuid) {
+				st.trashed++
+			}
 		}
 		if runCLIQuiet(cli, "purge", c.uuid) {
 			st.purged++

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -588,7 +588,11 @@ func initCLI(syncHistoryHead bool) *cliContext {
 	username := requireEnv("THINGS_USERNAME")
 	password := requireEnv("THINGS_PASSWORD")
 
-	c := thingscloud.New(thingscloud.APIEndpoint, username, password)
+	endpoint := thingscloud.APIEndpoint
+	if v := os.Getenv("THINGS_ENDPOINT"); v != "" {
+		endpoint = v // point the CLI at a test server
+	}
+	c := thingscloud.New(endpoint, username, password)
 	if os.Getenv("THINGS_DEBUG") != "" {
 		c.Debug = true
 	}

--- a/cmd/things-cli/wire_test.go
+++ b/cmd/things-cli/wire_test.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+)
+
+// ---------------------------------------------------------------------------
+// taskUpdate builder — every method builds part of a wire payload
+// ---------------------------------------------------------------------------
+
+func TestTaskUpdateBuilderFields(t *testing.T) {
+	midnight := todayMidnightUTC()
+
+	cases := []struct {
+		name  string
+		build func() map[string]any
+		want  map[string]any
+	}{
+		{"Title", func() map[string]any { return newTaskUpdate().Title("new title").build() },
+			map[string]any{"tt": "new title"}},
+		{"Status completed", func() map[string]any { return newTaskUpdate().Status(3).build() },
+			map[string]any{"ss": 3}},
+		{"StopDate", func() map[string]any { return newTaskUpdate().StopDate(1751791234.5).build() },
+			map[string]any{"sp": 1751791234.5}},
+		{"Trash", func() map[string]any { return newTaskUpdate().Trash(true).build() },
+			map[string]any{"tr": true}},
+		{"Today", func() map[string]any { return newTaskUpdate().Today().build() },
+			map[string]any{"st": 1, "sr": midnight, "tir": midnight}},
+		{"Anytime", func() map[string]any { return newTaskUpdate().Anytime().build() },
+			map[string]any{"st": 1, "sr": nil, "tir": nil}},
+		{"Someday", func() map[string]any { return newTaskUpdate().Someday().build() },
+			map[string]any{"st": 2, "sr": nil, "tir": nil}},
+		{"Inbox", func() map[string]any { return newTaskUpdate().Inbox().build() },
+			map[string]any{"st": 0, "sr": nil, "tir": nil}},
+		{"ScheduleDate", func() map[string]any { return newTaskUpdate().ScheduleDate(1760000000).build() },
+			map[string]any{"st": 1, "sr": int64(1760000000), "tir": int64(1760000000)}},
+		{"Deadline", func() map[string]any { return newTaskUpdate().Deadline(1770000000).build() },
+			map[string]any{"dd": int64(1770000000)}},
+		{"Scheduled", func() map[string]any { return newTaskUpdate().Scheduled(100, 200).build() },
+			map[string]any{"sr": int64(100), "tir": int64(200)}},
+		{"Tags", func() map[string]any { return newTaskUpdate().Tags([]string{"a1", "b2"}).build() },
+			map[string]any{"tg": []string{"a1", "b2"}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.build()
+			// Every update payload must carry a modification date (md is
+			// null only on CREATES — updates require a timestamp).
+			md, ok := got["md"].(float64)
+			if !ok || md <= 0 {
+				t.Errorf("md = %v, want positive float timestamp on updates", got["md"])
+			}
+			for k, want := range tc.want {
+				gotV, exists := got[k]
+				if !exists {
+					t.Errorf("field %q missing from payload %v", k, got)
+					continue
+				}
+				if fmt.Sprintf("%v", gotV) != fmt.Sprintf("%v", want) {
+					t.Errorf("field %q = %v, want %v", k, gotV, want)
+				}
+			}
+			// No extra fields beyond md + the expected set.
+			if len(got) != len(tc.want)+1 {
+				t.Errorf("payload has %d fields, want %d: %v", len(got), len(tc.want)+1, got)
+			}
+		})
+	}
+}
+
+func TestTaskUpdateNoteAndClearNote(t *testing.T) {
+	note := newTaskUpdate().Note("hello").build()
+	wn, ok := note["nt"].(WireNote)
+	if !ok {
+		t.Fatalf("nt = %T, want WireNote", note["nt"])
+	}
+	if wn.Value != "hello" || wn.TypeTag != "tx" || wn.Type != 1 {
+		t.Errorf("Note wire form = %+v", wn)
+	}
+	if wn.Checksum != noteChecksum("hello") {
+		t.Errorf("Note checksum = %d, want %d", wn.Checksum, noteChecksum("hello"))
+	}
+
+	cleared := newTaskUpdate().ClearNote().build()
+	cn := cleared["nt"].(WireNote)
+	if cn.Value != "" || cn.Checksum != 0 {
+		t.Errorf("ClearNote wire form = %+v, want empty value and zero checksum", cn)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Notes and dates
+// ---------------------------------------------------------------------------
+
+func TestNoteChecksumIsCRC32IEEE(t *testing.T) {
+	// crc32.ChecksumIEEE("hello") is a fixed, well-known value.
+	if got := noteChecksum("hello"); got != 0x3610a686 {
+		t.Errorf("noteChecksum(hello) = %#x, want 0x3610a686 (CRC-32/IEEE)", got)
+	}
+	if got := noteChecksum(""); got != 0 {
+		t.Errorf("noteChecksum(\"\") = %d, want 0", got)
+	}
+}
+
+func TestWireNoteJSONFieldOrder(t *testing.T) {
+	// Things expects the note object keys in _t, ch, v, t order.
+	bs, err := json.Marshal(textNote("x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(bs)
+	order := []string{`"_t"`, `"ch"`, `"v"`, `"t"`}
+	last := -1
+	for _, k := range order {
+		i := strings.Index(s, k)
+		if i < 0 || i < last {
+			t.Fatalf("note JSON %s does not have keys in order %v", s, order)
+		}
+		last = i
+	}
+}
+
+func TestTodayMidnightUTC(t *testing.T) {
+	got := todayMidnightUTC()
+	if got%86400 != 0 {
+		t.Errorf("todayMidnightUTC() = %d, not aligned to a UTC day boundary", got)
+	}
+	now := time.Now().UTC()
+	want := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).Unix()
+	// Allow the local-vs-UTC day to differ by one day at most (the function
+	// intentionally uses the local calendar date at UTC midnight).
+	if got != want && got != want-86400 && got != want+86400 {
+		t.Errorf("todayMidnightUTC() = %d, want within a day of %d", got, want)
+	}
+}
+
+func TestParseDate(t *testing.T) {
+	if ts := parseDate("2026-07-06"); ts == nil || ts.Format("2006-01-02") != "2026-07-06" {
+		t.Errorf("parseDate(2026-07-06) = %v", ts)
+	}
+	for _, bad := range []string{"07/06/2026", "yesterday", "", "2026-13-45"} {
+		if ts := parseDate(bad); ts != nil {
+			t.Errorf("parseDate(%q) = %v, want nil", bad, ts)
+		}
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	got := parseArgs([]string{"--title", "My Task", "--today", "--tags", "a,b", "--flag-at-end"})
+	want := map[string]string{"title": "My Task", "today": "true", "tags": "a,b", "flag-at-end": "true"}
+	if len(got) != len(want) {
+		t.Fatalf("parseArgs = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("parseArgs[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Golden shape: the 34-field create payload
+// ---------------------------------------------------------------------------
+
+func TestTaskCreatePayloadGoldenShape(t *testing.T) {
+	bs, err := json.Marshal(newTaskCreatePayload("shape check", map[string]string{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(bs, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	wantKeys := []string{
+		"tp", "sr", "dds", "rt", "rmd", "ss", "tr", "dl", "icp", "st",
+		"ar", "tt", "do", "lai", "tir", "tg", "agr", "ix", "cd", "lt",
+		"icc", "md", "ti", "dd", "ato", "nt", "icsd", "pr", "rp", "acrd",
+		"sp", "sb", "rr", "xx",
+	}
+	var gotKeys []string
+	for k := range m {
+		gotKeys = append(gotKeys, k)
+	}
+	sort.Strings(gotKeys)
+	sorted := append([]string(nil), wantKeys...)
+	sort.Strings(sorted)
+	if strings.Join(gotKeys, ",") != strings.Join(sorted, ",") {
+		t.Fatalf("create payload keys =\n  %v\nwant exactly the 34 HAR-derived fields:\n  %v", gotKeys, sorted)
+	}
+
+	// Fields that MUST be null on a bare create — 0 here means the Unix
+	// epoch and md-on-create corrupts sync.
+	for _, k := range []string{"sr", "tir", "dd", "md", "sp", "rr", "rp", "lai", "ato", "icsd", "acrd", "dds", "rmd"} {
+		if string(m[k]) != "null" {
+			t.Errorf("create payload %q = %s, want null", k, m[k])
+		}
+	}
+	// Empty arrays, not null.
+	for _, k := range []string{"rt", "dl", "ar", "tg", "agr", "pr"} {
+		if string(m[k]) != "[]" {
+			t.Errorf("create payload %q = %s, want []", k, m[k])
+		}
+	}
+	if string(m["st"]) != "0" || string(m["ss"]) != "0" || string(m["tp"]) != "0" {
+		t.Errorf("bare create defaults: st=%s ss=%s tp=%s, want all 0", m["st"], m["ss"], m["tp"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handler wire tests — drive the real cmd* handlers against a fake server
+// and assert the exact bytes that would reach Things Cloud.
+// ---------------------------------------------------------------------------
+
+type capturedCommit struct {
+	ancestorIndex string
+	body          map[string]struct {
+		T int             `json:"t"`
+		E string          `json:"e"`
+		P json.RawMessage `json:"p"`
+	}
+}
+
+// newWireRecorder returns a History wired to a fake server plus a slice
+// collecting every commit POSTed through it.
+func newWireRecorder(t *testing.T) (*thingscloud.History, *[]capturedCommit) {
+	t.Helper()
+	var commits []capturedCommit
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.Contains(r.URL.Path, "/commit") {
+			var cc capturedCommit
+			cc.ancestorIndex = r.URL.Query().Get("ancestor-index")
+			if err := json.NewDecoder(r.Body).Decode(&cc.body); err != nil {
+				t.Errorf("commit body did not parse: %v", err)
+			}
+			commits = append(commits, cc)
+			fmt.Fprint(w, `{"server-head-index":42}`)
+			return
+		}
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	c := thingscloud.New(server.URL, "test@example.com", "pw")
+	h := &thingscloud.History{Client: c, ID: "wire-test-history", LatestServerIndex: 7}
+	return h, &commits
+}
+
+func singleItem(t *testing.T, cc capturedCommit) (uuid string, action int, kind string, payload map[string]any) {
+	t.Helper()
+	if len(cc.body) != 1 {
+		t.Fatalf("commit has %d items, want 1: %v", len(cc.body), cc.body)
+	}
+	for id, item := range cc.body {
+		var p map[string]any
+		if err := json.Unmarshal(item.P, &p); err != nil {
+			t.Fatalf("payload not an object: %v", err)
+		}
+		return id, item.T, item.E, p
+	}
+	panic("unreachable")
+}
+
+func TestCmdCreateWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+
+	cmdCreate(h, []string{"Wire task", "--uuid", id, "--when", "today", "--note", "body"})
+
+	if len(*commits) != 1 {
+		t.Fatalf("%d commits, want 1", len(*commits))
+	}
+	cc := (*commits)[0]
+	if cc.ancestorIndex != "7" {
+		t.Errorf("ancestor-index = %q, want 7 (the synced head)", cc.ancestorIndex)
+	}
+	gotID, action, kind, p := singleItem(t, cc)
+	if gotID != id || action != 0 || kind != "Task6" {
+		t.Errorf("envelope = (%s, %d, %s), want (%s, 0, Task6)", gotID, action, kind, id)
+	}
+	if p["md"] != nil {
+		t.Errorf("create sent md = %v, must be null on creates", p["md"])
+	}
+	if p["st"] != float64(1) || p["sr"] == nil || p["tir"] == nil {
+		t.Errorf("--when today: st=%v sr=%v tir=%v", p["st"], p["sr"], p["tir"])
+	}
+	nt := p["nt"].(map[string]any)
+	if nt["v"] != "body" {
+		t.Errorf("note value = %v", nt["v"])
+	}
+}
+
+func TestCmdCompleteWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+
+	cmdComplete(h, id)
+
+	_, action, kind, p := singleItem(t, (*commits)[0])
+	if action != 1 || kind != "Task6" {
+		t.Errorf("envelope action/kind = %d/%s, want 1/Task6", action, kind)
+	}
+	if p["ss"] != float64(3) {
+		t.Errorf("ss = %v, want 3 (completed)", p["ss"])
+	}
+	if sp, ok := p["sp"].(float64); !ok || sp <= 0 {
+		t.Errorf("sp = %v, want completion timestamp", p["sp"])
+	}
+	if md, ok := p["md"].(float64); !ok || md <= 0 {
+		t.Errorf("md = %v, want modification timestamp on update", p["md"])
+	}
+}
+
+func TestCmdTrashWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+
+	cmdTrash(h, id)
+
+	_, action, kind, p := singleItem(t, (*commits)[0])
+	if action != 1 || kind != "Task6" || p["tr"] != true {
+		t.Errorf("trash wire = action %d kind %s tr %v", action, kind, p["tr"])
+	}
+}
+
+func TestCmdPurgeWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	target := thingscloud.NewUUID()
+
+	cmdPurge(h, target)
+
+	tombID, action, kind, p := singleItem(t, (*commits)[0])
+	if action != 0 || kind != "Tombstone2" {
+		t.Errorf("purge envelope = action %d kind %s, want 0/Tombstone2", action, kind)
+	}
+	if err := thingscloud.ValidateUUID(tombID); err != nil {
+		t.Errorf("tombstone UUID %q not canonical: %v", tombID, err)
+	}
+	if p["dloid"] != target {
+		t.Errorf("dloid = %v, want %s", p["dloid"], target)
+	}
+	if dld, ok := p["dld"].(float64); !ok || dld <= 0 {
+		t.Errorf("dld = %v, want deletion timestamp", p["dld"])
+	}
+}
+
+func TestCmdMoveToTodayWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+
+	cmdMoveToToday(h, thingscloud.NewUUID())
+
+	_, _, _, p := singleItem(t, (*commits)[0])
+	if p["st"] != float64(1) {
+		t.Errorf("st = %v, want 1", p["st"])
+	}
+	if p["sr"] == nil || p["tir"] == nil || p["sr"] != p["tir"] {
+		t.Errorf("sr/tir = %v/%v, want equal midnight timestamps", p["sr"], p["tir"])
+	}
+}
+
+func TestCmdCreateAreaWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+
+	cmdCreateArea(h, []string{"Wire Area", "--uuid", id})
+
+	gotID, action, kind, p := singleItem(t, (*commits)[0])
+	// Area2 is silently ignored by Things.app — Area3 is load-bearing.
+	if gotID != id || action != 0 || kind != "Area3" {
+		t.Errorf("area envelope = (%s, %d, %s), want (%s, 0, Area3)", gotID, action, kind, id)
+	}
+	if p["tt"] != "Wire Area" {
+		t.Errorf("tt = %v", p["tt"])
+	}
+}
+
+func TestCmdCreateTagWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+
+	cmdCreateTag(h, []string{"Wire Tag", "--uuid", id})
+
+	gotID, action, kind, p := singleItem(t, (*commits)[0])
+	if gotID != id || action != 0 || kind != "Tag4" {
+		t.Errorf("tag envelope = (%s, %d, %s), want (%s, 0, Tag4)", gotID, action, kind, id)
+	}
+	if p["sh"] != nil {
+		t.Errorf("sh = %v, want null when no shorthand given", p["sh"])
+	}
+}
+
+func TestCmdAddChecklistWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	task := thingscloud.NewUUID()
+
+	cmdAddChecklist(h, task, []string{"one,two"})
+
+	if len(*commits) != 2 {
+		t.Fatalf("%d commits, want 2 (one per checklist item)", len(*commits))
+	}
+	for i, cc := range *commits {
+		itemID, action, kind, p := singleItem(t, cc)
+		if action != 0 || kind != "ChecklistItem3" {
+			t.Errorf("item %d envelope = %d/%s, want 0/ChecklistItem3", i, action, kind)
+		}
+		if err := thingscloud.ValidateUUID(itemID); err != nil {
+			t.Errorf("checklist item UUID %q not canonical: %v", itemID, err)
+		}
+		ts := p["ts"].([]any)
+		if len(ts) != 1 || ts[0] != task {
+			t.Errorf("item %d ts = %v, want [%s]", i, p["ts"], task)
+		}
+		if p["md"] != nil {
+			t.Errorf("item %d md = %v, must be null on creates", i, p["md"])
+		}
+		if p["ix"] != float64(i) {
+			t.Errorf("item %d ix = %v, want %d", i, p["ix"], i)
+		}
+	}
+}
+
+func TestCmdEditWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	proj := thingscloud.NewUUID()
+
+	cmdEdit(h, id, []string{"--title", "renamed", "--project", proj})
+
+	gotID, action, kind, p := singleItem(t, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task6" {
+		t.Errorf("edit envelope = (%s, %d, %s)", gotID, action, kind)
+	}
+	if p["tt"] != "renamed" {
+		t.Errorf("tt = %v", p["tt"])
+	}
+	pr := p["pr"].([]any)
+	if len(pr) != 1 || pr[0] != proj {
+		t.Errorf("pr = %v, want [%s]", p["pr"], proj)
+	}
+	// Assigning a project without an explicit schedule must move the task
+	// out of inbox with null dates (Bug 8 + PR #9 semantics).
+	if p["st"] != float64(1) || p["sr"] != nil || p["tir"] != nil {
+		t.Errorf("auto-anytime on edit: st=%v sr=%v tir=%v, want 1/null/null", p["st"], p["sr"], p["tir"])
+	}
+}

--- a/cmd/things-cli/wire_test.go
+++ b/cmd/things-cli/wire_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -452,5 +454,170 @@ func TestCmdEditWire(t *testing.T) {
 	// out of inbox with null dates (Bug 8 + PR #9 semantics).
 	if p["st"] != float64(1) || p["sr"] != nil || p["tir"] != nil {
 		t.Errorf("auto-anytime on edit: st=%v sr=%v tir=%v, want 1/null/null", p["st"], p["sr"], p["tir"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// initCLI / loadState / cmdBatch — full command plumbing against a fake server
+// ---------------------------------------------------------------------------
+
+// fakeCloud spins up a server implementing enough of the Things Cloud API
+// for initCLI + read/write flows: verify, own-history, history head, items.
+func fakeCloud(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/commit"):
+			fmt.Fprint(w, `{"server-head-index":5}`)
+		case strings.HasSuffix(r.URL.Path, "/items"):
+			fmt.Fprint(w, `{"items":[{"VJ1edXTP9q3PmFDUuy8EQh":{"e":"Task6","t":0,"p":{"tt":"seeded","tp":0,"st":1,"ss":0}}}],"current-item-index":1,"schema":301}`)
+		case strings.Contains(r.URL.Path, "/version/1/history/"):
+			fmt.Fprint(w, `{"latest-server-index":1,"latest-schema-version":301}`)
+		case strings.Contains(r.URL.Path, "/account/"):
+			fmt.Fprint(w, `{"email":"t@example.com","status":"SYAccountStatusActive","history-key":"hist-1"}`)
+		default:
+			fmt.Fprint(w, `{}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestInitCLIUsesEndpointOverride(t *testing.T) {
+	server := fakeCloud(t)
+	t.Setenv("THINGS_ENDPOINT", server.URL)
+	t.Setenv("THINGS_USERNAME", "t@example.com")
+	t.Setenv("THINGS_PASSWORD", "pw")
+
+	ctx := initCLI(true)
+	if ctx.history == nil || ctx.history.ID != "hist-1" {
+		t.Fatalf("initCLI history = %+v, want ID hist-1 from fake server", ctx.history)
+	}
+	if got := ctx.serverIndex(); got != 1 {
+		t.Errorf("serverIndex() = %d, want 1", got)
+	}
+}
+
+func TestLoadStateBuildsAndCachesState(t *testing.T) {
+	server := fakeCloud(t)
+	t.Setenv("THINGS_ENDPOINT", server.URL)
+	t.Setenv("THINGS_USERNAME", "t@example.com")
+	t.Setenv("THINGS_PASSWORD", "pw")
+	cachePath := t.TempDir() + "/cache.json"
+	t.Setenv("THINGS_CLI_CACHE", cachePath)
+
+	ctx := initCLI(false)
+	state := ctx.loadState()
+	if state.Tasks["VJ1edXTP9q3PmFDUuy8EQh"] == nil {
+		t.Fatal("loadState did not aggregate the seeded task")
+	}
+
+	cache, err := loadCLIStateCache(cachePath)
+	if err != nil || cache == nil {
+		t.Fatalf("cache not written: %v %v", cache, err)
+	}
+	if cache.ServerIndex != 1 || cache.HistoryID != "hist-1" {
+		t.Errorf("cache = index %d history %q, want 1/hist-1", cache.ServerIndex, cache.HistoryID)
+	}
+
+	// Second load must serve from the cache without rebuilding from zero.
+	state2 := ctx.loadState()
+	if state2.Tasks["VJ1edXTP9q3PmFDUuy8EQh"] == nil {
+		t.Fatal("cached loadState lost the task")
+	}
+}
+
+func TestCmdBatchWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id1, id2 := thingscloud.NewUUID(), thingscloud.NewUUID()
+
+	// cmdBatch reads ops from stdin.
+	ops := fmt.Sprintf(`[
+		{"cmd":"create","title":"batch A","uuid":%q},
+		{"cmd":"complete","uuid":%q}
+	]`, id1, id2)
+	r, w, _ := os.Pipe()
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+	go func() { w.WriteString(ops); w.Close() }()
+
+	cmdBatch(h)
+
+	if len(*commits) != 1 {
+		t.Fatalf("%d commits, want 1 — batch must send all ops in a single HTTP request", len(*commits))
+	}
+	body := (*commits)[0].body
+	if len(body) != 2 {
+		t.Fatalf("commit has %d items, want 2", len(body))
+	}
+	create, complete := body[id1], body[id2]
+	if create.E != "Task6" || create.T != 0 {
+		t.Errorf("create envelope = %s/%d, want Task6/0", create.E, create.T)
+	}
+	if complete.T != 1 {
+		t.Errorf("complete envelope action = %d, want 1", complete.T)
+	}
+	var p map[string]any
+	if err := json.Unmarshal(complete.P, &p); err != nil || p["ss"] != float64(3) {
+		t.Errorf("complete payload ss = %v (err %v), want 3", p["ss"], err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Read commands — render a known state and assert the JSON output
+// ---------------------------------------------------------------------------
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	w.Close()
+	var buf strings.Builder
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func TestReadCommandsRenderState(t *testing.T) {
+	state := testStateForListFilters()
+
+	out := captureStdout(t, func() { cmdList(state, []string{"--today"}) })
+	if !strings.Contains(out, "today-1") {
+		t.Errorf("list --today output missing today-1:\n%s", out)
+	}
+
+	out = captureStdout(t, func() { cmdSearch(state, []string{"needle"}) })
+	if !strings.Contains(out, "upcoming-1") {
+		t.Errorf("search output missing upcoming-1:\n%s", out)
+	}
+
+	out = captureStdout(t, func() { cmdShow(state, "today-1") })
+	if !strings.Contains(out, `"uuid"`) || !strings.Contains(out, "today-1") {
+		t.Errorf("show output malformed:\n%s", out)
+	}
+
+	out = captureStdout(t, func() { cmdAreas(state) })
+	if !strings.Contains(out, "Work") {
+		t.Errorf("areas output missing Work:\n%s", out)
+	}
+
+	out = captureStdout(t, func() { cmdProjects(state) })
+	if !strings.Contains(out, "Project Alpha") {
+		t.Errorf("projects output missing Project Alpha:\n%s", out)
+	}
+
+	out = captureStdout(t, func() { cmdTags(state) })
+	var tags []map[string]any
+	if err := json.Unmarshal([]byte(out), &tags); err != nil {
+		t.Errorf("tags output is not a JSON array: %v\n%s", err, out)
 	}
 }

--- a/cmd/thingsync/main.go
+++ b/cmd/thingsync/main.go
@@ -45,17 +45,17 @@ type LocationInfo struct {
 
 // RichChange is the enhanced change output with full context
 type RichChange struct {
-	Type        string       `json:"type"`
-	UUID        string       `json:"uuid"`
-	Title       string       `json:"title,omitempty"`
-	Context     *TaskContext `json:"context,omitempty"`
+	Type        string        `json:"type"`
+	UUID        string        `json:"uuid"`
+	Title       string        `json:"title,omitempty"`
+	Context     *TaskContext  `json:"context,omitempty"`
 	From        *LocationInfo `json:"from,omitempty"`
 	To          *LocationInfo `json:"to,omitempty"`
-	Where       string       `json:"where,omitempty"` // for creates: inbox, today, etc.
-	Tags        []EntityRef  `json:"tags,omitempty"`
-	Date        string       `json:"date,omitempty"` // for scheduled
-	CompletedAt *time.Time   `json:"completedAt,omitempty"`
-	Timestamp   time.Time    `json:"timestamp"`
+	Where       string        `json:"where,omitempty"` // for creates: inbox, today, etc.
+	Tags        []EntityRef   `json:"tags,omitempty"`
+	Date        string        `json:"date,omitempty"` // for scheduled
+	CompletedAt *time.Time    `json:"completedAt,omitempty"`
+	Timestamp   time.Time     `json:"timestamp"`
 }
 
 type TagInfo struct {
@@ -113,13 +113,13 @@ func main() {
 	// Flags
 	dbPath := flag.String("db", "", "Path to SQLite database (default: ~/.things-workflow/sync.db)")
 	humanReadable := flag.Bool("human", false, "Human-readable output instead of JSON")
-	
+
 	// Workflow commands
 	cmdToday := flag.Bool("today", false, "Show today view for morning review")
 	cmdInbox := flag.Bool("inbox", false, "Show inbox for triage")
 	cmdReview := flag.Bool("review", false, "Show evening review")
 	cmdPatterns := flag.Bool("patterns", false, "Show behavioral patterns")
-	
+
 	flag.Parse()
 
 	// Credentials from env
@@ -200,7 +200,7 @@ func resolveEntityRef(uuid string, syncer *sync.Syncer) *EntityRef {
 		return nil
 	}
 	state := syncer.State()
-	
+
 	// Try task (could be project or heading)
 	if task, err := state.Task(uuid); err == nil && task != nil {
 		return &EntityRef{UUID: uuid, Title: task.Title}
@@ -213,7 +213,7 @@ func resolveEntityRef(uuid string, syncer *sync.Syncer) *EntityRef {
 	if tag, err := state.Tag(uuid); err == nil && tag != nil {
 		return &EntityRef{UUID: uuid, Title: tag.Title}
 	}
-	
+
 	return &EntityRef{UUID: uuid, Title: "(unknown)"}
 }
 
@@ -222,15 +222,15 @@ func getTaskContext(task *things.Task, syncer *sync.Syncer) *TaskContext {
 	if task == nil {
 		return nil
 	}
-	
+
 	ctx := &TaskContext{}
 	state := syncer.State()
-	
+
 	// Heading (action group)
 	if len(task.ActionGroupIDs) > 0 {
 		ctx.Heading = resolveEntityRef(task.ActionGroupIDs[0], syncer)
 	}
-	
+
 	// Project (parent task that is a project)
 	if len(task.ParentTaskIDs) > 0 {
 		for _, parentID := range task.ParentTaskIDs {
@@ -242,19 +242,19 @@ func getTaskContext(task *things.Task, syncer *sync.Syncer) *TaskContext {
 			}
 		}
 	}
-	
+
 	// Area
 	if len(task.AreaIDs) > 0 {
 		if area, err := state.Area(task.AreaIDs[0]); err == nil && area != nil {
 			ctx.Area = &EntityRef{UUID: area.UUID, Title: area.Title}
 		}
 	}
-	
+
 	// Check if context is empty
 	if ctx.Heading == nil && ctx.Project == nil && ctx.Area == nil {
 		return nil
 	}
-	
+
 	return ctx
 }
 
@@ -263,17 +263,17 @@ func getTaskLocation(task *things.Task, syncer *sync.Syncer) string {
 	if task == nil {
 		return "unknown"
 	}
-	
+
 	// Check trash first
 	if task.InTrash {
 		return "trash"
 	}
-	
+
 	// Check status
 	if task.Status == things.TaskStatusCompleted {
 		return "completed"
 	}
-	
+
 	// Based on schedule/start state
 	switch task.Schedule {
 	case things.TaskScheduleInbox:
@@ -291,20 +291,20 @@ func getTaskLocation(task *things.Task, syncer *sync.Syncer) string {
 		}
 		return "someday"
 	}
-	
+
 	return "unknown"
 }
 
 // buildRichChanges converts sync changes to rich format with context
 func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 	var result []RichChange
-	
+
 	for _, c := range changes {
 		rich := RichChange{
 			UUID:      c.EntityUUID(),
 			Timestamp: c.Timestamp(),
 		}
-		
+
 		switch v := c.(type) {
 		case sync.TaskCreated:
 			rich.Type = "task_created"
@@ -314,7 +314,7 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 				rich.Context = getTaskContext(v.Task, syncer)
 				rich.Tags = getTaskTags(v.Task, syncer)
 			}
-			
+
 		case sync.TaskCompleted:
 			rich.Type = "task_completed"
 			if v.Task != nil {
@@ -324,14 +324,14 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 					rich.CompletedAt = v.Task.CompletionDate
 				}
 			}
-			
+
 		case sync.TaskTitleChanged:
 			rich.Type = "task_updated"
 			if v.Task != nil {
 				rich.Title = v.Task.Title
 				rich.Context = getTaskContext(v.Task, syncer)
 			}
-			
+
 		case sync.TaskMovedToToday:
 			rich.Type = "task_today"
 			if v.Task != nil {
@@ -339,14 +339,14 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 				rich.Context = getTaskContext(v.Task, syncer)
 				rich.To = &LocationInfo{Location: "today"}
 			}
-			
+
 		case sync.TaskMovedToInbox:
 			rich.Type = "task_moved"
 			if v.Task != nil {
 				rich.Title = v.Task.Title
 				rich.To = &LocationInfo{Location: "inbox"}
 			}
-			
+
 		case sync.TaskMovedToAnytime:
 			rich.Type = "task_moved"
 			if v.Task != nil {
@@ -354,7 +354,7 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 				rich.Context = getTaskContext(v.Task, syncer)
 				rich.To = &LocationInfo{Location: "anytime"}
 			}
-			
+
 		case sync.TaskMovedToSomeday:
 			rich.Type = "task_deferred"
 			if v.Task != nil {
@@ -362,7 +362,7 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 				rich.Context = getTaskContext(v.Task, syncer)
 				rich.To = &LocationInfo{Location: "someday"}
 			}
-			
+
 		case sync.TaskMovedToUpcoming:
 			rich.Type = "task_scheduled"
 			if v.Task != nil {
@@ -374,21 +374,21 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 					rich.To.Date = rich.Date
 				}
 			}
-			
+
 		case sync.TaskTrashed:
 			rich.Type = "task_trashed"
 			if v.Task != nil {
 				rich.Title = v.Task.Title
 				rich.Context = getTaskContext(v.Task, syncer)
 			}
-			
+
 		case sync.TaskTagsChanged:
 			rich.Type = "task_tagged"
 			if v.Task != nil {
 				rich.Title = v.Task.Title
 				rich.Tags = getTaskTags(v.Task, syncer)
 			}
-			
+
 		case sync.TaskAssignedToProject:
 			rich.Type = "task_moved"
 			if v.Task != nil {
@@ -401,19 +401,19 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 					}
 				}
 			}
-			
+
 		case sync.ProjectCreated:
 			rich.Type = "project_created"
 			if v.Project != nil {
 				rich.Title = v.Project.Title
 			}
-			
+
 		case sync.ProjectCompleted:
 			rich.Type = "project_completed"
 			if v.Project != nil {
 				rich.Title = v.Project.Title
 			}
-			
+
 		case sync.HeadingCreated:
 			rich.Type = "heading_created"
 			if v.Heading != nil {
@@ -425,7 +425,7 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 					}
 				}
 			}
-			
+
 		case sync.HeadingTitleChanged:
 			rich.Type = "heading_updated"
 			if v.Heading != nil {
@@ -436,27 +436,27 @@ func buildRichChanges(changes []sync.Change, syncer *sync.Syncer) []RichChange {
 					}
 				}
 			}
-			
+
 		case sync.AreaCreated:
 			rich.Type = "area_created"
 			if v.Area != nil {
 				rich.Title = v.Area.Title
 			}
-			
+
 		case sync.TagCreated:
 			rich.Type = "tag_created"
 			if v.Tag != nil {
 				rich.Title = v.Tag.Title
 			}
-			
+
 		default:
 			// Generic fallback
 			rich.Type = c.ChangeType()
 		}
-		
+
 		result = append(result, rich)
 	}
-	
+
 	return result
 }
 
@@ -465,16 +465,16 @@ func getTaskTags(task *things.Task, syncer *sync.Syncer) []EntityRef {
 	if task == nil || len(task.TagIDs) == 0 {
 		return nil
 	}
-	
+
 	var tags []EntityRef
 	state := syncer.State()
-	
+
 	for _, tagID := range task.TagIDs {
 		if tag, err := state.Tag(tagID); err == nil && tag != nil {
 			tags = append(tags, EntityRef{UUID: tag.UUID, Title: tag.Title})
 		}
 	}
-	
+
 	return tags
 }
 
@@ -649,7 +649,7 @@ func printTaskHuman(t TaskInfo) {
 
 func printChangeHuman(c RichChange) {
 	var desc string
-	
+
 	switch c.Type {
 	case "task_created":
 		desc = fmt.Sprintf("✚ Created: %s", c.Title)
@@ -697,7 +697,7 @@ func printChangeHuman(c RichChange) {
 	default:
 		desc = fmt.Sprintf("%s: %s", c.Type, c.Title)
 	}
-	
+
 	// Add context if available
 	if c.Context != nil && c.Type != "heading_created" {
 		var ctxParts []string
@@ -711,12 +711,12 @@ func printChangeHuman(c RichChange) {
 			desc += fmt.Sprintf(" (%s)", strings.Join(ctxParts, ", "))
 		}
 	}
-	
+
 	fmt.Printf("  %s\n", desc)
 }
 
 func printHuman(output Output) {
-	fmt.Printf("Synced: %d → %d (%d changes)\n", 
+	fmt.Printf("Synced: %d → %d (%d changes)\n",
 		output.Sync.LastIndex, output.Sync.NewIndex, output.Sync.ChangesCount)
 
 	// Show changes if any
@@ -758,17 +758,17 @@ func printHuman(output Output) {
 // ============================================
 
 type TodayView struct {
-	Tasks      []TaskInfo  `json:"tasks"`
-	Overloaded bool        `json:"overloaded"`
-	Alerts     []Alert     `json:"alerts"`
-	Summary    string      `json:"summary"`
+	Tasks      []TaskInfo `json:"tasks"`
+	Overloaded bool       `json:"overloaded"`
+	Alerts     []Alert    `json:"alerts"`
+	Summary    string     `json:"summary"`
 }
 
 type InboxView struct {
-	Items      []TaskInfo  `json:"items"`
-	Count      int         `json:"count"`
-	OldestDays int         `json:"oldestDays"`
-	Alerts     []Alert     `json:"alerts"`
+	Items      []TaskInfo `json:"items"`
+	Count      int        `json:"count"`
+	OldestDays int        `json:"oldestDays"`
+	Alerts     []Alert    `json:"alerts"`
 }
 
 type ReviewView struct {
@@ -779,25 +779,25 @@ type ReviewView struct {
 }
 
 type PatternView struct {
-	Rescheduled    []TaskInfo  `json:"rescheduled"`    // Tasks moved 3+ times
-	StaleInbox     []TaskInfo  `json:"staleInbox"`     // Inbox items >7 days
-	NeglectedAreas []string    `json:"neglectedAreas"` // Areas with no activity
+	Rescheduled    []TaskInfo `json:"rescheduled"`    // Tasks moved 3+ times
+	StaleInbox     []TaskInfo `json:"staleInbox"`     // Inbox items >7 days
+	NeglectedAreas []string   `json:"neglectedAreas"` // Areas with no activity
 }
 
 func printTodayView(syncer *sync.Syncer) {
 	state := syncer.State()
 	today, _ := state.TasksInToday(sync.QueryOpts{})
-	
+
 	view := TodayView{
 		Tasks:      []TaskInfo{},
 		Overloaded: len(today) > 5,
 		Alerts:     []Alert{},
 	}
-	
+
 	for _, t := range today {
 		info := taskToInfo(t, syncer, "today")
 		view.Tasks = append(view.Tasks, info)
-		
+
 		// Check for reschedule patterns
 		if info.MoveCount >= 3 {
 			view.Alerts = append(view.Alerts, Alert{
@@ -807,7 +807,7 @@ func printTodayView(syncer *sync.Syncer) {
 				Reason: fmt.Sprintf("rescheduled %d times - what's blocking this?", info.MoveCount),
 			})
 		}
-		
+
 		// Check for deadlines
 		if info.Deadline != "" {
 			deadline, _ := time.Parse("2006-01-02", info.Deadline)
@@ -821,16 +821,16 @@ func printTodayView(syncer *sync.Syncer) {
 			}
 		}
 	}
-	
+
 	if view.Overloaded {
 		view.Alerts = append(view.Alerts, Alert{
 			Type:   "overloaded",
 			Reason: fmt.Sprintf("Today has %d tasks - consider deferring some", len(today)),
 		})
 	}
-	
+
 	view.Summary = fmt.Sprintf("%d tasks for today", len(today))
-	
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.Encode(view)
@@ -839,21 +839,21 @@ func printTodayView(syncer *sync.Syncer) {
 func printInboxView(syncer *sync.Syncer) {
 	state := syncer.State()
 	inbox, _ := state.TasksInInbox(sync.QueryOpts{})
-	
+
 	view := InboxView{
 		Items:  []TaskInfo{},
 		Count:  len(inbox),
 		Alerts: []Alert{},
 	}
-	
+
 	for _, t := range inbox {
 		info := taskToInfo(t, syncer, "inbox")
 		view.Items = append(view.Items, info)
-		
+
 		if info.AgeDays > view.OldestDays {
 			view.OldestDays = info.AgeDays
 		}
-		
+
 		if info.AgeDays >= 7 {
 			view.Alerts = append(view.Alerts, Alert{
 				Type:   "stale",
@@ -863,14 +863,14 @@ func printInboxView(syncer *sync.Syncer) {
 			})
 		}
 	}
-	
+
 	if len(inbox) > 10 {
 		view.Alerts = append(view.Alerts, Alert{
 			Type:   "inbox_overflow",
 			Reason: fmt.Sprintf("inbox has %d items - needs triage", len(inbox)),
 		})
 	}
-	
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.Encode(view)
@@ -879,7 +879,7 @@ func printInboxView(syncer *sync.Syncer) {
 func printReviewView(syncer *sync.Syncer) {
 	state := syncer.State()
 	todayStart := syncutil.StartOfToday()
-	
+
 	// Get completed tasks today
 	changes, _ := syncer.ChangesSince(todayStart)
 	completedUUIDs := make(map[string]bool)
@@ -888,13 +888,13 @@ func printReviewView(syncer *sync.Syncer) {
 			completedUUIDs[c.EntityUUID()] = true
 		}
 	}
-	
+
 	view := ReviewView{
 		CompletedToday: []TaskInfo{},
 		StillInToday:   []TaskInfo{},
 		Summary:        syncutil.BuildDailySummary(syncer),
 	}
-	
+
 	// Get completed tasks
 	for uuid := range completedUUIDs {
 		if task, err := state.Task(uuid); err == nil && task != nil {
@@ -902,21 +902,21 @@ func printReviewView(syncer *sync.Syncer) {
 			view.CompletedToday = append(view.CompletedToday, info)
 		}
 	}
-	
+
 	// Get remaining today tasks
 	today, _ := state.TasksInToday(sync.QueryOpts{})
 	for _, t := range today {
 		info := taskToInfo(t, syncer, "today")
 		view.StillInToday = append(view.StillInToday, info)
 	}
-	
+
 	// Count tasks moved today
 	for _, c := range changes {
 		if strings.HasPrefix(c.ChangeType(), "TaskMovedTo") {
 			view.MovedCount++
 		}
 	}
-	
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.Encode(view)
@@ -924,13 +924,13 @@ func printReviewView(syncer *sync.Syncer) {
 
 func printPatternsView(syncer *sync.Syncer) {
 	state := syncer.State()
-	
+
 	view := PatternView{
 		Rescheduled:    []TaskInfo{},
 		StaleInbox:     []TaskInfo{},
 		NeglectedAreas: []string{},
 	}
-	
+
 	// Find rescheduled tasks (anywhere, not just today)
 	today, _ := state.TasksInToday(sync.QueryOpts{})
 	for _, t := range today {
@@ -939,7 +939,7 @@ func printPatternsView(syncer *sync.Syncer) {
 			view.Rescheduled = append(view.Rescheduled, info)
 		}
 	}
-	
+
 	// Also check all tasks for reschedule patterns
 	allTasks, _ := state.AllTasks(sync.QueryOpts{})
 	seenUUIDs := make(map[string]bool)
@@ -955,7 +955,7 @@ func printPatternsView(syncer *sync.Syncer) {
 			view.Rescheduled = append(view.Rescheduled, info)
 		}
 	}
-	
+
 	// Stale inbox items
 	inbox, _ := state.TasksInInbox(sync.QueryOpts{})
 	for _, t := range inbox {
@@ -964,9 +964,9 @@ func printPatternsView(syncer *sync.Syncer) {
 			view.StaleInbox = append(view.StaleInbox, info)
 		}
 	}
-	
+
 	// TODO: Track area activity for neglected areas
-	
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.Encode(view)

--- a/cmd/thingsync/main.go
+++ b/cmd/thingsync/main.go
@@ -878,7 +878,7 @@ func printInboxView(syncer *sync.Syncer) {
 
 func printReviewView(syncer *sync.Syncer) {
 	state := syncer.State()
-	todayStart := time.Now().Truncate(24 * time.Hour)
+	todayStart := syncutil.StartOfToday()
 	
 	// Get completed tasks today
 	changes, _ := syncer.ChangesSince(todayStart)

--- a/docs/client-side-bugs.md
+++ b/docs/client-side-bugs.md
@@ -331,6 +331,33 @@ if v, ok := opts["area"]; ok && v != "" {
 
 Tasks moved from Inbox to project/area/heading via `things-cli edit` now correctly appear under their parent instead of remaining in Inbox.
 
+## Bug 9: Base58 Encoder Dropped Leading Zero Bytes (2026-07-06)
+
+### The Problem
+
+Even after the Bug 5 fix switched UUID generation to Base58, accounts still intermittently accumulated items that crashed Things.app. The failure was probabilistic: everything worked for dozens of creates, then one item poisoned the history.
+
+### Root Cause
+
+The Base58 encoders in `things-cli` and `example/` (duplicated code) converted the UUID through `math/big`, which normalizes away leading zero bytes. Canonical Base58 represents each leading `0x00` byte as a leading `1` character; without that padding, a UUID whose first byte is zero encodes one character short and no longer decodes to 16 bytes. Byte 0 of a v4 UUID is fully random, so **~1 in 256 generated identifiers was malformed** — feeding the exact decoder (`BSIdentifierFromBase58String`, see Bug 5) whose array-bounds failure crashes the app.
+
+### Evidence
+
+- All identifiers captured from real Things.app traffic round-trip through a canonical encoder unchanged (`VJ1edXTP9q3PmFDUuy8EQh`, `FQxaqvLBkbR5q2Q5oRoknc`, `BVU8qZ9dNjrdxLvDHPvfDS`) — Things uses standard Bitcoin-style Base58 with leading-`1` padding.
+- Empirical: a UUID starting `0x00` encoded by the old code round-trips to only 15 bytes.
+
+### The Fix (v0.3.0)
+
+Moved a single canonical implementation into the SDK (`base58.go`): `EncodeUUID` emits one `1` per leading zero byte; `DecodeUUID` rejects anything that doesn't decode to exactly 16 bytes; `NewUUID()` is the one true generator. Defense in depth:
+
+- `History.Write()` validates every item UUID (and rejects duplicate UUIDs per commit) before anything reaches the server
+- `things-cli` validates all user-supplied identifiers (`--uuid`, `--project`, `--area`, `--heading`, `--tags`, positional targets)
+- Related hole closed: `create --type heading --when inbox` could still emit `tp=2, st=0` (Bug 6's crash payload) because the `--when` switch ran after the type switch; projects and headings now force `st=1` after all schedule processing
+
+### Verification
+
+TDD with real-traffic round-trip vectors; forced leading-zero-byte cases in the round-trip suite; 2000-draw canonical-validity test on the generator.
+
 ## Files Changed
 
 | File | Changes |

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -51,10 +51,12 @@ Nothing local can prove Things.app *accepts* our bytes. This step does.
 
 ### a. Run the soak driver
 
-It builds `things-cli`, drives many create/edit/move/complete/trash
-cycles through it (the real user write path), **deliberately including
-identifiers built from leading-zero-byte UUIDs**, verifies every write
-landed by reading the account back through the sync engine, then cleans up.
+It builds `things-cli` and drives every write command through it (the
+real user write path): create (tasks, projects, headings, areas, tags),
+edit, move-to-today, complete, add-checklist, batch (multi-op single
+commit), trash, and purge — **deliberately including identifiers built
+from leading-zero-byte UUIDs**. It verifies every write landed by reading
+the account back through the sync engine, then cleans up.
 
 ```bash
 export THINGS_USERNAME='test-account@example.com'

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -1,0 +1,111 @@
+# Stress Testing the Write & Sync Paths
+
+This SDK's failure mode was **cumulative history corruption**: a rare bad
+identifier (roughly 1 write in 256) made Things.app crash on its next sync,
+and a poisoned history cannot be repaired. The tests below attack that
+class three ways — two fully local and automated, one live against a
+disposable account.
+
+## 1. Fuzzing the identifier layer (local, automated)
+
+`base58_fuzz_test.go` throws millions of random inputs at the Base58
+encode/decode/validate functions:
+
+```bash
+go test -run '^$' -fuzz=FuzzUUIDRoundTrip       -fuzztime=60s .
+go test -run '^$' -fuzz=FuzzValidateUUIDIsSound -fuzztime=60s .
+go test -run '^$' -fuzz=FuzzDecodeUUIDNeverPanics -fuzztime=30s .
+```
+
+- `FuzzUUIDRoundTrip` — every 16-byte UUID must survive `EncodeUUID → DecodeUUID` unchanged and encode canonically. This is the exact property the old encoder violated for leading-zero bytes; the fuzzer hits that case within a few iterations.
+- `FuzzValidateUUIDIsSound` — treats `ValidateUUID` as the security boundary: anything it accepts must decode to exactly 16 bytes and be canonical. If it ever accepts a corrupting identifier, `Write()` could poison a history.
+- `FuzzDecodeUUIDNeverPanics` — arbitrary caller/server strings must never crash the SDK.
+
+The seed corpus alone catches a reverted encoder in <0.1s.
+
+## 2. Chaos-testing the sync engine (local, automated)
+
+`sync/chaos_test.go` (`TestChaos_MidSyncFailuresNeverCorrupt`) serves a
+synthetic history through a fault-injecting fake server and, across 40
+trials, kills the sync partway through at random batch boundaries (via
+truncated responses and a 500), then recovers. After each recovery it
+asserts:
+
+- the cursor sits exactly at the last **committed** batch (never past the failed one),
+- `change_log` has **zero** duplicate `(server_index, entity_uuid, change_type)` rows,
+- the final task state is byte-identical to a clean single-shot sync.
+
+```bash
+go test -run TestChaos ./sync/
+```
+
+Reverting the atomic-cursor fix makes this fail immediately
+(`cursor = 0, want 10`), confirming it tests the real invariant.
+
+## 3. Live soak against a disposable account (manual)
+
+Nothing local can prove Things.app *accepts* our bytes. This step does.
+
+> **Use a throwaway test account only.** Never a real account — the soak
+> writes and then trashes/purges hundreds of items.
+
+### a. Run the soak driver
+
+It builds `things-cli`, drives many create/edit/move/complete/trash
+cycles through it (the real user write path), **deliberately including
+identifiers built from leading-zero-byte UUIDs**, verifies every write
+landed by reading the account back through the sync engine, then cleans up.
+
+```bash
+export THINGS_USERNAME='test-account@example.com'
+export THINGS_PASSWORD='...'
+export THINGS_SOAK_CONFIRM=yes-throwaway-account
+go run ./cmd/soak --cycles 50
+```
+
+A `PASS` means every write was accepted and re-synced. A `FAIL` means the
+account may now hold data Things.app cannot decode — stop and inspect
+before opening any client on it.
+
+### b. Watch the live app while (or after) it runs
+
+On the machine where **Things.app is signed into the same test account**:
+
+```bash
+# Classify any pre-existing crash reports
+scripts/things-crash-watch.sh --scan
+
+# Watch for new crashes + stream the sync log during the soak
+scripts/things-crash-watch.sh
+```
+
+The script watches `~/Library/Logs/DiagnosticReports` for new
+`Things*.ips` reports and classifies each against the known
+sync-decode crash signatures (`BSIdentifierFromBase58String`,
+`BSSyncValueEncoder`, `decodeToOneRelation`, `LegacySCHistoryPerformSync`
+— see [`client-side-bugs.md`](client-side-bugs.md)). A backtrace hitting
+any of them is the history-poisoning class this SDK exists to prevent.
+
+### c. If Things.app does crash — attach a debugger
+
+```bash
+# Symbolicate the newest crash report
+ls -t ~/Library/Logs/DiagnosticReports/Things*.ips | head -1
+
+# Or attach lldb to a running instance to catch it live
+lldb -p "$(pgrep -x Things3 || pgrep -x Things)"
+(lldb) continue
+# on crash:
+(lldb) thread backtrace all
+(lldb) image lookup --address <faulting-address>
+```
+
+The crashing frame plus the offending item (the last thing the soak wrote
+before the crash) pinpoint which wire-format rule was violated. Add a
+regression test at the SDK boundary so `Write()` refuses that shape.
+
+### d. The final human check
+
+Even on a clean `PASS` with no crash reports, open Things.app on the test
+account and confirm the created items appear and sync across a second
+device. That end-to-end observation is the real acceptance test.

--- a/helpers_coverage_test.go
+++ b/helpers_coverage_test.go
@@ -1,0 +1,25 @@
+package thingscloud
+
+import "testing"
+
+func TestSchedule_Ptr(t *testing.T) {
+	t.Parallel()
+	p := Schedule(TaskScheduleSomeday)
+	if p == nil {
+		t.Fatal("Schedule returned nil")
+	}
+	if *p != TaskScheduleSomeday {
+		t.Errorf("*Schedule = %d, want %d", *p, TaskScheduleSomeday)
+	}
+}
+
+func TestTaskTypePtr_Ptr(t *testing.T) {
+	t.Parallel()
+	p := TaskTypePtr(TaskTypeProject)
+	if p == nil {
+		t.Fatal("TaskTypePtr returned nil")
+	}
+	if *p != TaskTypeProject {
+		t.Errorf("*TaskTypePtr = %d, want %d", *p, TaskTypeProject)
+	}
+}

--- a/histories_coverage_test.go
+++ b/histories_coverage_test.go
@@ -1,0 +1,206 @@
+package thingscloud
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// asHTTPError reports whether err (or a wrapped error) is an *HTTPError, and if
+// so stores it in *target.
+func asHTTPError(err error, target **HTTPError) bool {
+	return errors.As(err, target)
+}
+
+func TestClient_History(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		// History() reads the "latest-server-index" field (historyResponse),
+		// distinct from Sync()'s "current-item-index" (itemsResponse).
+		server, _ := captureServer(http.StatusOK, `{"latest-server-index":42,"latest-schema-version":300,"latest-total-content-size":80112}`)
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		h, err := c.History("33333abb-bfe4-4b03-a5c9-106d42220c72")
+		if err != nil {
+			t.Fatalf("History failed: %v", err)
+		}
+		if h.ID != "33333abb-bfe4-4b03-a5c9-106d42220c72" {
+			t.Errorf("ID = %q", h.ID)
+		}
+		if h.LatestServerIndex != 42 {
+			t.Errorf("LatestServerIndex = %d, want 42", h.LatestServerIndex)
+		}
+		if h.LatestSchemaVersion != 300 {
+			t.Errorf("LatestSchemaVersion = %d, want 300", h.LatestSchemaVersion)
+		}
+		if h.Client != c {
+			t.Error("History.Client not wired to originating client")
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusUnauthorized, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		if _, err := c.History("id"); err != ErrUnauthorized {
+			t.Errorf("History err = %v, want ErrUnauthorized", err)
+		}
+	})
+
+	t.Run("OtherStatusReturnsHTTPError", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusInternalServerError, "")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		_, err := c.History("id")
+		var httpErr *HTTPError
+		if !asHTTPError(err, &httpErr) {
+			t.Fatalf("History err = %v, want *HTTPError", err)
+		}
+		if httpErr.StatusCode != http.StatusInternalServerError {
+			t.Errorf("StatusCode = %d, want 500", httpErr.StatusCode)
+		}
+	})
+
+	t.Run("MalformedJSON", func(t *testing.T) {
+		t.Parallel()
+		server, _ := captureServer(http.StatusOK, "not json")
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		if _, err := c.History("id"); err == nil {
+			t.Error("expected decode error on malformed JSON, got nil")
+		}
+	})
+}
+
+func TestClient_OwnHistory(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		server := fakeServer(fakeResponse{200, "verify-success.json"})
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		h, err := c.OwnHistory()
+		if err != nil {
+			t.Fatalf("OwnHistory failed: %v", err)
+		}
+		if h.Client != c {
+			t.Error("OwnHistory.Client not wired to originating client")
+		}
+	})
+
+	t.Run("VerifyError", func(t *testing.T) {
+		t.Parallel()
+		server := fakeServer(fakeResponse{401, "error.json"})
+		defer server.Close()
+
+		c := New(server.URL, "martin@example.com", "")
+		if _, err := c.OwnHistory(); err == nil {
+			t.Error("expected OwnHistory to fail when Verify fails, got nil")
+		}
+	})
+}
+
+func TestClient_HistoryWithID(t *testing.T) {
+	t.Parallel()
+	c := New("http://example.com", "martin@example.com", "")
+	h := c.HistoryWithID("known-id")
+	if h.ID != "known-id" {
+		t.Errorf("ID = %q, want known-id", h.ID)
+	}
+	if h.Client != c {
+		t.Error("Client not wired")
+	}
+	if h.LatestServerIndex != 0 {
+		t.Errorf("LatestServerIndex = %d, want 0 (no network call made)", h.LatestServerIndex)
+	}
+}
+
+func TestHistory_Delete_ErrorStatus(t *testing.T) {
+	t.Parallel()
+	server, _ := captureServer(http.StatusInternalServerError, "")
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := History{Client: c, ID: "id"}
+	if err := h.Delete(); err == nil {
+		t.Error("expected Delete to fail on non-202, got nil")
+	}
+}
+
+func TestHistory_Sync_ErrorStatus(t *testing.T) {
+	t.Parallel()
+	server, _ := captureServer(http.StatusInternalServerError, "")
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := History{Client: c, ID: "id"}
+	err := h.Sync()
+	var httpErr *HTTPError
+	if !asHTTPError(err, &httpErr) {
+		t.Fatalf("Sync err = %v, want *HTTPError", err)
+	}
+}
+
+func TestHistory_Sync_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	server, _ := captureServer(http.StatusOK, "not json")
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	h := History{Client: c, ID: "id"}
+	if err := h.Sync(); err == nil {
+		t.Error("expected Sync to fail on malformed JSON, got nil")
+	}
+}
+
+func TestClient_CreateHistory_Unauthorized(t *testing.T) {
+	t.Parallel()
+	server, _ := captureServer(http.StatusUnauthorized, "")
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	if _, err := c.CreateHistory(); err != ErrUnauthorized {
+		t.Errorf("CreateHistory err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestClient_Histories_Unauthorized(t *testing.T) {
+	t.Parallel()
+	server, _ := captureServer(http.StatusUnauthorized, "")
+	defer server.Close()
+
+	c := New(server.URL, "martin@example.com", "")
+	if _, err := c.Histories(); err != ErrUnauthorized {
+		t.Errorf("Histories err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestHistory_Write_DuplicateUUID(t *testing.T) {
+	t.Parallel()
+	// A valid Base58 UUID reused twice in one commit must be rejected before
+	// any network call, since the map keyed by UUID would silently drop one.
+	id := NewUUID()
+	c := New("http://example.com", "martin@example.com", "")
+	h := History{Client: c, ID: "hist"}
+	item := TombstoneActionItem{Item: Item{UUID: id}}
+	if err := h.Write(item, item); err == nil {
+		t.Error("expected Write to reject duplicate UUID in one commit, got nil")
+	}
+}
+
+func TestHistory_Write_InvalidUUID(t *testing.T) {
+	t.Parallel()
+	c := New("http://example.com", "martin@example.com", "")
+	h := History{Client: c, ID: "hist"}
+	// Contains '0', which is not in the Base58 (Bitcoin) alphabet.
+	item := TombstoneActionItem{Item: Item{UUID: "0000-not-base58"}}
+	if err := h.Write(item); err == nil {
+		t.Error("expected Write to reject non-Base58 UUID, got nil")
+	}
+}

--- a/notes.go
+++ b/notes.go
@@ -37,6 +37,11 @@ func ApplyPatches(original string, patches []NotePatch) string {
 		if end > len(runes) {
 			end = len(runes)
 		}
+		if end < p.Position {
+			// Negative length in a corrupt/hostile patch: treat as a
+			// pure insertion instead of slicing out of bounds.
+			end = p.Position
+		}
 		actualLength := end - p.Position
 		replacementRunes := []rune(p.Replacement)
 		newCap := len(runes) - actualLength + len(replacementRunes)

--- a/notes_negative_patch_test.go
+++ b/notes_negative_patch_test.go
@@ -1,0 +1,19 @@
+package thingscloud
+
+import "testing"
+
+func TestApplyPatches_NegativeLengthDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// A hostile or corrupted server payload with a negative length must not
+	// crash the SDK. A negative length is treated as zero (pure insertion).
+	got := ApplyPatches("hello", []NotePatch{{Replacement: "X", Position: 0, Length: -5}})
+	if got != "Xhello" {
+		t.Errorf("ApplyPatches negative length = %q, want %q", got, "Xhello")
+	}
+
+	got = ApplyPatches("hello", []NotePatch{{Replacement: "", Position: 3, Length: -1}})
+	if got != "hello" {
+		t.Errorf("ApplyPatches negative length no-op = %q, want %q", got, "hello")
+	}
+}

--- a/repeat_coverage_test.go
+++ b/repeat_coverage_test.go
@@ -1,0 +1,46 @@
+package thingscloud
+
+import (
+	"testing"
+	"time"
+)
+
+// FrequencyUnit 0 matches none of the daily/weekly/monthly/yearly constants, so
+// both entry points fall through to their zero-time default branch.
+func TestComputeFirstScheduledAt_UnknownFrequency(t *testing.T) {
+	t.Parallel()
+	c := RepeaterConfiguration{FrequencyUnit: FrequencyUnit(0)}
+	if got := c.ComputeFirstScheduledAt(time.Now()); !got.IsZero() {
+		t.Errorf("ComputeFirstScheduledAt = %v, want zero time", got)
+	}
+}
+
+func TestNextScheduledAt_UnknownFrequency(t *testing.T) {
+	t.Parallel()
+	c := RepeaterConfiguration{FrequencyUnit: FrequencyUnit(0)}
+	if got := c.NextScheduledAt(0); !got.IsZero() {
+		t.Errorf("NextScheduledAt = %v, want zero time", got)
+	}
+}
+
+// A daily repeater bounded by RepeatCount (no LastScheduledAt) must stop once
+// the requested occurrence reaches the count.
+func TestNextDailyScheduledAt_RepeatCountExhausted(t *testing.T) {
+	t.Parallel()
+	first := Timestamp(time.Date(2017, 9, 3, 0, 0, 0, 0, time.UTC))
+	count := int64(3)
+	c := RepeaterConfiguration{
+		FrequencyUnit:      FrequencyUnitDaily,
+		FrequencyAmplitude: 1,
+		FirstScheduledAt:   &first,
+		RepeatCount:        &count,
+	}
+	// Occurrence within the count is a real date.
+	if got := c.NextScheduledAt(1); got.IsZero() {
+		t.Error("NextScheduledAt(1) = zero, want a real date within RepeatCount")
+	}
+	// Occurrence at/after the count is exhausted -> zero time.
+	if got := c.NextScheduledAt(3); !got.IsZero() {
+		t.Errorf("NextScheduledAt(3) = %v, want zero time (RepeatCount exhausted)", got)
+	}
+}

--- a/scripts/things-crash-watch.sh
+++ b/scripts/things-crash-watch.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# things-crash-watch.sh — watch for Things.app sync crashes on macOS and
+# classify them against the known sync-decode crash signatures.
+#
+# Run this on the machine where Things.app is signed into the SOAK TEST
+# account, then run the soak tool (cmd/soak) against the same account.
+# If a write ever puts undecodable data in the history, Things.app crashes
+# on the next sync and this script captures and classifies the report.
+#
+# Usage:
+#   scripts/things-crash-watch.sh            # watch crash reports + sync log
+#   scripts/things-crash-watch.sh --logonly  # only stream the sync log
+#   scripts/things-crash-watch.sh --scan     # classify existing crash reports and exit
+#
+set -euo pipefail
+
+REPORTS_DIR="$HOME/Library/Logs/DiagnosticReports"
+
+# Known crash sites from prior reverse-engineering (see docs/client-side-bugs.md
+# and the sync-decode analysis). A crash whose backtrace hits any of these is
+# the history-poisoning class this SDK is meant to prevent.
+SIGNATURES=(
+  "BSIdentifierFromBase58String"   # Base58 identifier decode — the leading-zero bug
+  "BSSyncValueEncoder"             # Base.framework value decode
+  "decodeToOneRelation"            # relation decode (heading st=0 crash)
+  "insertTaskWithUUID"             # task insert
+  "LegacySCHistoryPerformSync"     # Syncrony pull/apply
+)
+
+classify() {
+  local file="$1"
+  echo "── $(basename "$file") ($(stat -f '%Sm' "$file")) ──"
+  local hit=0
+  for sig in "${SIGNATURES[@]}"; do
+    if grep -q "$sig" "$file" 2>/dev/null; then
+      echo "  ⚠️  matches known sync-decode crash signature: $sig"
+      hit=1
+    fi
+  done
+  # Show the faulting frames regardless, for context.
+  echo "  Faulting frames:"
+  grep -Ei "Things|Base\.framework|Syncrony|ThingsCommon" "$file" 2>/dev/null | head -8 | sed 's/^/    /'
+  if [[ $hit -eq 1 ]]; then
+    echo "  VERDICT: history-poisoning crash class — inspect the last-written items."
+  else
+    echo "  VERDICT: crash does not match a known sync-decode signature (may be unrelated)."
+  fi
+  echo
+}
+
+things_reports() {
+  # macOS names reports Things3-*.ips (JSON) or Things-*.crash on older systems.
+  find "$REPORTS_DIR" -maxdepth 1 \( -iname 'Things*.ips' -o -iname 'Things*.crash' \) 2>/dev/null
+}
+
+if [[ "${1:-}" == "--scan" ]]; then
+  found=0
+  while IFS= read -r f; do [[ -n "$f" ]] && { classify "$f"; found=1; }; done < <(things_reports)
+  [[ $found -eq 0 ]] && echo "No existing Things crash reports in $REPORTS_DIR."
+  exit 0
+fi
+
+if [[ "${1:-}" != "--logonly" ]]; then
+  echo "Watching $REPORTS_DIR for new Things crash reports…"
+  # Baseline of existing reports so we only classify NEW ones.
+  BASELINE="$(things_reports | sort)"
+  (
+    while true; do
+      CURRENT="$(things_reports | sort)"
+      comm -13 <(printf '%s\n' "$BASELINE") <(printf '%s\n' "$CURRENT") | while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        echo; echo "🚨 NEW CRASH REPORT DETECTED"
+        sleep 1   # let the OS finish writing the file
+        classify "$f"
+      done
+      BASELINE="$CURRENT"
+      sleep 5
+    done
+  ) &
+  WATCH_PID=$!
+  trap 'kill $WATCH_PID 2>/dev/null || true' EXIT
+fi
+
+echo "Streaming Things sync log (Ctrl-C to stop)…"
+echo "Look for sync errors, decode failures, or the process dying mid-sync."
+exec log stream \
+  --style compact \
+  --predicate 'processImagePath CONTAINS "Things" AND (eventMessage CONTAINS[c] "sync" OR eventMessage CONTAINS[c] "decode" OR eventMessage CONTAINS[c] "history" OR eventMessage CONTAINS[c] "base58" OR category == "Syncrony")'

--- a/state/memory/area_inheritance_test.go
+++ b/state/memory/area_inheritance_test.go
@@ -1,0 +1,48 @@
+package memory
+
+import (
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// Tasks inside an area-less project have no area — directly or inherited —
+// and must appear in TasksWithoutArea. Tasks whose parent chain reaches an
+// area inherit it and must not. This exercises hasArea's parent recursion,
+// which was previously unreachable because parented tasks were skipped.
+func TestTasksWithoutArea_ParentChainInheritance(t *testing.T) {
+	state := NewState()
+	state.Areas["area-1"] = &things.Area{UUID: "area-1", Title: "Work"}
+
+	state.Tasks["proj-with-area"] = &things.Task{
+		UUID: "proj-with-area", Title: "Homed project", AreaIDs: []string{"area-1"},
+	}
+	state.Tasks["child-of-homed"] = &things.Task{
+		UUID: "child-of-homed", Title: "inherits area", ParentTaskIDs: []string{"proj-with-area"},
+	}
+
+	state.Tasks["proj-no-area"] = &things.Task{
+		UUID: "proj-no-area", Title: "Homeless project",
+	}
+	state.Tasks["child-of-homeless"] = &things.Task{
+		UUID: "child-of-homeless", Title: "no area anywhere", ParentTaskIDs: []string{"proj-no-area"},
+	}
+
+	got := map[string]bool{}
+	for _, task := range state.TasksWithoutArea() {
+		got[task.UUID] = true
+	}
+
+	if !got["proj-no-area"] {
+		t.Error("proj-no-area missing from TasksWithoutArea")
+	}
+	if !got["child-of-homeless"] {
+		t.Error("child-of-homeless missing from TasksWithoutArea — a task in an area-less project has no area")
+	}
+	if got["proj-with-area"] {
+		t.Error("proj-with-area listed despite having an area")
+	}
+	if got["child-of-homed"] {
+		t.Error("child-of-homed listed despite inheriting its parent's area")
+	}
+}

--- a/state/memory/coverage_test.go
+++ b/state/memory/coverage_test.go
@@ -1,0 +1,208 @@
+package memory
+
+import (
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// buildState returns a State populated with a small hierarchy used across the
+// query-method tests below. Records are inserted directly into the maps to keep
+// the fixtures explicit and independent of the Update() code path.
+func buildState() *State {
+	s := NewState()
+
+	s.Areas["area-work"] = &things.Area{UUID: "area-work", Title: "Work"}
+	s.Areas["area-home"] = &things.Area{UUID: "area-home", Title: "Home"}
+
+	s.Tasks["proj-1"] = &things.Task{UUID: "proj-1", Title: "Launch", Type: things.TaskTypeProject, AreaIDs: []string{"area-work"}}
+	s.Tasks["task-in-area"] = &things.Task{UUID: "task-in-area", Title: "In Area", Type: things.TaskTypeTask, AreaIDs: []string{"area-work"}, Index: 1}
+	s.Tasks["task-done"] = &things.Task{UUID: "task-done", Title: "Done", Type: things.TaskTypeTask, AreaIDs: []string{"area-work"}, Status: things.TaskStatusCompleted, Index: 2}
+	s.Tasks["task-trashed"] = &things.Task{UUID: "task-trashed", Title: "Trashed", Type: things.TaskTypeTask, AreaIDs: []string{"area-work"}, InTrash: true, Index: 3}
+
+	// Subtasks under proj-1
+	s.Tasks["sub-a"] = &things.Task{UUID: "sub-a", Title: "Sub A", Type: things.TaskTypeTask, ParentTaskIDs: []string{"proj-1"}, Index: 2}
+	s.Tasks["sub-b"] = &things.Task{UUID: "sub-b", Title: "Sub B", Type: things.TaskTypeTask, ParentTaskIDs: []string{"proj-1"}, Index: 1}
+
+	return s
+}
+
+func containsTask(tasks []*things.Task, uuid string) bool {
+	for _, t := range tasks {
+		if t.UUID == uuid {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProjects(t *testing.T) {
+	t.Parallel()
+	s := buildState()
+	projects := s.Projects()
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(projects))
+	}
+	if projects[0].UUID != "proj-1" {
+		t.Errorf("expected proj-1, got %q", projects[0].UUID)
+	}
+}
+
+func TestProjectByName(t *testing.T) {
+	t.Parallel()
+	s := buildState()
+
+	if p := s.ProjectByName("Launch"); p == nil || p.UUID != "proj-1" {
+		t.Errorf("expected to find project 'Launch', got %v", p)
+	}
+	if p := s.ProjectByName("Nonexistent"); p != nil {
+		t.Errorf("expected nil for unknown project, got %v", p)
+	}
+	// A non-project task with a matching title must not be returned.
+	if p := s.ProjectByName("In Area"); p != nil {
+		t.Errorf("expected nil when title matches a non-project task, got %v", p)
+	}
+}
+
+func TestAreaByName(t *testing.T) {
+	t.Parallel()
+	s := buildState()
+
+	if a := s.AreaByName("Work"); a == nil || a.UUID != "area-work" {
+		t.Errorf("expected to find area 'Work', got %v", a)
+	}
+	if a := s.AreaByName("Missing"); a != nil {
+		t.Errorf("expected nil for unknown area, got %v", a)
+	}
+}
+
+func TestSubtasks(t *testing.T) {
+	t.Parallel()
+	s := buildState()
+	root := s.Tasks["proj-1"]
+
+	subs := s.Subtasks(root, ListOption{})
+	if len(subs) != 2 {
+		t.Fatalf("expected 2 subtasks, got %d", len(subs))
+	}
+	// Sorted by Index ascending: sub-b (1) before sub-a (2).
+	if subs[0].UUID != "sub-b" || subs[1].UUID != "sub-a" {
+		t.Errorf("expected sub-b then sub-a, got %q then %q", subs[0].UUID, subs[1].UUID)
+	}
+}
+
+func TestSubtasksExcludesCompletedAndTrashed(t *testing.T) {
+	t.Parallel()
+	s := NewState()
+	root := &things.Task{UUID: "root", Title: "Root"}
+	s.Tasks["root"] = root
+	s.Tasks["child-open"] = &things.Task{UUID: "child-open", ParentTaskIDs: []string{"root"}, Index: 1}
+	s.Tasks["child-done"] = &things.Task{UUID: "child-done", ParentTaskIDs: []string{"root"}, Status: things.TaskStatusCompleted, Index: 2}
+	s.Tasks["child-trash"] = &things.Task{UUID: "child-trash", ParentTaskIDs: []string{"root"}, InTrash: true, Index: 3}
+
+	subs := s.Subtasks(root, ListOption{ExcludeCompleted: true, ExcludeInTrash: true})
+	if len(subs) != 1 || subs[0].UUID != "child-open" {
+		t.Errorf("expected only child-open, got %v", subs)
+	}
+}
+
+func TestTasksByArea(t *testing.T) {
+	t.Parallel()
+	s := buildState()
+	area := s.Areas["area-work"]
+
+	all := s.TasksByArea(area, ListOption{})
+	// proj-1, task-in-area, task-done, task-trashed all reference area-work.
+	if len(all) != 4 {
+		t.Fatalf("expected 4 tasks in area, got %d", len(all))
+	}
+
+	filtered := s.TasksByArea(area, ListOption{ExcludeCompleted: true, ExcludeInTrash: true})
+	if containsTask(filtered, "task-done") {
+		t.Error("completed task should be excluded")
+	}
+	if containsTask(filtered, "task-trashed") {
+		t.Error("trashed task should be excluded")
+	}
+	if !containsTask(filtered, "task-in-area") {
+		t.Error("open task should be included")
+	}
+
+	// An area with no tasks returns an empty slice.
+	empty := s.TasksByArea(s.Areas["area-home"], ListOption{})
+	if len(empty) != 0 {
+		t.Errorf("expected 0 tasks for area-home, got %d", len(empty))
+	}
+}
+
+func TestCheckListItemsByTask(t *testing.T) {
+	t.Parallel()
+	s := NewState()
+	task := &things.Task{UUID: "task-1", Title: "Has checklist"}
+	s.Tasks["task-1"] = task
+
+	s.CheckListItems["c1"] = &things.CheckListItem{UUID: "c1", Title: "Step 2", TaskIDs: []string{"task-1"}, Index: 2}
+	s.CheckListItems["c2"] = &things.CheckListItem{UUID: "c2", Title: "Step 1", TaskIDs: []string{"task-1"}, Index: 1}
+	s.CheckListItems["c3"] = &things.CheckListItem{UUID: "c3", Title: "Done step", TaskIDs: []string{"task-1"}, Status: things.TaskStatusCompleted, Index: 3}
+	s.CheckListItems["c4"] = &things.CheckListItem{UUID: "c4", Title: "Other", TaskIDs: []string{"other-task"}, Index: 0}
+
+	all := s.CheckListItemsByTask(task, ListOption{})
+	if len(all) != 3 {
+		t.Fatalf("expected 3 checklist items, got %d", len(all))
+	}
+	// Sorted by Index: c2 (1), c1 (2), c3 (3).
+	if all[0].UUID != "c2" || all[1].UUID != "c1" || all[2].UUID != "c3" {
+		t.Errorf("unexpected order: %q %q %q", all[0].UUID, all[1].UUID, all[2].UUID)
+	}
+
+	open := s.CheckListItemsByTask(task, ListOption{ExcludeCompleted: true})
+	for _, item := range open {
+		if item.UUID == "c3" {
+			t.Error("completed checklist item should be excluded")
+		}
+	}
+	if len(open) != 2 {
+		t.Errorf("expected 2 open items, got %d", len(open))
+	}
+}
+
+func TestSubTags(t *testing.T) {
+	t.Parallel()
+	s := NewState()
+	root := &things.Tag{UUID: "root-tag", Title: "Priority"}
+	s.Tags["root-tag"] = root
+	s.Tags["child-b"] = &things.Tag{UUID: "child-b", Title: "Low", ShortHand: "b", ParentTagIDs: []string{"root-tag"}}
+	s.Tags["child-a"] = &things.Tag{UUID: "child-a", Title: "High", ShortHand: "a", ParentTagIDs: []string{"root-tag"}}
+	s.Tags["unrelated"] = &things.Tag{UUID: "unrelated", Title: "Other", ShortHand: "z"}
+
+	children := s.SubTags(root)
+	if len(children) != 2 {
+		t.Fatalf("expected 2 child tags, got %d", len(children))
+	}
+	// Sorted by ShortHand ascending: child-a ("a") before child-b ("b").
+	if children[0].UUID != "child-a" || children[1].UUID != "child-b" {
+		t.Errorf("expected child-a then child-b, got %q then %q", children[0].UUID, children[1].UUID)
+	}
+}
+
+// TestHasAreaViaTasksWithoutArea exercises the recursive hasArea helper through
+// the public TasksWithoutArea query: a top-level task with an area is excluded,
+// while a top-level task with neither area nor parent is returned.
+func TestHasAreaViaTasksWithoutArea(t *testing.T) {
+	t.Parallel()
+	s := NewState()
+	s.Areas["area-1"] = &things.Area{UUID: "area-1", Title: "Work"}
+
+	// Top-level task directly assigned to an area -> hasArea true -> excluded.
+	s.Tasks["with-area"] = &things.Task{UUID: "with-area", Title: "With Area", AreaIDs: []string{"area-1"}, Index: 1}
+	// Top-level task with no area and no parent -> hasArea false -> included.
+	s.Tasks["loose"] = &things.Task{UUID: "loose", Title: "Loose", Index: 2}
+
+	result := s.TasksWithoutArea()
+	if !containsTask(result, "loose") {
+		t.Error("expected loose task without area to be returned")
+	}
+	if containsTask(result, "with-area") {
+		t.Error("task with an area should not be returned")
+	}
+}

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -339,14 +339,13 @@ func hasArea(task *things.Task, state *State) bool {
 	return false
 }
 
-// TasksWithoutArea looks up top level tasks not assigned to any area, e.g. just created and placed in today
+// TasksWithoutArea looks up tasks not assigned to any area, directly or
+// through their parent chain (a task in a project that lives in an area
+// inherits that area).
 func (s *State) TasksWithoutArea() []*things.Task {
 	tasks := []*things.Task{}
 	for _, task := range s.Tasks {
 		if task.Status == things.TaskStatusCompleted {
-			continue
-		}
-		if len(task.ParentTaskIDs) != 0 {
 			continue
 		}
 		if task.InTrash {

--- a/sync/chaos_test.go
+++ b/sync/chaos_test.go
@@ -1,0 +1,258 @@
+package sync
+
+import (
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// outerItem is one entry in the synthetic history's outer array.
+type outerItem struct {
+	uuid    string
+	kind    string
+	action  int
+	payload string
+}
+
+// buildSyntheticHistory returns a deterministic sequence of history items:
+// task creates followed by modifies and completes on those same tasks, so
+// replaying a committed batch would visibly duplicate change_log rows and
+// re-drive state transitions.
+func buildSyntheticHistory(nTasks int) []outerItem {
+	ids := make([]string, nTasks)
+	for i := range ids {
+		ids[i] = things.NewUUID()
+	}
+
+	var items []outerItem
+	for _, id := range ids {
+		items = append(items, outerItem{
+			uuid: id, kind: "Task6", action: 0,
+			payload: `{"tt":"task ` + id[:6] + `","tp":0,"st":1,"ss":0}`,
+		})
+	}
+	// Second pass: rename each task (modify) and complete every third one.
+	for i, id := range ids {
+		items = append(items, outerItem{
+			uuid: id, kind: "Task6", action: 1,
+			payload: `{"tt":"renamed ` + id[:6] + `"}`,
+		})
+		if i%3 == 0 {
+			items = append(items, outerItem{
+				uuid: id, kind: "Task6", action: 1,
+				payload: `{"ss":3}`,
+			})
+		}
+	}
+	return items
+}
+
+// chaosServer serves a synthetic history in fixed-size pages and can be
+// told to fail exactly once at a chosen start-index, simulating a server
+// error or a truncated response mid-sync.
+type chaosServer struct {
+	items     []outerItem
+	batchSize int
+	failAt    int    // start-index to fail at; -1 disables
+	failMode  string // "500" or "truncate"
+}
+
+func (cs *chaosServer) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if !strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprintf(w, `{"latest-server-index":%d,"latest-schema-version":301}`, len(cs.items))
+			return
+		}
+		start, _ := strconv.Atoi(r.URL.Query().Get("start-index"))
+		if cs.failAt >= 0 && start == cs.failAt {
+			switch cs.failMode {
+			case "500":
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			case "truncate":
+				fmt.Fprint(w, `{"items":[{"broken":`) // valid header, truncated body
+				return
+			}
+		}
+
+		end := start + cs.batchSize
+		if end > len(cs.items) {
+			end = len(cs.items)
+		}
+		var b strings.Builder
+		b.WriteString(`{"items":[`)
+		for i := start; i < end; i++ {
+			if i > start {
+				b.WriteByte(',')
+			}
+			it := cs.items[i]
+			fmt.Fprintf(&b, `{%q:{"e":%q,"t":%d,"p":%s}}`, it.uuid, it.kind, it.action, it.payload)
+		}
+		fmt.Fprintf(&b, `],"current-item-index":%d,"schema":301}`, len(cs.items))
+		fmt.Fprint(w, b.String())
+	}
+}
+
+func openSyncerFor(t *testing.T, cs *chaosServer, dbName string) (*Syncer, string, func()) {
+	server := httptest.NewServer(cs.handler(t))
+	client := things.New(server.URL, "test@example.com", "password")
+	dbPath := filepath.Join(t.TempDir(), dbName)
+	syncer, err := Open(dbPath, client)
+	if err != nil {
+		server.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	if err := syncer.saveSyncState("chaos-history", 0); err != nil {
+		server.Close()
+		syncer.Close()
+		t.Fatalf("saveSyncState: %v", err)
+	}
+	return syncer, dbPath, func() { syncer.Close(); server.Close() }
+}
+
+// changeLogFingerprint returns the sorted set of (server_index, entity_uuid,
+// change_type) tuples and flags any duplicate. Duplicates are the signature
+// of a replayed committed batch — exactly what the atomic-cursor fix prevents.
+func changeLogFingerprint(t *testing.T, dbPath string) (fingerprint string, duplicates int) {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db for inspection: %v", err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`SELECT server_index, entity_uuid, change_type, COUNT(*)
+		FROM change_log GROUP BY server_index, entity_uuid, change_type
+		ORDER BY server_index, entity_uuid, change_type`)
+	if err != nil {
+		t.Fatalf("query change_log: %v", err)
+	}
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var idx, count int
+		var uuid, ctype string
+		if err := rows.Scan(&idx, &uuid, &ctype, &count); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if count > 1 {
+			duplicates += count - 1
+		}
+		lines = append(lines, fmt.Sprintf("%d|%s|%s", idx, uuid, ctype))
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n"), duplicates
+}
+
+func taskStateFingerprint(t *testing.T, dbPath string) string {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	rows, err := db.Query(`SELECT uuid, title, status, deleted FROM tasks ORDER BY uuid`)
+	if err != nil {
+		t.Fatalf("query tasks: %v", err)
+	}
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var uuid, title string
+		var status, deleted int
+		if err := rows.Scan(&uuid, &title, &status, &deleted); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		lines = append(lines, fmt.Sprintf("%s|%s|%d|%d", uuid, title, status, deleted))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// TestChaos_MidSyncFailuresNeverCorrupt runs many trials, each injecting a
+// failure at a random batch boundary, then recovering. After recovery the
+// database must be byte-for-byte equivalent to a clean single-shot sync:
+// no duplicated change_log rows, identical final task state.
+func TestChaos_MidSyncFailuresNeverCorrupt(t *testing.T) {
+	t.Parallel()
+
+	history := buildSyntheticHistory(40) // ~93 items
+	batchSize := 5
+
+	// Reference: a clean sync with no faults.
+	refCS := &chaosServer{items: history, batchSize: batchSize, failAt: -1}
+	refSyncer, refDBPath, refClose := openSyncerFor(t, refCS, "ref.db")
+	if _, err := refSyncer.Sync(); err != nil {
+		refClose()
+		t.Fatalf("reference sync: %v", err)
+	}
+	refChanges, refDups := changeLogFingerprint(t, refDBPath)
+	refState := taskStateFingerprint(t, refDBPath)
+	if refDups != 0 {
+		refClose()
+		t.Fatalf("reference sync itself has %d duplicate change_log rows", refDups)
+	}
+	if refChanges == "" {
+		refClose()
+		t.Fatal("reference sync produced no changes — history did not apply")
+	}
+	refClose()
+
+	rng := rand.New(rand.NewSource(1))
+
+	for trial := 0; trial < 40; trial++ {
+		failAt := (rng.Intn(len(history)/batchSize-1) + 1) * batchSize // a non-zero batch boundary
+		// "truncate" is a non-retryable decode error that fails instantly,
+		// so the bulk of trials stay fast. One trial exercises the
+		// retry-then-exhaust path via a 500, which pays the real retry
+		// backoff (~14s) — skip it under -short.
+		mode := "truncate"
+		if trial == 0 && !testing.Short() {
+			mode = "500"
+		}
+
+		cs := &chaosServer{items: history, batchSize: batchSize, failAt: failAt, failMode: mode}
+		syncer, dbPath, closeFn := openSyncerFor(t, cs, fmt.Sprintf("trial%d.db", trial))
+
+		// First sync fails partway through.
+		if _, err := syncer.Sync(); err == nil {
+			closeFn()
+			t.Fatalf("trial %d (%s@%d): expected failure, got nil", trial, mode, failAt)
+		}
+		// Cursor must sit exactly at the last committed batch, never past
+		// the failed one.
+		if got := syncer.LastSyncedIndex(); got != failAt {
+			closeFn()
+			t.Fatalf("trial %d (%s@%d): cursor = %d, want %d (last committed batch)", trial, mode, failAt, got, failAt)
+		}
+
+		// Clear the fault and drive to completion.
+		cs.failAt = -1
+		if _, err := syncer.Sync(); err != nil {
+			closeFn()
+			t.Fatalf("trial %d recovery sync: %v", trial, err)
+		}
+
+		gotChanges, gotDups := changeLogFingerprint(t, dbPath)
+		gotState := taskStateFingerprint(t, dbPath)
+		closeFn()
+
+		if gotDups != 0 {
+			t.Errorf("trial %d (%s@%d): %d duplicate change_log rows after recovery", trial, mode, failAt, gotDups)
+		}
+		if gotChanges != refChanges {
+			t.Errorf("trial %d (%s@%d): change_log differs from clean sync", trial, mode, failAt)
+		}
+		if gotState != refState {
+			t.Errorf("trial %d (%s@%d): final task state differs from clean sync", trial, mode, failAt)
+		}
+	}
+}

--- a/sync/coverage_test.go
+++ b/sync/coverage_test.go
@@ -1,0 +1,521 @@
+package sync
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// TestChangeGetters constructs every Change implementation and verifies its
+// ChangeType/EntityType/EntityUUID getters. These are trivial accessors, so the
+// value is guarding against copy-paste mistakes in the string literals.
+func TestChangeGetters(t *testing.T) {
+	t.Parallel()
+
+	task := &things.Task{UUID: "task-1"}
+	project := &things.Task{UUID: "proj-1", Type: things.TaskTypeProject}
+	heading := &things.Task{UUID: "head-1", Type: things.TaskTypeHeading}
+	area := &things.Area{UUID: "area-1"}
+	tag := &things.Tag{UUID: "tag-1"}
+	item := &things.CheckListItem{UUID: "cli-1"}
+
+	tc := taskChange{Task: task}
+	pc := projectChange{Project: project}
+	hc := headingChange{Heading: heading}
+	ac := areaChange{Area: area}
+	tgc := tagChange{Tag: tag}
+	cic := checklistItemChange{Item: item}
+
+	cases := []struct {
+		change     Change
+		changeType string
+		entityType string
+		entityUUID string
+	}{
+		{TaskCreated{taskChange: tc}, "TaskCreated", "Task", "task-1"},
+		{TaskDeleted{taskChange: tc}, "TaskDeleted", "Task", "task-1"},
+		{TaskCompleted{taskChange: tc}, "TaskCompleted", "Task", "task-1"},
+		{TaskUncompleted{taskChange: tc}, "TaskUncompleted", "Task", "task-1"},
+		{TaskCanceled{taskChange: tc}, "TaskCanceled", "Task", "task-1"},
+		{TaskTitleChanged{taskChange: tc}, "TaskTitleChanged", "Task", "task-1"},
+		{TaskNoteChanged{taskChange: tc}, "TaskNoteChanged", "Task", "task-1"},
+		{TaskMovedToInbox{taskChange: tc}, "TaskMovedToInbox", "Task", "task-1"},
+		{TaskMovedToToday{taskChange: tc}, "TaskMovedToToday", "Task", "task-1"},
+		{TaskMovedToAnytime{taskChange: tc}, "TaskMovedToAnytime", "Task", "task-1"},
+		{TaskMovedToSomeday{taskChange: tc}, "TaskMovedToSomeday", "Task", "task-1"},
+		{TaskMovedToUpcoming{taskChange: tc}, "TaskMovedToUpcoming", "Task", "task-1"},
+		{TaskDeadlineChanged{taskChange: tc}, "TaskDeadlineChanged", "Task", "task-1"},
+		{TaskAssignedToProject{taskChange: tc}, "TaskAssignedToProject", "Task", "task-1"},
+		{TaskAssignedToArea{taskChange: tc}, "TaskAssignedToArea", "Task", "task-1"},
+		{TaskTrashed{taskChange: tc}, "TaskTrashed", "Task", "task-1"},
+		{TaskRestored{taskChange: tc}, "TaskRestored", "Task", "task-1"},
+		{TaskTagsChanged{taskChange: tc}, "TaskTagsChanged", "Task", "task-1"},
+
+		{ProjectCreated{projectChange: pc}, "ProjectCreated", "Project", "proj-1"},
+		{ProjectDeleted{projectChange: pc}, "ProjectDeleted", "Project", "proj-1"},
+		{ProjectCompleted{projectChange: pc}, "ProjectCompleted", "Project", "proj-1"},
+		{ProjectTitleChanged{projectChange: pc}, "ProjectTitleChanged", "Project", "proj-1"},
+		{ProjectTrashed{projectChange: pc}, "ProjectTrashed", "Project", "proj-1"},
+		{ProjectRestored{projectChange: pc}, "ProjectRestored", "Project", "proj-1"},
+
+		{HeadingCreated{headingChange: hc}, "HeadingCreated", "Heading", "head-1"},
+		{HeadingDeleted{headingChange: hc}, "HeadingDeleted", "Heading", "head-1"},
+		{HeadingTitleChanged{headingChange: hc}, "HeadingTitleChanged", "Heading", "head-1"},
+
+		{AreaCreated{areaChange: ac}, "AreaCreated", "Area", "area-1"},
+		{AreaDeleted{areaChange: ac}, "AreaDeleted", "Area", "area-1"},
+		{AreaRenamed{areaChange: ac}, "AreaRenamed", "Area", "area-1"},
+
+		{TagCreated{tagChange: tgc}, "TagCreated", "Tag", "tag-1"},
+		{TagDeleted{tagChange: tgc}, "TagDeleted", "Tag", "tag-1"},
+		{TagRenamed{tagChange: tgc}, "TagRenamed", "Tag", "tag-1"},
+		{TagShortcutChanged{tagChange: tgc}, "TagShortcutChanged", "Tag", "tag-1"},
+
+		{ChecklistItemCreated{checklistItemChange: cic}, "ChecklistItemCreated", "ChecklistItem", "cli-1"},
+		{ChecklistItemDeleted{checklistItemChange: cic}, "ChecklistItemDeleted", "ChecklistItem", "cli-1"},
+		{ChecklistItemCompleted{checklistItemChange: cic}, "ChecklistItemCompleted", "ChecklistItem", "cli-1"},
+		{ChecklistItemUncompleted{checklistItemChange: cic}, "ChecklistItemUncompleted", "ChecklistItem", "cli-1"},
+		{ChecklistItemTitleChanged{checklistItemChange: cic}, "ChecklistItemTitleChanged", "ChecklistItem", "cli-1"},
+
+		{UnknownChange{entityType: "Weird", entityUUID: "u-1"}, "UnknownChange", "Weird", "u-1"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.changeType, func(t *testing.T) {
+			t.Parallel()
+			if got := c.change.ChangeType(); got != c.changeType {
+				t.Errorf("ChangeType() = %q, want %q", got, c.changeType)
+			}
+			if got := c.change.EntityType(); got != c.entityType {
+				t.Errorf("EntityType() = %q, want %q", got, c.entityType)
+			}
+			if got := c.change.EntityUUID(); got != c.entityUUID {
+				t.Errorf("EntityUUID() = %q, want %q", got, c.entityUUID)
+			}
+		})
+	}
+}
+
+// TestChangeEntityUUIDNilEntity checks the nil-guard branches in the embedded
+// EntityUUID accessors.
+func TestChangeEntityUUIDNilEntity(t *testing.T) {
+	t.Parallel()
+
+	if got := (TaskCreated{}).EntityUUID(); got != "" {
+		t.Errorf("nil task EntityUUID() = %q, want empty", got)
+	}
+	if got := (ProjectCreated{}).EntityUUID(); got != "" {
+		t.Errorf("nil project EntityUUID() = %q, want empty", got)
+	}
+	if got := (HeadingCreated{}).EntityUUID(); got != "" {
+		t.Errorf("nil heading EntityUUID() = %q, want empty", got)
+	}
+	if got := (AreaCreated{}).EntityUUID(); got != "" {
+		t.Errorf("nil area EntityUUID() = %q, want empty", got)
+	}
+	if got := (TagCreated{}).EntityUUID(); got != "" {
+		t.Errorf("nil tag EntityUUID() = %q, want empty", got)
+	}
+	if got := (ChecklistItemCreated{}).EntityUUID(); got != "" {
+		t.Errorf("nil checklist item EntityUUID() = %q, want empty", got)
+	}
+}
+
+// TestLoggedChangeGetters covers the LoggedChange accessors, including Payload.
+func TestLoggedChangeGetters(t *testing.T) {
+	t.Parallel()
+	lc := LoggedChange{
+		changeType: "TaskCreated",
+		entityType: "Task",
+		entityUUID: "task-1",
+		payload:    `{"tt":"hi"}`,
+	}
+	if lc.ChangeType() != "TaskCreated" {
+		t.Errorf("ChangeType() = %q", lc.ChangeType())
+	}
+	if lc.EntityType() != "Task" {
+		t.Errorf("EntityType() = %q", lc.EntityType())
+	}
+	if lc.EntityUUID() != "task-1" {
+		t.Errorf("EntityUUID() = %q", lc.EntityUUID())
+	}
+	if lc.Payload() != `{"tt":"hi"}` {
+		t.Errorf("Payload() = %q", lc.Payload())
+	}
+}
+
+func TestStateAccessors(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	syncer, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	syncer.saveArea(&things.Area{UUID: "area-1", Title: "Work"})
+	syncer.saveTag(&things.Tag{UUID: "tag-1", Title: "Urgent", ShortHand: "u"})
+	syncer.saveTag(&things.Tag{UUID: "tag-2", Title: "Later", ShortHand: "l"})
+
+	state := syncer.State()
+
+	t.Run("Area", func(t *testing.T) {
+		area, err := state.Area("area-1")
+		if err != nil {
+			t.Fatalf("Area failed: %v", err)
+		}
+		if area == nil || area.Title != "Work" {
+			t.Errorf("expected area 'Work', got %v", area)
+		}
+	})
+
+	t.Run("Tag", func(t *testing.T) {
+		tag, err := state.Tag("tag-1")
+		if err != nil {
+			t.Fatalf("Tag failed: %v", err)
+		}
+		if tag == nil || tag.Title != "Urgent" {
+			t.Errorf("expected tag 'Urgent', got %v", tag)
+		}
+	})
+
+	t.Run("AllTags", func(t *testing.T) {
+		tags, err := state.AllTags()
+		if err != nil {
+			t.Fatalf("AllTags failed: %v", err)
+		}
+		if len(tags) != 2 {
+			t.Errorf("expected 2 tags, got %d", len(tags))
+		}
+	})
+}
+
+func TestStateProjectAreaAndChecklistQueries(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	syncer, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	syncer.saveTask(&things.Task{UUID: "proj-1", Title: "Project", Type: things.TaskTypeProject})
+	syncer.saveTask(&things.Task{UUID: "in-project", Title: "In Project", Type: things.TaskTypeTask, ParentTaskIDs: []string{"proj-1"}, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "in-area", Title: "In Area", Type: things.TaskTypeTask, AreaIDs: []string{"area-1"}, Status: things.TaskStatusPending})
+	syncer.saveChecklistItem(&things.CheckListItem{UUID: "cli-1", Title: "Step 1", Index: 0, TaskIDs: []string{"in-project"}})
+	syncer.saveChecklistItem(&things.CheckListItem{UUID: "cli-2", Title: "Step 2", Index: 1, TaskIDs: []string{"in-project"}})
+
+	state := syncer.State()
+
+	t.Run("TasksInProject", func(t *testing.T) {
+		tasks, err := state.TasksInProject("proj-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInProject failed: %v", err)
+		}
+		if len(tasks) != 1 || tasks[0].UUID != "in-project" {
+			t.Errorf("expected [in-project], got %v", tasks)
+		}
+	})
+
+	t.Run("TasksInArea", func(t *testing.T) {
+		tasks, err := state.TasksInArea("area-1", QueryOpts{})
+		if err != nil {
+			t.Fatalf("TasksInArea failed: %v", err)
+		}
+		if len(tasks) != 1 || tasks[0].UUID != "in-area" {
+			t.Errorf("expected [in-area], got %v", tasks)
+		}
+	})
+
+	t.Run("ChecklistItems", func(t *testing.T) {
+		items, err := state.ChecklistItems("in-project")
+		if err != nil {
+			t.Fatalf("ChecklistItems failed: %v", err)
+		}
+		if len(items) != 2 {
+			t.Fatalf("expected 2 checklist items, got %d", len(items))
+		}
+		if items[0].UUID != "cli-1" || items[1].UUID != "cli-2" {
+			t.Errorf("unexpected order: %q %q", items[0].UUID, items[1].UUID)
+		}
+		if len(items[0].TaskIDs) != 1 || items[0].TaskIDs[0] != "in-project" {
+			t.Errorf("expected TaskIDs to be set to parent, got %v", items[0].TaskIDs)
+		}
+	})
+}
+
+// TestSearchTasksEscapesLikeWildcards verifies that LIKE metacharacters in the
+// query are escaped rather than treated as wildcards.
+func TestSearchTasksEscapesLikeWildcards(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	syncer, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	opts := QueryOpts{}
+	syncer.saveTask(&things.Task{UUID: "pct", Title: "50% off", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+	syncer.saveTask(&things.Task{UUID: "other", Title: "nothing special", Schedule: things.TaskScheduleAnytime, Status: things.TaskStatusPending})
+
+	state := syncer.State()
+
+	// A bare "%" must not match every task; it should be treated literally.
+	tasks, err := state.SearchTasks("%", opts)
+	if err != nil {
+		t.Fatalf("SearchTasks failed: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].UUID != "pct" {
+		t.Errorf("expected only the literal '%%' match, got %v", tasks)
+	}
+
+	// Blank query returns an empty (non-nil) slice.
+	empty, err := state.SearchTasks("   ", opts)
+	if err != nil {
+		t.Fatalf("SearchTasks failed: %v", err)
+	}
+	if empty == nil || len(empty) != 0 {
+		t.Errorf("expected empty non-nil slice, got %v", empty)
+	}
+}
+
+// TestProcessTagChecklistTombstone drives processItems through the tag,
+// checklist, and tombstone code paths.
+func TestProcessTagChecklistTombstone(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	syncer, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	t.Run("tag create then delete", func(t *testing.T) {
+		title := "Urgent"
+		shorthand := "u"
+		p, _ := json.Marshal(things.TagActionItemPayload{Title: &title, ShortHand: &shorthand})
+		changes, err := syncer.processItems([]things.Item{{
+			UUID: "tag-x", Kind: things.ItemKindTag, Action: things.ItemActionCreated, P: p,
+		}}, 0)
+		if err != nil {
+			t.Fatalf("processItems (tag create) failed: %v", err)
+		}
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change, got %d", len(changes))
+		}
+		if _, ok := changes[0].(TagCreated); !ok {
+			t.Errorf("expected TagCreated, got %T", changes[0])
+		}
+
+		delChanges, err := syncer.processItems([]things.Item{{
+			UUID: "tag-x", Kind: things.ItemKindTag, Action: things.ItemActionDeleted, P: json.RawMessage(`{}`),
+		}}, 1)
+		if err != nil {
+			t.Fatalf("processItems (tag delete) failed: %v", err)
+		}
+		if len(delChanges) != 1 {
+			t.Fatalf("expected 1 delete change, got %d", len(delChanges))
+		}
+		if _, ok := delChanges[0].(TagDeleted); !ok {
+			t.Errorf("expected TagDeleted, got %T", delChanges[0])
+		}
+	})
+
+	t.Run("checklist item create and delete", func(t *testing.T) {
+		syncer.saveTask(&things.Task{UUID: "parent-task", Title: "Parent"})
+		title := "A step"
+		p, _ := json.Marshal(things.CheckListActionItemPayload{Title: &title, TaskIDs: &[]string{"parent-task"}})
+		changes, err := syncer.processItems([]things.Item{{
+			UUID: "cli-x", Kind: things.ItemKindChecklistItem, Action: things.ItemActionCreated, P: p,
+		}}, 2)
+		if err != nil {
+			t.Fatalf("processItems (checklist create) failed: %v", err)
+		}
+		created, ok := changes[0].(ChecklistItemCreated)
+		if !ok {
+			t.Fatalf("expected ChecklistItemCreated, got %T", changes[0])
+		}
+		if created.Task == nil || created.Task.UUID != "parent-task" {
+			t.Error("expected parent task to be resolved on the change")
+		}
+
+		delChanges, err := syncer.processItems([]things.Item{{
+			UUID: "cli-x", Kind: things.ItemKindChecklistItem, Action: things.ItemActionDeleted, P: json.RawMessage(`{}`),
+		}}, 3)
+		if err != nil {
+			t.Fatalf("processItems (checklist delete) failed: %v", err)
+		}
+		if _, ok := delChanges[0].(ChecklistItemDeleted); !ok {
+			t.Errorf("expected ChecklistItemDeleted, got %T", delChanges[0])
+		}
+	})
+
+	t.Run("tombstone deletes a task", func(t *testing.T) {
+		syncer.saveTask(&things.Task{UUID: "doomed", Title: "Doomed Task"})
+		p, _ := json.Marshal(things.TombstoneActionItemPayload{DeletedObjectID: "doomed"})
+		changes, err := syncer.processItems([]things.Item{{
+			UUID: "tomb-1", Kind: things.ItemKindTombstone, Action: things.ItemActionCreated, P: p,
+		}}, 4)
+		if err != nil {
+			t.Fatalf("processItems (tombstone) failed: %v", err)
+		}
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change, got %d", len(changes))
+		}
+		if _, ok := changes[0].(TaskDeleted); !ok {
+			t.Errorf("expected TaskDeleted, got %T", changes[0])
+		}
+		task, _ := syncer.State().Task("doomed")
+		if task != nil {
+			t.Error("expected task to be soft-deleted after tombstone")
+		}
+	})
+
+	t.Run("tombstone for unknown object is a no-op", func(t *testing.T) {
+		p, _ := json.Marshal(things.TombstoneActionItemPayload{DeletedObjectID: "never-existed"})
+		changes, err := syncer.processItems([]things.Item{{
+			UUID: "tomb-2", Kind: things.ItemKindTombstone, Action: things.ItemActionCreated, P: p,
+		}}, 5)
+		if err != nil {
+			t.Fatalf("processItems (unknown tombstone) failed: %v", err)
+		}
+		if len(changes) != 0 {
+			t.Errorf("expected no changes for unknown tombstone, got %d", len(changes))
+		}
+	})
+}
+
+// TestProcessNotePayloads covers parseNotePayload for plain-string, full-text,
+// and delta note representations.
+func TestProcessNotePayloads(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain string note", func(t *testing.T) {
+		t.Parallel()
+		got := parseNotePayload("old", json.RawMessage(`"a plain note"`))
+		if got != "a plain note" {
+			t.Errorf("expected plain string note, got %q", got)
+		}
+	})
+
+	t.Run("full text note", func(t *testing.T) {
+		t.Parallel()
+		raw, _ := json.Marshal(things.Note{Type: things.NoteTypeFullText, Value: "full replacement"})
+		got := parseNotePayload("old", raw)
+		if got != "full replacement" {
+			t.Errorf("expected full-text replacement, got %q", got)
+		}
+	})
+
+	t.Run("delta note applies patches", func(t *testing.T) {
+		t.Parallel()
+		raw, _ := json.Marshal(things.Note{
+			Type:    things.NoteTypeDelta,
+			Patches: []things.NotePatch{{Position: 0, Length: 0, Replacement: "Hi "}},
+		})
+		got := parseNotePayload("there", raw)
+		if got != "Hi there" {
+			t.Errorf("expected patched note 'Hi there', got %q", got)
+		}
+	})
+
+	t.Run("invalid note keeps current value", func(t *testing.T) {
+		t.Parallel()
+		got := parseNotePayload("unchanged", json.RawMessage(`12345`))
+		if got != "unchanged" {
+			t.Errorf("expected current note preserved, got %q", got)
+		}
+	})
+
+	t.Run("note delivered through processItems", func(t *testing.T) {
+		t.Parallel()
+		dbPath := filepath.Join(t.TempDir(), "test.db")
+		syncer, err := Open(dbPath, nil)
+		if err != nil {
+			t.Fatalf("Open failed: %v", err)
+		}
+		defer syncer.Close()
+
+		title := "Task with note"
+		tp := things.TaskTypeTask
+		note := json.RawMessage(`"initial note"`)
+		p, _ := json.Marshal(things.TaskActionItemPayload{Title: &title, Type: &tp, Note: note})
+		if _, err := syncer.processItems([]things.Item{{
+			UUID: "note-task", Kind: things.ItemKindTask, Action: things.ItemActionCreated, P: p,
+		}}, 0); err != nil {
+			t.Fatalf("processItems failed: %v", err)
+		}
+
+		task, _ := syncer.State().Task("note-task")
+		if task == nil || task.Note != "initial note" {
+			t.Errorf("expected note 'initial note', got %v", task)
+		}
+	})
+}
+
+// TestChangesSinceAndForEntity exercises the timestamp- and entity-scoped
+// change-log queries.
+func TestChangesSinceAndForEntity(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	syncer, err := Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	title := "Logged task"
+	tp := things.TaskTypeTask
+	p, _ := json.Marshal(things.TaskActionItemPayload{Title: &title, Type: &tp})
+	if _, err := syncer.processItems([]things.Item{{
+		UUID: "logged-1", Kind: things.ItemKindTask, Action: things.ItemActionCreated, P: p,
+	}}, 0); err != nil {
+		t.Fatalf("processItems failed: %v", err)
+	}
+
+	t.Run("ChangesSince returns recent entries", func(t *testing.T) {
+		changes, err := syncer.ChangesSince(time.Unix(0, 0))
+		if err != nil {
+			t.Fatalf("ChangesSince failed: %v", err)
+		}
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change since epoch, got %d", len(changes))
+		}
+		if changes[0].EntityUUID() != "logged-1" {
+			t.Errorf("expected entity logged-1, got %q", changes[0].EntityUUID())
+		}
+	})
+
+	t.Run("ChangesSince excludes future window", func(t *testing.T) {
+		changes, err := syncer.ChangesSince(time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("ChangesSince failed: %v", err)
+		}
+		if len(changes) != 0 {
+			t.Errorf("expected 0 changes in future window, got %d", len(changes))
+		}
+	})
+
+	t.Run("ChangesForEntity filters by UUID", func(t *testing.T) {
+		changes, err := syncer.ChangesForEntity("logged-1")
+		if err != nil {
+			t.Fatalf("ChangesForEntity failed: %v", err)
+		}
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 change for logged-1, got %d", len(changes))
+		}
+
+		none, err := syncer.ChangesForEntity("no-such-entity")
+		if err != nil {
+			t.Fatalf("ChangesForEntity failed: %v", err)
+		}
+		if len(none) != 0 {
+			t.Errorf("expected 0 changes for unknown entity, got %d", len(none))
+		}
+	})
+}

--- a/syncutil/dailysummary_tz_test.go
+++ b/syncutil/dailysummary_tz_test.go
@@ -54,3 +54,16 @@ func TestBuildDailySummary_LocalMidnightBoundary(t *testing.T) {
 		t.Errorf("Completed = %d, want 1 — yesterday's local-evening change must not count toward today", summary.Completed)
 	}
 }
+
+func TestStartOfToday_LocalMidnight(t *testing.T) {
+	zone := time.FixedZone("UTC+10", 10*3600)
+	orig := timeNow
+	timeNow = func() time.Time { return time.Date(2026, 7, 6, 1, 0, 0, 0, zone) }
+	defer func() { timeNow = orig }()
+
+	got := StartOfToday()
+	want := time.Date(2026, 7, 6, 0, 0, 0, 0, zone)
+	if !got.Equal(want) {
+		t.Errorf("StartOfToday() = %v, want %v (local midnight)", got, want)
+	}
+}

--- a/syncutil/dailysummary_tz_test.go
+++ b/syncutil/dailysummary_tz_test.go
@@ -1,0 +1,56 @@
+package syncutil
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arthursoares/things-cloud-sdk/sync"
+	_ "modernc.org/sqlite"
+)
+
+// BuildDailySummary's "today" must start at LOCAL midnight, not UTC
+// midnight. Fixed scenario: now = 01:00 on Jul 6 in UTC+10.
+//   - local midnight = Jul 5 14:00 UTC
+//   - UTC truncation would give Jul 5 00:00 UTC
+//
+// A change at Jul 5 10:00 UTC (= Jul 5 20:00 local — YESTERDAY evening)
+// sits between the two cutoffs: the buggy UTC truncation counts it,
+// local-midnight semantics must not.
+func TestBuildDailySummary_LocalMidnightBoundary(t *testing.T) {
+	zone := time.FixedZone("UTC+10", 10*3600)
+	now := time.Date(2026, 7, 6, 1, 0, 0, 0, zone)
+	orig := timeNow
+	timeNow = func() time.Time { return now }
+	defer func() { timeNow = orig }()
+
+	dbPath := filepath.Join(t.TempDir(), "tz.db")
+	syncer, err := sync.Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer syncer.Close()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	insert := func(syncedAt time.Time, changeType string) {
+		if _, err := db.Exec(`INSERT INTO change_log (server_index, synced_at, change_type, entity_type, entity_uuid, payload)
+			VALUES (1, ?, ?, 'Task', 'u1', '{}')`, syncedAt.Unix(), changeType); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	yesterdayLocalEvening := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC) // Jul 5 20:00 local
+	todayLocalMorning := time.Date(2026, 7, 5, 14, 30, 0, 0, time.UTC)    // Jul 6 00:30 local
+	insert(yesterdayLocalEvening, "TaskCompleted")
+	insert(todayLocalMorning, "TaskCompleted")
+
+	summary := BuildDailySummary(syncer)
+	if summary.Completed != 1 {
+		t.Errorf("Completed = %d, want 1 — yesterday's local-evening change must not count toward today", summary.Completed)
+	}
+}

--- a/syncutil/syncutil.go
+++ b/syncutil/syncutil.go
@@ -70,8 +70,14 @@ type DailySummary struct {
 }
 
 // BuildDailySummary calculates activity stats from today's changes.
+// timeNow is a test seam.
+var timeNow = time.Now
+
 func BuildDailySummary(syncer *sync.Syncer) DailySummary {
-	today := time.Now().Truncate(24 * time.Hour)
+	// Local midnight — Truncate would give midnight UTC and count part of
+	// yesterday (or miss part of today) in any other timezone.
+	now := timeNow()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	changes, _ := syncer.ChangesSince(today)
 
 	summary := DailySummary{}

--- a/syncutil/syncutil.go
+++ b/syncutil/syncutil.go
@@ -73,11 +73,16 @@ type DailySummary struct {
 // timeNow is a test seam.
 var timeNow = time.Now
 
-func BuildDailySummary(syncer *sync.Syncer) DailySummary {
-	// Local midnight — Truncate would give midnight UTC and count part of
-	// yesterday (or miss part of today) in any other timezone.
+// StartOfToday returns local midnight of the current day. Use this for any
+// "today" cutoff — time.Now().Truncate(24h) is midnight UTC and counts part
+// of yesterday (or misses part of today) in every other timezone.
+func StartOfToday() time.Time {
 	now := timeNow()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+}
+
+func BuildDailySummary(syncer *sync.Syncer) DailySummary {
+	today := StartOfToday()
 	changes, _ := syncer.ChangesSince(today)
 
 	summary := DailySummary{}

--- a/syncutil/syncutil_test.go
+++ b/syncutil/syncutil_test.go
@@ -1,0 +1,362 @@
+package syncutil
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+	"github.com/arthursoares/things-cloud-sdk/sync"
+	_ "modernc.org/sqlite"
+)
+
+// fakeChange is a minimal sync.Change implementation used to drive the
+// change-list helpers with fully controlled ChangeType and Timestamp values.
+// The real sync.Change types embed unexported timestamp fields that cannot be
+// set from outside the sync package, so a stub is required to exercise
+// timestamp-dependent logic like DaysSinceCreated.
+type fakeChange struct {
+	changeType string
+	timestamp  time.Time
+}
+
+func (f fakeChange) ChangeType() string   { return f.changeType }
+func (f fakeChange) EntityType() string   { return "Task" }
+func (f fakeChange) EntityUUID() string   { return "" }
+func (f fakeChange) ServerIndex() int     { return 0 }
+func (f fakeChange) Timestamp() time.Time { return f.timestamp }
+
+// changes builds a []sync.Change from a list of change-type strings.
+func changes(types ...string) []sync.Change {
+	result := make([]sync.Change, 0, len(types))
+	for _, t := range types {
+		result = append(result, fakeChange{changeType: t})
+	}
+	return result
+}
+
+func TestFilterChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      []sync.Change
+		changeType string
+		want       int
+	}{
+		{"nil input", nil, "TaskCreated", 0},
+		{"empty input", changes(), "TaskCreated", 0},
+		{
+			name:       "single match",
+			input:      changes("TaskCreated", "TaskCompleted"),
+			changeType: "TaskCreated",
+			want:       1,
+		},
+		{
+			name:       "multiple matches",
+			input:      changes("TaskCreated", "TaskCreated", "TaskCompleted"),
+			changeType: "TaskCreated",
+			want:       2,
+		},
+		{
+			name:       "no match",
+			input:      changes("TaskCreated", "TaskCompleted"),
+			changeType: "TaskDeleted",
+			want:       0,
+		},
+		{
+			name:       "exact match not prefix",
+			input:      changes("TaskMovedToToday", "TaskMovedToInbox"),
+			changeType: "TaskMovedTo",
+			want:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FilterChanges(tt.input, tt.changeType)
+			if len(got) != tt.want {
+				t.Errorf("FilterChanges() returned %d changes, want %d", len(got), tt.want)
+			}
+			for _, c := range got {
+				if c.ChangeType() != tt.changeType {
+					t.Errorf("FilterChanges() returned change of type %q, want %q", c.ChangeType(), tt.changeType)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterChangesPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []sync.Change
+		prefix string
+		want   int
+	}{
+		{"nil input", nil, "Task", 0},
+		{"empty input", changes(), "Task", 0},
+		{
+			name:   "prefix matches several",
+			input:  changes("TaskMovedToToday", "TaskMovedToInbox", "TaskCreated"),
+			prefix: "TaskMovedTo",
+			want:   2,
+		},
+		{
+			name:   "prefix matches all",
+			input:  changes("TaskCreated", "TaskCompleted"),
+			prefix: "Task",
+			want:   2,
+		},
+		{
+			name:   "empty prefix matches all",
+			input:  changes("TaskCreated", "AreaCreated"),
+			prefix: "",
+			want:   2,
+		},
+		{
+			name:   "no match",
+			input:  changes("AreaCreated", "TagCreated"),
+			prefix: "Task",
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FilterChangesPrefix(tt.input, tt.prefix)
+			if len(got) != tt.want {
+				t.Errorf("FilterChangesPrefix() returned %d changes, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestDaysSinceCreated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []sync.Change
+		want  int
+	}{
+		{"nil input", nil, 0},
+		{"empty input", changes(), 0},
+		{
+			name:  "no TaskCreated change",
+			input: changes("TaskCompleted", "TaskMovedToToday"),
+			want:  0,
+		},
+		{
+			name: "created three days ago",
+			input: []sync.Change{
+				fakeChange{changeType: "TaskCreated", timestamp: time.Now().Add(-72 * time.Hour)},
+			},
+			want: 3,
+		},
+		{
+			name: "created just now rounds to zero days",
+			input: []sync.Change{
+				fakeChange{changeType: "TaskCreated", timestamp: time.Now()},
+			},
+			want: 0,
+		},
+		{
+			name: "uses first TaskCreated encountered",
+			input: []sync.Change{
+				fakeChange{changeType: "TaskCompleted", timestamp: time.Now()},
+				fakeChange{changeType: "TaskCreated", timestamp: time.Now().Add(-48 * time.Hour)},
+				fakeChange{changeType: "TaskCreated", timestamp: time.Now().Add(-240 * time.Hour)},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DaysSinceCreated(tt.input)
+			if got != tt.want {
+				t.Errorf("DaysSinceCreated() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountMoves(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []sync.Change
+		want  int
+	}{
+		{"nil input", nil, 0},
+		{"empty input", changes(), 0},
+		{
+			name:  "no moves",
+			input: changes("TaskCreated", "TaskCompleted"),
+			want:  0,
+		},
+		{
+			name:  "counts all TaskMovedTo variants",
+			input: changes("TaskMovedToToday", "TaskMovedToInbox", "TaskMovedToUpcoming", "TaskMovedToSomeday", "TaskMovedToAnytime"),
+			want:  5,
+		},
+		{
+			name:  "ignores non-move changes",
+			input: changes("TaskMovedToToday", "TaskCreated", "TaskMovedToInbox"),
+			want:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CountMoves(tt.input)
+			if got != tt.want {
+				t.Errorf("CountMoves() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskAge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		task *things.Task
+		want int
+	}{
+		{
+			name: "zero creation date",
+			task: &things.Task{},
+			want: 0,
+		},
+		{
+			name: "created two days ago",
+			task: &things.Task{CreationDate: time.Now().Add(-48 * time.Hour)},
+			want: 2,
+		},
+		{
+			name: "created just now",
+			task: &things.Task{CreationDate: time.Now()},
+			want: 0,
+		},
+		{
+			name: "created ten days ago",
+			task: &things.Task{CreationDate: time.Now().Add(-240 * time.Hour)},
+			want: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TaskAge(tt.task)
+			if got != tt.want {
+				t.Errorf("TaskAge() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// newTestSyncer opens a real SQLite-backed Syncer (migrating the schema) and
+// returns it alongside a raw connection to the same database file so tests can
+// seed the change_log directly.
+func newTestSyncer(t *testing.T) (*sync.Syncer, *sql.DB) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "sync.db")
+	syncer, err := sync.Open(dbPath, nil)
+	if err != nil {
+		t.Fatalf("sync.Open() error: %v", err)
+	}
+	t.Cleanup(func() { syncer.Close() })
+
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error: %v", err)
+	}
+	t.Cleanup(func() { raw.Close() })
+
+	return syncer, raw
+}
+
+func insertChange(t *testing.T, db *sql.DB, changeType string, syncedAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO change_log (server_index, synced_at, change_type, entity_type, entity_uuid, payload) VALUES (?, ?, ?, ?, ?, ?)`,
+		0, syncedAt.Unix(), changeType, "Task", "uuid", nil,
+	)
+	if err != nil {
+		t.Fatalf("insert change_log row: %v", err)
+	}
+}
+
+func TestBuildDailySummary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty change log", func(t *testing.T) {
+		t.Parallel()
+		syncer, _ := newTestSyncer(t)
+		got := BuildDailySummary(syncer)
+		if (got != DailySummary{}) {
+			t.Errorf("BuildDailySummary() = %+v, want zero summary", got)
+		}
+	})
+
+	t.Run("counts today's activity by category", func(t *testing.T) {
+		t.Parallel()
+		syncer, raw := newTestSyncer(t)
+
+		// today's changes (synced_at is well after today's UTC midnight)
+		now := time.Now()
+		insertChange(t, raw, "TaskCompleted", now)
+		insertChange(t, raw, "TaskCompleted", now)
+		insertChange(t, raw, "TaskCreated", now)
+		insertChange(t, raw, "TaskMovedToToday", now)
+		insertChange(t, raw, "TaskMovedToUpcoming", now) // rescheduled
+		insertChange(t, raw, "TaskMovedToSomeday", now)  // rescheduled
+		insertChange(t, raw, "TaskMovedToInbox", now)    // rescheduled
+
+		// a change from many days ago that must be excluded
+		insertChange(t, raw, "TaskCreated", now.Add(-240*time.Hour))
+
+		got := BuildDailySummary(syncer)
+		want := DailySummary{
+			Completed:    2,
+			Created:      1,
+			MovedToToday: 1,
+			Rescheduled:  3,
+		}
+		if got != want {
+			t.Errorf("BuildDailySummary() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("TaskMovedToToday is not counted as rescheduled", func(t *testing.T) {
+		t.Parallel()
+		syncer, raw := newTestSyncer(t)
+		insertChange(t, raw, "TaskMovedToToday", time.Now())
+
+		got := BuildDailySummary(syncer)
+		if got.Rescheduled != 0 {
+			t.Errorf("Rescheduled = %d, want 0", got.Rescheduled)
+		}
+		if got.MovedToToday != 1 {
+			t.Errorf("MovedToToday = %d, want 1", got.MovedToToday)
+		}
+	})
+}

--- a/types_coverage_test.go
+++ b/types_coverage_test.go
@@ -1,0 +1,110 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestActionItem_UUID(t *testing.T) {
+	t.Parallel()
+	const id = "VJ1edXTP9q3PmFDUuy8EQh"
+
+	if got := (TagActionItem{Item: Item{UUID: id}}).UUID(); got != id {
+		t.Errorf("TagActionItem.UUID() = %q, want %q", got, id)
+	}
+	if got := (AreaActionItem{Item: Item{UUID: id}}).UUID(); got != id {
+		t.Errorf("AreaActionItem.UUID() = %q, want %q", got, id)
+	}
+	if got := (CheckListActionItem{Item: Item{UUID: id}}).UUID(); got != id {
+		t.Errorf("CheckListActionItem.UUID() = %q, want %q", got, id)
+	}
+	if got := (TombstoneActionItem{Item: Item{UUID: id}}).UUID(); got != id {
+		t.Errorf("TombstoneActionItem.UUID() = %q, want %q", got, id)
+	}
+}
+
+func TestTimestamp_UnmarshalJSON_Error(t *testing.T) {
+	t.Parallel()
+	var ts Timestamp
+	// A JSON string is not a number and must fail to unmarshal into a float.
+	if err := ts.UnmarshalJSON([]byte(`"not a number"`)); err == nil {
+		t.Error("expected UnmarshalJSON to fail on a non-numeric value, got nil")
+	}
+}
+
+func TestBoolean_UnmarshalJSON_Error(t *testing.T) {
+	t.Parallel()
+	var b Boolean
+	// A JSON string is not an int and must fail to unmarshal.
+	if err := b.UnmarshalJSON([]byte(`"true"`)); err == nil {
+		t.Error("expected UnmarshalJSON to fail on a non-integer value, got nil")
+	}
+}
+
+func TestTimestamp_UnmarshalJSON_SubSecond(t *testing.T) {
+	t.Parallel()
+	var ts Timestamp
+	if err := json.Unmarshal([]byte(`1770713623.4716659`), &ts); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	tt := ts.Time()
+	if tt.Unix() != 1770713623 {
+		t.Errorf("Unix seconds = %d, want 1770713623", tt.Unix())
+	}
+	if tt.Nanosecond() == 0 {
+		t.Error("sub-second precision was dropped")
+	}
+}
+
+func TestItemAction_String(t *testing.T) {
+	t.Parallel()
+	cases := map[ItemAction]string{
+		ItemActionCreated:  "ItemActionCreated",
+		ItemActionModified: "ItemActionModified",
+		ItemActionDeleted:  "ItemActionDeleted",
+	}
+	for action, want := range cases {
+		if got := action.String(); got != want {
+			t.Errorf("ItemAction(%d).String() = %q, want %q", action, got, want)
+		}
+	}
+	// Out-of-range values fall through to the fmt.Sprintf branch.
+	if got := ItemAction(99).String(); got == "" {
+		t.Error("out-of-range ItemAction.String() returned empty")
+	}
+}
+
+func TestTaskStatus_String(t *testing.T) {
+	t.Parallel()
+	cases := map[TaskStatus]string{
+		TaskStatusPending:   "TaskStatusPending",
+		TaskStatusCanceled:  "TaskStatusCanceled",
+		TaskStatusCompleted: "TaskStatusCompleted",
+	}
+	for status, want := range cases {
+		if got := status.String(); got != want {
+			t.Errorf("TaskStatus(%d).String() = %q, want %q", status, got, want)
+		}
+	}
+	// A value outside the known set hits the default fmt.Sprintf branch.
+	if got := TaskStatus(99).String(); got == "" {
+		t.Error("out-of-range TaskStatus.String() returned empty")
+	}
+}
+
+func TestTaskSchedule_String(t *testing.T) {
+	t.Parallel()
+	cases := map[TaskSchedule]string{
+		TaskScheduleInbox:   "TaskScheduleInbox",
+		TaskScheduleAnytime: "TaskScheduleAnytime",
+		TaskScheduleSomeday: "TaskScheduleSomeday",
+	}
+	for sched, want := range cases {
+		if got := sched.String(); got != want {
+			t.Errorf("TaskSchedule(%d).String() = %q, want %q", sched, got, want)
+		}
+	}
+	if got := TaskSchedule(99).String(); got == "" {
+		t.Error("out-of-range TaskSchedule.String() returned empty")
+	}
+}


### PR DESCRIPTION
## Summary

Promotes `develop` to `main` for the v0.4.0 release.

### Fixes
- **`AccountService.ChangePassword` was unauthenticated** — now sends the `Authorization` header like every other account mutation (#19)
- **Local-vs-UTC day boundary** — `syncutil.BuildDailySummary` and `thingsync`'s review view both counted "today" from UTC midnight; a new exported `syncutil.StartOfToday()` is the single tested local-midnight implementation, and the last `Truncate(24h)` is gone (#19, #20 — the latter caught by Codex review)
- **Area inheritance was dead code** — `state/memory.TasksWithoutArea` now considers parented tasks via `hasArea`'s parent-chain recursion (behavior change: no longer top-level-only) (#19)
- **`notes.ApplyPatches` panicked on a negative patch length** — clamped to a pure insertion (#19)

### Testing & tooling (#18)
- **Stress suite**: Base58 fuzz targets (4M+ execs), sync chaos harness (40 fault-injected trials asserting cursor/change-log/state invariants), live soak driver (`cmd/soak`) + Things.app crash-watch script; all validated against a real test account (30/30 verified, 0 rejections, leading-zero UUIDs accepted; Things.app confirmed syncing)
- **Coverage**: root 68→**88.8%**, sync 66→**84.6%**, state/memory 60→**89.9%**, syncutil 0→**100%**, things-cli 31→**69%**
- `THINGS_ENDPOINT` env override so the CLI can target test servers
- Docs: fixed non-compiling README examples, Bug 9 write-up, stress-testing guide; CI workflow modernized (checkout@v4, setup-go@v5 with go-version-file)

## After merging
Tag `v0.4.0` (new exported API: `syncutil.StartOfToday`, `things.HTTPError` et al. already in v0.3.0 — minor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)