### PR TITLE
fix: aggregate pre-migration history items under their migrated identifiers

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -57,7 +57,13 @@ func EncodeUUID(u uuid.UUID) string {
 // Recurring-task instances use composite identifiers of the form
 // <uuid>-YYYYMMDD and hash in two steps: first the <uuid> prefix alone,
 // then its raw 16-byte digest followed by the "-YYYYMMDD" text.
+//
+// The empty string is returned unchanged: a malformed item should keep an
+// obviously-bogus key rather than gain a plausible-looking derived one.
 func EncodeLegacyIdentifier(legacyID string) string {
+	if legacyID == "" {
+		return ""
+	}
 	input := []byte(legacyID)
 	if prefix, suffix, ok := splitLegacyRecurrenceIdentifier(legacyID); ok {
 		prefixSum := sha1.Sum([]byte(prefix))

--- a/base58.go
+++ b/base58.go
@@ -1,6 +1,7 @@
 package thingscloud
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"math/big"
 	"strings"
@@ -37,6 +38,55 @@ func EncodeUUID(u uuid.UUID) string {
 		encoded[i], encoded[j] = encoded[j], encoded[i]
 	}
 	return string(encoded)
+}
+
+// EncodeLegacyIdentifier derives the current Base58 identifier for an object
+// created before Things Cloud's identifier migration. Old history items
+// (Task3, Task4, Area2, ...) key objects by identifier strings such as
+// uppercase UUIDs; newer items (Task6, ...) key the same objects by
+//
+//	Base58(SHA1(legacyID)[:16])
+//
+// The history contains no records linking the two generations; this
+// derivation is the only link. legacyID must be the identifier text exactly
+// as stored in the history: hashing is byte-exact, so any normalization
+// (such as lowercasing a UUID) yields a different identifier. SHA-1 mirrors
+// the derivation Things itself performs; it is not a security primitive
+// here.
+//
+// Recurring-task instances use composite identifiers of the form
+// <uuid>-YYYYMMDD and hash in two steps: first the <uuid> prefix alone,
+// then its raw 16-byte digest followed by the "-YYYYMMDD" text.
+func EncodeLegacyIdentifier(legacyID string) string {
+	input := []byte(legacyID)
+	if prefix, suffix, ok := splitLegacyRecurrenceIdentifier(legacyID); ok {
+		prefixSum := sha1.Sum([]byte(prefix))
+		input = make([]byte, 0, 16+len(suffix))
+		input = append(input, prefixSum[:16]...)
+		input = append(input, suffix...)
+	}
+	sum := sha1.Sum(input)
+	var u uuid.UUID
+	copy(u[:], sum[:len(u)])
+	return EncodeUUID(u)
+}
+
+func splitLegacyRecurrenceIdentifier(id string) (string, []byte, bool) {
+	const uuidLength = 36
+	const dateSuffixLength = len("-YYYYMMDD")
+	if len(id) != uuidLength+dateSuffixLength {
+		return "", nil, false
+	}
+	prefix := id[:uuidLength]
+	if _, err := uuid.Parse(prefix); err != nil || id[uuidLength] != '-' {
+		return "", nil, false
+	}
+	for i := uuidLength + 1; i < len(id); i++ {
+		if id[i] < '0' || id[i] > '9' {
+			return "", nil, false
+		}
+	}
+	return prefix, []byte(id[uuidLength:]), true
 }
 
 // DecodeUUID decodes a canonical Base58 identifier back into a UUID.

--- a/base58_test.go
+++ b/base58_test.go
@@ -1,6 +1,7 @@
 package thingscloud
 
 import (
+	"crypto/sha1"
 	"strings"
 	"testing"
 
@@ -56,6 +57,34 @@ func TestEncodeLegacyIdentifier_RecurrenceInstance(t *testing.T) {
 	}
 	if got := EncodeLegacyIdentifier(strings.ToLower(legacyID)); got == want {
 		t.Errorf("EncodeLegacyIdentifier normalized recurrence identifier case; input must be hashed exactly as stored")
+	}
+}
+
+func TestEncodeLegacyIdentifier_MalformedRecurrenceSuffixes(t *testing.T) {
+	t.Parallel()
+
+	// Near misses of the <uuid>-YYYYMMDD form must hash as ordinary
+	// identifier text, never through the recurrence formula.
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"non-digit in date", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-2024013X"},
+		{"date too short", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-2024013"},
+		{"date too long", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-202401310"},
+		{"invalid uuid prefix", "GGGGGGGG-BBBB-CCCC-DDDD-EEEEEEEEEEEE-20240131"},
+		{"missing date separator", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE920240131"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sum := sha1.Sum([]byte(test.id))
+			var u uuid.UUID
+			copy(u[:], sum[:len(u)])
+			want := EncodeUUID(u)
+			if got := EncodeLegacyIdentifier(test.id); got != want {
+				t.Errorf("EncodeLegacyIdentifier(%q) = %q, want ordinary derivation %q", test.id, got, want)
+			}
+		})
 	}
 }
 

--- a/base58_test.go
+++ b/base58_test.go
@@ -88,6 +88,39 @@ func TestEncodeLegacyIdentifier_MalformedRecurrenceSuffixes(t *testing.T) {
 	}
 }
 
+func TestEncodeLegacyIdentifier_LeadingZeroClasses(t *testing.T) {
+	t.Parallel()
+
+	// Derived identifiers are 21 or 22 characters depending on leading zero
+	// bytes in the truncated digest; roughly 3% land at 21 characters and
+	// some start with '1'. These are exactly the classes behind the
+	// leading-zero corruption documented in docs/client-side-bugs.md, so pin
+	// one exact vector for each.
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"21-character result", "00000006-1111-2222-3333-000000000006", "fxsSvCT97pJn3XZ4wp5t4"},
+		{"leading-1 result", "000000B4-1111-2222-3333-0000000000B4", "14q4keicwiREVK8EKAuowZ"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := EncodeLegacyIdentifier(test.id); got != test.want {
+				t.Errorf("EncodeLegacyIdentifier(%q) = %q, want %q", test.id, got, test.want)
+			}
+		})
+	}
+}
+
+func TestEncodeLegacyIdentifier_Empty(t *testing.T) {
+	t.Parallel()
+
+	if got := EncodeLegacyIdentifier(""); got != "" {
+		t.Errorf("EncodeLegacyIdentifier(\"\") = %q, want empty string passed through", got)
+	}
+}
+
 func TestEncodeDecodeUUID_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/base58_test.go
+++ b/base58_test.go
@@ -33,6 +33,32 @@ func TestEncodeUUID_AllZero(t *testing.T) {
 	}
 }
 
+func TestEncodeLegacyIdentifier(t *testing.T) {
+	t.Parallel()
+
+	const legacyID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+	const want = "LXmxn9gakySzcEjKj1DtgD"
+	if got := EncodeLegacyIdentifier(legacyID); got != want {
+		t.Errorf("EncodeLegacyIdentifier(%q) = %q, want %q", legacyID, got, want)
+	}
+	if got := EncodeLegacyIdentifier(strings.ToLower(legacyID)); got == want {
+		t.Errorf("EncodeLegacyIdentifier normalized identifier case; input must be hashed exactly as stored")
+	}
+}
+
+func TestEncodeLegacyIdentifier_RecurrenceInstance(t *testing.T) {
+	t.Parallel()
+
+	const legacyID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-20240131"
+	const want = "H8Xu72gj7fooPuYoBMZ5TK"
+	if got := EncodeLegacyIdentifier(legacyID); got != want {
+		t.Errorf("EncodeLegacyIdentifier(%q) = %q, want %q", legacyID, got, want)
+	}
+	if got := EncodeLegacyIdentifier(strings.ToLower(legacyID)); got == want {
+		t.Errorf("EncodeLegacyIdentifier normalized recurrence identifier case; input must be hashed exactly as stored")
+	}
+}
+
 func TestEncodeDecodeUUID_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -555,7 +555,11 @@ func loadCLIStateCache(path string) (*cliStateCache, error) {
 	}
 	var cache cliStateCache
 	if err := json.Unmarshal(bs, &cache); err != nil {
-		return nil, err
+		// The cache is purely derived data: a malformed file (format drift,
+		// partial write) degrades to a full replay, same as a version
+		// mismatch, instead of an error the user can only clear by deleting
+		// the file by hand.
+		return nil, nil
 	}
 	if cache.Version != cliStateCacheVersion {
 		return nil, nil

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -513,7 +513,14 @@ type cliContext struct {
 	history *thingscloud.History
 }
 
+// cliStateCacheVersion marks which generation of replay logic built a cached
+// state. Caches with any other version are ignored, forcing a full replay.
+// Bump it whenever replay output changes for the same history, e.g. when
+// object keys or memory.State's representation change.
+const cliStateCacheVersion = 1
+
 type cliStateCache struct {
+	Version     int           `json:"version"`
 	HistoryID   string        `json:"historyId"`
 	ServerIndex int           `json:"serverIndex"`
 	State       *memory.State `json:"state"`
@@ -550,6 +557,9 @@ func loadCLIStateCache(path string) (*cliStateCache, error) {
 	if err := json.Unmarshal(bs, &cache); err != nil {
 		return nil, err
 	}
+	if cache.Version != cliStateCacheVersion {
+		return nil, nil
+	}
 	if cache.State == nil {
 		cache.State = memory.NewState()
 	} else {
@@ -577,6 +587,7 @@ func saveCLIStateCache(path string, cache *cliStateCache) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
+	cache.Version = cliStateCacheVersion
 	bs, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -260,6 +260,9 @@ func TestCLIStateCacheRoundTrip(t *testing.T) {
 	if loaded.HistoryID != "history-1" {
 		t.Fatalf("HistoryID = %q, want history-1", loaded.HistoryID)
 	}
+	if loaded.Version != cliStateCacheVersion {
+		t.Fatalf("Version = %d, want %d", loaded.Version, cliStateCacheVersion)
+	}
 	if loaded.ServerIndex != 42 {
 		t.Fatalf("ServerIndex = %d, want 42", loaded.ServerIndex)
 	}
@@ -297,6 +300,21 @@ func TestCLIStateCacheNormalizesEmptyState(t *testing.T) {
 	}
 	if loaded.State.CheckListItems == nil {
 		t.Fatal("CheckListItems map was not initialized")
+	}
+}
+
+func TestCLIStateCacheRejectsOldVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, []byte(`{"historyId":"history-1","serverIndex":7,"state":{}}`), 0o600); err != nil {
+		t.Fatalf("writing old cache: %v", err)
+	}
+
+	cache, err := loadCLIStateCache(path)
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if cache != nil {
+		t.Fatalf("old-version cache was accepted: %#v", cache)
 	}
 }
 

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -318,6 +318,21 @@ func TestCLIStateCacheRejectsOldVersion(t *testing.T) {
 	}
 }
 
+func TestCLIStateCacheMalformedFileTreatedAsNoCache(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, []byte(`{"historyId":"history-1",`), 0o600); err != nil {
+		t.Fatalf("writing malformed cache: %v", err)
+	}
+
+	cache, err := loadCLIStateCache(path)
+	if err != nil {
+		t.Fatalf("loadCLIStateCache failed: %v", err)
+	}
+	if cache != nil {
+		t.Fatalf("malformed cache was accepted: %#v", cache)
+	}
+}
+
 func testStateForListFilters() *memory.State {
 	state := memory.NewState()
 	today := time.Now().UTC()

--- a/state/memory/legacy_uuid_test.go
+++ b/state/memory/legacy_uuid_test.go
@@ -1,0 +1,230 @@
+package memory
+
+import (
+	"encoding/json"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+func legacyPayload(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshaling payload: %v", err)
+	}
+	return payload
+}
+
+func TestState_LegacyUUIDRemapping(t *testing.T) {
+	t.Parallel()
+
+	const (
+		legacyTaskID       = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-20240131"
+		legacyAreaID       = "11111111-2222-3333-4444-555555555555"
+		legacyProjectID    = "22222222-3333-4444-5555-666666666666"
+		legacyHeadingID    = "33333333-4444-5555-6666-777777777777"
+		legacyTagID        = "44444444-5555-6666-7777-888888888888"
+		legacyParentTagID  = "55555555-6666-7777-8888-999999999999"
+		legacyRecurrenceID = "66666666-7777-8888-9999-AAAAAAAAAAAA"
+		legacyDelegateID   = "77777777-8888-9999-AAAA-BBBBBBBBBBBB"
+		legacyChecklistID  = "88888888-9999-AAAA-BBBB-CCCCCCCCCCCC"
+	)
+
+	currentTaskID := things.EncodeLegacyIdentifier(legacyTaskID)
+	unrelatedTaskID := things.EncodeLegacyIdentifier("99999999-AAAA-BBBB-CCCC-DDDDDDDDDDDD")
+	state := NewState()
+	err := state.Update(
+		things.Item{
+			UUID:   legacyAreaID,
+			Kind:   things.ItemKindArea,
+			Action: things.ItemActionCreated,
+			P:      legacyPayload(t, map[string]any{"tt": "Context"}),
+		},
+		things.Item{
+			UUID:   legacyTagID,
+			Kind:   things.ItemKindTag,
+			Action: things.ItemActionCreated,
+			P: legacyPayload(t, map[string]any{
+				"tt": "Tag",
+				"pn": []string{legacyParentTagID},
+			}),
+		},
+		things.Item{
+			UUID:   legacyTaskID,
+			Kind:   things.ItemKindTask3,
+			Action: things.ItemActionCreated,
+			P: legacyPayload(t, map[string]any{
+				"tt":  "Repeated title",
+				"ar":  []string{legacyAreaID},
+				"pr":  []string{legacyProjectID},
+				"agr": []string{legacyHeadingID},
+				"tg":  []string{legacyTagID},
+				"rt":  []string{legacyRecurrenceID},
+				"dl":  []string{legacyDelegateID},
+			}),
+		},
+		things.Item{
+			UUID:   legacyTaskID,
+			Kind:   things.ItemKindTask4,
+			Action: things.ItemActionModified,
+			P:      legacyPayload(t, map[string]any{"ss": things.TaskStatusCompleted}),
+		},
+		things.Item{
+			UUID:   currentTaskID,
+			Kind:   things.ItemKindTask,
+			Action: things.ItemActionModified,
+			P:      legacyPayload(t, map[string]any{"ar": []string{}}),
+		},
+		things.Item{
+			UUID:   legacyChecklistID,
+			Kind:   things.ItemKindChecklistItem2,
+			Action: things.ItemActionCreated,
+			P: legacyPayload(t, map[string]any{
+				"tt": "Checklist entry",
+				"ts": []string{legacyTaskID},
+			}),
+		},
+		things.Item{
+			UUID:   unrelatedTaskID,
+			Kind:   things.ItemKindTask,
+			Action: things.ItemActionCreated,
+			P:      legacyPayload(t, map[string]any{"tt": "Repeated title"}),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if len(state.Tasks) != 2 {
+		t.Fatalf("got %d tasks, want the remapped task and unrelated same-title task", len(state.Tasks))
+	}
+	task := state.Tasks[currentTaskID]
+	if task == nil {
+		t.Fatalf("remapped task %q not found", currentTaskID)
+	}
+	if task.Title != "Repeated title" || task.Status != things.TaskStatusCompleted {
+		t.Errorf("remapped task content = title %q, status %v", task.Title, task.Status)
+	}
+	if len(task.AreaIDs) != 0 {
+		t.Errorf("Task6 stub did not override legacy area IDs: %v", task.AreaIDs)
+	}
+	assertIDs(t, "parent tasks", task.ParentTaskIDs, things.EncodeLegacyIdentifier(legacyProjectID))
+	assertIDs(t, "action groups", task.ActionGroupIDs, things.EncodeLegacyIdentifier(legacyHeadingID))
+	assertIDs(t, "tags", task.TagIDs, things.EncodeLegacyIdentifier(legacyTagID))
+	assertIDs(t, "recurrences", task.RecurrenceIDs, things.EncodeLegacyIdentifier(legacyRecurrenceID))
+	assertIDs(t, "delegates", task.DelegateIDs, things.EncodeLegacyIdentifier(legacyDelegateID))
+	if _, ok := state.Tasks[legacyTaskID]; ok {
+		t.Errorf("legacy task key %q remains in state", legacyTaskID)
+	}
+	if other := state.Tasks[unrelatedTaskID]; other == nil || other.Title != task.Title {
+		t.Errorf("unrelated same-title task was merged: %#v", other)
+	}
+
+	if state.Areas[things.EncodeLegacyIdentifier(legacyAreaID)] == nil {
+		t.Errorf("legacy area was not stored under its migrated identifier")
+	}
+	tag := state.Tags[things.EncodeLegacyIdentifier(legacyTagID)]
+	if tag == nil {
+		t.Fatalf("legacy tag was not stored under its migrated identifier")
+	}
+	assertIDs(t, "parent tags", tag.ParentTagIDs, things.EncodeLegacyIdentifier(legacyParentTagID))
+	checklist := state.CheckListItems[things.EncodeLegacyIdentifier(legacyChecklistID)]
+	if checklist == nil {
+		t.Fatalf("legacy checklist item was not stored under its migrated identifier")
+	}
+	assertIDs(t, "checklist tasks", checklist.TaskIDs, currentTaskID)
+}
+
+func TestState_LegacyDeletesCanonicalItem(t *testing.T) {
+	t.Parallel()
+
+	t.Run("item delete", func(t *testing.T) {
+		const legacyID = "AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB"
+		state := NewState()
+		if err := state.Update(
+			things.Item{UUID: legacyID, Kind: things.ItemKindTask3, Action: things.ItemActionCreated, P: json.RawMessage(`{"tt":"Task"}`)},
+			things.Item{UUID: legacyID, Kind: things.ItemKindTask4, Action: things.ItemActionDeleted, P: json.RawMessage(`{}`)},
+		); err != nil {
+			t.Fatalf("Update failed: %v", err)
+		}
+		if _, ok := state.Tasks[things.EncodeLegacyIdentifier(legacyID)]; ok {
+			t.Errorf("legacy delete left canonical task in state")
+		}
+	})
+
+	t.Run("legacy tombstone", func(t *testing.T) {
+		const legacyID = "CCCCCCCC-1111-2222-3333-DDDDDDDDDDDD"
+		state := NewState()
+		if err := state.Update(
+			things.Item{UUID: legacyID, Kind: things.ItemKindChecklistItem2, Action: things.ItemActionCreated, P: json.RawMessage(`{"tt":"Entry"}`)},
+			things.Item{
+				UUID:   "EEEEEEEE-1111-2222-3333-FFFFFFFFFFFF",
+				Kind:   things.ItemKindTombstonePlain,
+				Action: things.ItemActionCreated,
+				P:      legacyPayload(t, map[string]any{"dloid": legacyID, "dld": 1}),
+			},
+		); err != nil {
+			t.Fatalf("Update failed: %v", err)
+		}
+		if _, ok := state.CheckListItems[things.EncodeLegacyIdentifier(legacyID)]; ok {
+			t.Errorf("legacy tombstone left canonical checklist item in state")
+		}
+	})
+}
+
+func TestState_AllLegacyKindsUseMigratedKeys(t *testing.T) {
+	t.Parallel()
+
+	const legacyID = "AAAAAAAA-2222-3333-4444-BBBBBBBBBBBB"
+	currentID := things.EncodeLegacyIdentifier(legacyID)
+	tests := []struct {
+		name string
+		kind things.ItemKind
+		has  func(*State, string) bool
+	}{
+		{"Task4", things.ItemKindTask4, func(s *State, id string) bool { return s.Tasks[id] != nil }},
+		{"Task3", things.ItemKindTask3, func(s *State, id string) bool { return s.Tasks[id] != nil }},
+		{"Task", things.ItemKindTaskPlain, func(s *State, id string) bool { return s.Tasks[id] != nil }},
+		{"ChecklistItem2", things.ItemKindChecklistItem2, func(s *State, id string) bool { return s.CheckListItems[id] != nil }},
+		{"ChecklistItem", things.ItemKindChecklistItem, func(s *State, id string) bool { return s.CheckListItems[id] != nil }},
+		{"Area2", things.ItemKindArea, func(s *State, id string) bool { return s.Areas[id] != nil }},
+		{"Area", things.ItemKindAreaPlain, func(s *State, id string) bool { return s.Areas[id] != nil }},
+		{"Tag3", things.ItemKindTag, func(s *State, id string) bool { return s.Tags[id] != nil }},
+		{"Tag", things.ItemKindTagPlain, func(s *State, id string) bool { return s.Tags[id] != nil }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := NewState()
+			if err := state.Update(things.Item{
+				UUID:   legacyID,
+				Kind:   test.kind,
+				Action: things.ItemActionCreated,
+				P:      json.RawMessage(`{}`),
+			}); err != nil {
+				t.Fatalf("Update failed: %v", err)
+			}
+			if !test.has(state, currentID) {
+				t.Errorf("%s item not found under migrated key %q", test.kind, currentID)
+			}
+			if test.has(state, legacyID) {
+				t.Errorf("%s item remains under legacy key %q", test.kind, legacyID)
+			}
+		})
+	}
+}
+
+func assertIDs(t *testing.T, field string, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%s = %v, want %v", field, got, want)
+		return
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s = %v, want %v", field, got, want)
+			return
+		}
+	}
+}

--- a/state/memory/legacy_uuid_test.go
+++ b/state/memory/legacy_uuid_test.go
@@ -173,6 +173,58 @@ func TestState_LegacyDeletesCanonicalItem(t *testing.T) {
 	})
 }
 
+func TestState_LegacyKindWithCurrentIdentifierIsNotRederived(t *testing.T) {
+	t.Parallel()
+
+	// A legacy-kind item can carry an already-migrated Base58 identifier
+	// (if any kind kept being emitted after its objects moved to current
+	// identifiers). Deriving again would split the object across a phantom
+	// key and the real one.
+	currentID := things.EncodeLegacyIdentifier("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")
+	currentTagID := things.EncodeLegacyIdentifier("11111111-2222-3333-4444-555555555555")
+	state := NewState()
+	if err := state.Update(
+		things.Item{
+			UUID:   currentID,
+			Kind:   things.ItemKindTask4,
+			Action: things.ItemActionCreated,
+			P:      legacyPayload(t, map[string]any{"tt": "Carried over", "tg": []string{currentTagID}}),
+		},
+		things.Item{
+			UUID:   currentID,
+			Kind:   things.ItemKindTask,
+			Action: things.ItemActionModified,
+			P:      legacyPayload(t, map[string]any{"ss": things.TaskStatusCompleted}),
+		},
+	); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if len(state.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1: legacy-kind item with current identifier must not fork", len(state.Tasks))
+	}
+	task := state.Tasks[currentID]
+	if task == nil {
+		t.Fatalf("task not found under its current identifier %q", currentID)
+	}
+	if task.Title != "Carried over" || task.Status != things.TaskStatusCompleted {
+		t.Errorf("task = title %q, status %v; legacy and current events did not merge", task.Title, task.Status)
+	}
+	assertIDs(t, "tags", task.TagIDs, currentTagID)
+
+	if err := state.Update(things.Item{
+		UUID:   "FFFFFFFF-1111-2222-3333-444444444444",
+		Kind:   things.ItemKindTombstonePlain,
+		Action: things.ItemActionCreated,
+		P:      legacyPayload(t, map[string]any{"dloid": currentID, "dld": 1}),
+	}); err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if _, ok := state.Tasks[currentID]; ok {
+		t.Errorf("legacy tombstone with current dloid did not delete the task")
+	}
+}
+
 func TestState_AllLegacyKindsUseMigratedKeys(t *testing.T) {
 	t.Parallel()
 

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -49,11 +49,15 @@ func isLegacyItemKind(kind things.ItemKind) bool {
 }
 
 // encodeLegacyIDs rewrites each identifier in place to its derived
-// equivalent. Every entry is rewritten: identifier lists in legacy payloads
-// are assumed to never contain current-generation identifiers, which matches
-// Things hashing the stored text verbatim during its migration.
+// equivalent. Identifiers that already parse as canonical Base58 are
+// current-generation and left untouched: deriving them again would produce a
+// phantom key. Genuine legacy identifiers always contain '-', which is not
+// in the Base58 alphabet, so they can never be skipped by mistake.
 func encodeLegacyIDs(ids []string) {
 	for i := range ids {
+		if things.ValidateUUID(ids[i]) == nil {
+			continue
+		}
 		ids[i] = things.EncodeLegacyIdentifier(ids[i])
 	}
 }
@@ -65,12 +69,16 @@ func encodeLegacyTaskReferences(p *things.TaskActionItemPayload) {
 	if p.ParentTaskIDs != nil {
 		encodeLegacyIDs(*p.ParentTaskIDs)
 	}
-	encodeLegacyIDs(p.TagIDs)
-	if p.RecurrenceTaskIDs != nil {
-		encodeLegacyIDs(*p.RecurrenceTaskIDs)
-	}
 	if p.ActionGroupIDs != nil {
 		encodeLegacyIDs(*p.ActionGroupIDs)
+	}
+	encodeLegacyIDs(p.TagIDs)
+	// rt and dl are rewritten on the same assumption as the fields above —
+	// that they hold object identifiers — but nothing in this package
+	// resolves them against state, so unlike ar/pr/agr/tg the assumption is
+	// unverified against Things' own database.
+	if p.RecurrenceTaskIDs != nil {
+		encodeLegacyIDs(*p.RecurrenceTaskIDs)
 	}
 	if p.DelegateIDs != nil {
 		encodeLegacyIDs(*p.DelegateIDs)
@@ -243,7 +251,11 @@ func (s *State) updateTag(item things.TagActionItem) *things.Tag {
 func (s *State) Update(items ...things.Item) error {
 	for _, rawItem := range items {
 		legacy := isLegacyItemKind(rawItem.Kind)
-		if legacy {
+		// A legacy-kind item whose key already parses as canonical Base58
+		// carries a current-generation identifier and must not be re-derived
+		// (see encodeLegacyIDs for why this can never skip a genuine legacy
+		// identifier).
+		if legacy && things.ValidateUUID(rawItem.UUID) != nil {
 			rawItem.UUID = things.EncodeLegacyIdentifier(rawItem.UUID)
 		}
 
@@ -293,6 +305,11 @@ func (s *State) Update(items ...things.Item) error {
 			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
 				continue // Skip unparseable items
 			}
+			// updateArea currently discards tg, but rewrite it anyway so a
+			// future consumer of area tags sees consistent keys.
+			if legacy {
+				encodeLegacyIDs(item.P.TagIDs)
+			}
 
 			switch item.Action {
 			case things.ItemActionCreated:
@@ -327,12 +344,15 @@ func (s *State) Update(items ...things.Item) error {
 			}
 
 		case things.ItemKindTombstone, things.ItemKindTombstonePlain:
+			// Plain Tombstone items were ignored before the legacy-identifier
+			// remapping: they record pre-migration deletes, so they must
+			// delete objects just like Tombstone2.
 			item := things.TombstoneActionItem{Item: rawItem}
 			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
 				continue
 			}
 			oid := item.P.DeletedObjectID
-			if legacy {
+			if legacy && things.ValidateUUID(oid) != nil {
 				oid = things.EncodeLegacyIdentifier(oid)
 			}
 			delete(s.Tasks, oid)

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -29,6 +29,54 @@ func NewState() *State {
 	}
 }
 
+// Things Cloud migrated from UUID-style identifiers to Base58 identifiers
+// without writing mapping records into the history: the current identifier
+// is derived by hashing the old one (see things.EncodeLegacyIdentifier).
+// Items of the kinds below are keyed by old identifiers, so replay stores
+// them under their derived identifiers; later current-kind events then find
+// and update the same objects.
+func isLegacyItemKind(kind things.ItemKind) bool {
+	switch kind {
+	case things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain,
+		things.ItemKindChecklistItem, things.ItemKindChecklistItem2,
+		things.ItemKindArea, things.ItemKindAreaPlain,
+		things.ItemKindTag, things.ItemKindTagPlain,
+		things.ItemKindTombstonePlain:
+		return true
+	default:
+		return false
+	}
+}
+
+// encodeLegacyIDs rewrites each identifier in place to its derived
+// equivalent. Every entry is rewritten: identifier lists in legacy payloads
+// are assumed to never contain current-generation identifiers, which matches
+// Things hashing the stored text verbatim during its migration.
+func encodeLegacyIDs(ids []string) {
+	for i := range ids {
+		ids[i] = things.EncodeLegacyIdentifier(ids[i])
+	}
+}
+
+func encodeLegacyTaskReferences(p *things.TaskActionItemPayload) {
+	if p.AreaIDs != nil {
+		encodeLegacyIDs(*p.AreaIDs)
+	}
+	if p.ParentTaskIDs != nil {
+		encodeLegacyIDs(*p.ParentTaskIDs)
+	}
+	encodeLegacyIDs(p.TagIDs)
+	if p.RecurrenceTaskIDs != nil {
+		encodeLegacyIDs(*p.RecurrenceTaskIDs)
+	}
+	if p.ActionGroupIDs != nil {
+		encodeLegacyIDs(*p.ActionGroupIDs)
+	}
+	if p.DelegateIDs != nil {
+		encodeLegacyIDs(*p.DelegateIDs)
+	}
+}
+
 func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 	t, ok := s.Tasks[item.UUID()]
 	if !ok {
@@ -194,11 +242,19 @@ func (s *State) updateTag(item things.TagActionItem) *things.Tag {
 // Update applies all items to update the aggregated state
 func (s *State) Update(items ...things.Item) error {
 	for _, rawItem := range items {
+		legacy := isLegacyItemKind(rawItem.Kind)
+		if legacy {
+			rawItem.UUID = things.EncodeLegacyIdentifier(rawItem.UUID)
+		}
+
 		switch rawItem.Kind {
 		case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 			item := things.TaskActionItem{Item: rawItem}
 			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
 				continue // Skip items that can't be parsed
+			}
+			if legacy {
+				encodeLegacyTaskReferences(&item.P)
 			}
 
 			switch item.Action {
@@ -216,6 +272,9 @@ func (s *State) Update(items ...things.Item) error {
 			item := things.CheckListActionItem{Item: rawItem}
 			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
 				continue // Skip unparseable items
+			}
+			if legacy && item.P.TaskIDs != nil {
+				encodeLegacyIDs(*item.P.TaskIDs)
 			}
 
 			switch item.Action {
@@ -252,6 +311,9 @@ func (s *State) Update(items ...things.Item) error {
 			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
 				continue // Skip unparseable items
 			}
+			if legacy && item.P.ParentTagIDs != nil {
+				encodeLegacyIDs(*item.P.ParentTagIDs)
+			}
 
 			switch item.Action {
 			case things.ItemActionCreated:
@@ -264,12 +326,15 @@ func (s *State) Update(items ...things.Item) error {
 				// Unsupported action: skip
 			}
 
-		case things.ItemKindTombstone:
+		case things.ItemKindTombstone, things.ItemKindTombstonePlain:
 			item := things.TombstoneActionItem{Item: rawItem}
 			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
 				continue
 			}
 			oid := item.P.DeletedObjectID
+			if legacy {
+				oid = things.EncodeLegacyIdentifier(oid)
+			}
 			delete(s.Tasks, oid)
 			delete(s.Areas, oid)
 			delete(s.Tags, oid)

--- a/state/memory/memory_test.go
+++ b/state/memory/memory_test.go
@@ -201,7 +201,7 @@ func TestState_Update(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err.Error())
 			}
-			if s.CheckListItems[things.EncodeLegacyIdentifier("")].Title != "Modified Title" {
+			if s.CheckListItems[""].Title != "Modified Title" {
 				t.Fatal("Expected title to be updated")
 			}
 		})
@@ -231,7 +231,7 @@ func TestState_Update(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err.Error())
 			}
-			if s.Tags[things.EncodeLegacyIdentifier("")].Title != "Modified Tag" {
+			if s.Tags[""].Title != "Modified Tag" {
 				t.Fatal("Expected title to be updated")
 			}
 		})
@@ -263,7 +263,7 @@ func TestState_Update(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			if s.Areas[things.EncodeLegacyIdentifier("")].Title != "Modified Area" {
+			if s.Areas[""].Title != "Modified Area" {
 				t.Fatal("Expected title to be updated")
 			}
 		})

--- a/state/memory/memory_test.go
+++ b/state/memory/memory_test.go
@@ -201,7 +201,7 @@ func TestState_Update(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err.Error())
 			}
-			if s.CheckListItems[""].Title != "Modified Title" {
+			if s.CheckListItems[things.EncodeLegacyIdentifier("")].Title != "Modified Title" {
 				t.Fatal("Expected title to be updated")
 			}
 		})
@@ -231,7 +231,7 @@ func TestState_Update(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err.Error())
 			}
-			if s.Tags[""].Title != "Modified Tag" {
+			if s.Tags[things.EncodeLegacyIdentifier("")].Title != "Modified Tag" {
 				t.Fatal("Expected title to be updated")
 			}
 		})
@@ -263,7 +263,7 @@ func TestState_Update(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			if s.Areas[""].Title != "Modified Area" {
+			if s.Areas[things.EncodeLegacyIdentifier("")].Title != "Modified Area" {
 				t.Fatal("Expected title to be updated")
 			}
 		})

--- a/types.go
+++ b/types.go
@@ -75,10 +75,11 @@ var (
 	// ItemKindSettings  identifies a setting
 	ItemKindSettings ItemKind = "Settings3"
 	// ItemKindTag identifies a Tag
-	ItemKindTag       ItemKind = "Tag3"
-	ItemKindTag4      ItemKind = "Tag4"
-	ItemKindTagPlain  ItemKind = "Tag"
-	ItemKindTombstone ItemKind = "Tombstone2"
+	ItemKindTag            ItemKind = "Tag3"
+	ItemKindTag4           ItemKind = "Tag4"
+	ItemKindTagPlain       ItemKind = "Tag"
+	ItemKindTombstone      ItemKind = "Tombstone2"
+	ItemKindTombstonePlain ItemKind = "Tombstone"
 )
 
 // Timestamp allows unix epochs represented as float or ints to be unmarshalled


### PR DESCRIPTION
## The symptom

On an account with history going back to 2018, `memory.State` reports tasks that should not be there. Old items that were long since completed, deleted, or edited into something else show up alongside the current ones, and some current tasks come back empty (no title, default status) even though the app shows them correctly. Task counts come out well above what Things itself displays. Accounts created recently look fine, which is why this has gone unnoticed: it only appears once a history is old enough to span the identifier change described below.

## Why it happens

Things Cloud has used two generations of object identifier over the life of the service. Older history items (`Task3`, `Task4`, `Area2`, `Tag3`, `ChecklistItem`, `ChecklistItem2`, `Tombstone`) key objects by identifier strings, usually an uppercase UUID. Newer items (`Task6`, `Area3`, `Tag4`, `ChecklistItem3`, `Tombstone2`) key the same logical objects by a 22-character Base58 identifier.

When Things migrated, it did not write any mapping record into the history, and it did not rewrite the old items. Both generations are still in the log, and a client replaying that log has to know that the two identifier forms can refer to the same object. Things derives the new identifier from the old one by hashing it:

```go
current = Base58(SHA1(legacy_identifier_text)[:16])
```

Recurring-task instances use a composite identifier of the form `<uuid>-YYYYMMDD` and hash in two steps: the UUID prefix first, then that raw 16-byte digest followed by the `-YYYYMMDD` text.

The SDK replayed both generations under their own raw keys, so one object became two entries in state. The old entry kept whatever the object looked like at migration time and was never touched again, which is the stale task that surfaces. The new entry started empty and only received whatever changes happened after the migration, which is why post-migration tasks with no recent edits appear blank. Deletes have the same split: a legacy delete or a `Tombstone` removes the legacy key and leaves the current one behind.

The derivation is the only link between the two generations. There is no mapping commit to read instead. I checked: the large commits around area deletions look like migration tables but contain only `{"ar":[]}` payload edits, and the kinds the SDK skips (`Settings4`/`Settings5`, `Command`) carry no cross-references either.

## The fix

`EncodeLegacyIdentifier` implements the derivation, and `state/memory` runs every pre-migration item through it during replay: the envelope key, the identifier-valued reference fields on those items (task `ar`, `pr`, `agr`, `tg`, `rt`, `dl`; checklist `ts`; tag `pn`), and the deleted-object identifier on legacy tombstones. Items of current kinds are untouched, and no arbitrary string is ever rewritten, so an account with no pre-migration history replays exactly as before.

`things-cli` also needed a change. It caches aggregated state as JSON and resumes incremental sync on top of it, so a cache written by the old logic keeps its wrongly-keyed objects forever: later sync only appends newer history and never revisits them. The cache now carries a version, and any other version (including its absence, i.e. every existing cache) is treated as no cache, which forces one full replay through the corrected logic.

## Validation

Unit tests cover the derivation against exact vectors, including the recurrence form and near-misses of it that must hash as ordinary text, plus replay tests for each pre-migration kind.

Beyond that, I replayed a full 239,199-item history through this branch and diffed the resulting state against the `main.sqlite` that Things.app maintains on the Mac for the same account, comparing task identity, title, type, status, trash state, and area/project/heading relationships, plus area and tag identity and title:

```
    sqlite: 13167 tasks, 6 areas, 10 tags
    cloud:  13167 tasks, 6 areas, 10 tags
    missing: 0   extra: 0   field mismatches: 0
```

Before the fix the same history produced 1,458 extra pre-migration tasks. Each one's derived identifier is unique and accounts for a current object: 1,326 map to a task that still exists in sqlite, 132 map to an identifier whose last history event is a delete, and none are left unexplained. That mapping was established from identifiers and timestamps alone, without matching on titles.

The comparison does not yet cover dates, notes, task tags, recurrence, delegates, or checklist items, so treat the zero as validating the identifier handling rather than every field the SDK exposes.

## Known gap

The `sync` package keys the same pre-migration kinds by their raw identifiers and has the same bug. I left it alone deliberately: fixing it changes what gets written to a user's existing database, so it needs a decision about whether those databases are rebuilt or migrated in place, and that does not belong in this change. If you would rather see the shared pieces (the kind predicate and the payload rewriting) lifted out of `state/memory` into the root package now so `sync` can reuse them later, say so and I will restructure.

Assisted by Claude Code + Codex