### PR TITLE
ci: enforce gofmt with golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,3 +27,24 @@ jobs:
 
     - name: Test Coverage
       run: go test -cover ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Install golangci-lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.12.2
+        install-only: true
+
+    - name: Lint
+      run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+linters:
+  default: none
+  exclusions:
+    generated: disable
+
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: false
+  exclusions:
+    generated: disable

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: lint
+
+lint:
+	golangci-lint run ./...

--- a/cmd/debugupdate/main.go
+++ b/cmd/debugupdate/main.go
@@ -22,19 +22,19 @@ func main() {
 	startIndex := 0
 	for {
 		items, hasMore, _ := history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
-		
+
 		for _, item := range items {
 			if strings.HasPrefix(item.UUID, target) {
 				var p map[string]interface{}
 				json.Unmarshal(item.P, &p)
 				fmt.Printf("Processing: UUID=%s Kind=%s Action=%d\n", item.UUID, item.Kind, item.Action)
-				
+
 				// Try updating just this one item
 				err := state.Update(item)
 				if err != nil {
 					fmt.Printf("ERROR: %v\n", err)
 				}
-				
+
 				// Check if it's in state now
 				if t, ok := state.Tasks[item.UUID]; ok {
 					fmt.Printf("  -> In state: title=%q\n", t.Title)
@@ -43,7 +43,7 @@ func main() {
 				}
 			}
 		}
-		
+
 		if !hasMore {
 			break
 		}

--- a/cmd/findtask/main.go
+++ b/cmd/findtask/main.go
@@ -21,19 +21,19 @@ func main() {
 	startIndex := 0
 	for {
 		items, hasMore, _ := history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
-		
+
 		// Check state before update
 		if t, ok := state.Tasks[target+"5hZt2sSEw4PvDb"]; ok {
 			fmt.Printf("BEFORE batch: Task exists, title=%q trash=%v\n", t.Title, t.InTrash)
 		}
-		
+
 		state.Update(items...)
-		
+
 		// Check state after update
 		if t, ok := state.Tasks[target+"5hZt2sSEw4PvDb"]; ok {
 			fmt.Printf("AFTER batch: Task exists, title=%q trash=%v\n", t.Title, t.InTrash)
 		}
-		
+
 		// Look for our target in this batch
 		for _, item := range items {
 			if item.UUID == target+"5hZt2sSEw4PvDb" {
@@ -42,13 +42,13 @@ func main() {
 				fmt.Printf("Found item: Kind=%s Action=%d tr=%v\n", item.Kind, item.Action, p["tr"])
 			}
 		}
-		
+
 		if !hasMore {
 			break
 		}
 		startIndex = history.LoadedServerIndex
 	}
-	
+
 	fmt.Printf("\nFinal state has %d tasks\n", len(state.Tasks))
 	if t, ok := state.Tasks[target+"5hZt2sSEw4PvDb"]; ok {
 		fmt.Printf("Target task: %q trash=%v status=%d\n", t.Title, t.InTrash, t.Status)

--- a/cmd/rawitem/main.go
+++ b/cmd/rawitem/main.go
@@ -19,20 +19,20 @@ func main() {
 	startIndex := 0
 	for {
 		items, hasMore, _ := history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
-		
+
 		for _, item := range items {
 			if item.UUID == target {
 				fmt.Printf("UUID: %s\n", item.UUID)
 				fmt.Printf("Kind: %s\n", item.Kind)
 				fmt.Printf("Action (parsed): %d\n", item.Action)
-				
+
 				// Also print item as raw JSON
 				raw, _ := json.MarshalIndent(item, "", "  ")
 				fmt.Printf("Raw item: %s\n", string(raw))
 				return
 			}
 		}
-		
+
 		if !hasMore {
 			break
 		}

--- a/cmd/recent/main.go
+++ b/cmd/recent/main.go
@@ -17,15 +17,15 @@ func main() {
 
 	// Get the LAST batch (most recent items)
 	fmt.Printf("LatestServerIndex: %d\n", history.LatestServerIndex)
-	
+
 	// Start from near the end
 	startIndex := history.LatestServerIndex - 100
 	if startIndex < 0 {
 		startIndex = 0
 	}
-	
+
 	items, _, _ := history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
-	
+
 	fmt.Printf("\n=== LAST %d ITEMS ===\n", len(items))
 	for _, item := range items {
 		var p map[string]interface{}

--- a/cmd/statedebug/main.go
+++ b/cmd/statedebug/main.go
@@ -16,30 +16,30 @@ func main() {
 	history.Sync()
 
 	state := memory.NewState()
-	
+
 	// Fetch and update incrementally
 	startIndex := 0
 	totalTask6 := 0
 	for {
 		items, hasMore, _ := history.Items(thingscloud.ItemsOptions{StartIndex: startIndex})
-		
+
 		for _, item := range items {
 			if item.Kind == "Task6" {
 				totalTask6++
 			}
 		}
-		
+
 		state.Update(items...)
-		
+
 		if !hasMore {
 			break
 		}
 		startIndex = history.LoadedServerIndex
 	}
-	
+
 	fmt.Printf("Total Task6 items processed: %d\n", totalTask6)
 	fmt.Printf("Final state.Tasks count: %d\n", len(state.Tasks))
-	
+
 	fmt.Println("\nAll tasks in state:")
 	for uuid, task := range state.Tasks {
 		fmt.Printf("  %s: %s (trash:%v status:%d)\n", uuid[:8], task.Title, task.InTrash, task.Status)

--- a/cmd/trace/main.go
+++ b/cmd/trace/main.go
@@ -10,8 +10,8 @@ import (
 )
 
 func main() {
-	target := "2MNjM5gT" // "Book Teeth Cleaning" 
-	
+	target := "2MNjM5gT" // "Book Teeth Cleaning"
+
 	c := thingscloud.New(thingscloud.APIEndpoint, os.Getenv("THINGS_USERNAME"), os.Getenv("THINGS_PASSWORD"))
 	c.Verify()
 

--- a/types.go
+++ b/types.go
@@ -75,8 +75,8 @@ var (
 	// ItemKindSettings  identifies a setting
 	ItemKindSettings ItemKind = "Settings3"
 	// ItemKindTag identifies a Tag
-	ItemKindTag      ItemKind = "Tag3"
-	ItemKindTag4     ItemKind = "Tag4"
+	ItemKindTag       ItemKind = "Tag3"
+	ItemKindTag4      ItemKind = "Tag4"
 	ItemKindTagPlain  ItemKind = "Tag"
 	ItemKindTombstone ItemKind = "Tombstone2"
 )
@@ -198,39 +198,39 @@ type Task struct {
 	AreaIDs          []string
 	ParentTaskIDs    []string
 	ActionGroupIDs   []string
-	InTrash         bool
-	Schedule        TaskSchedule
-	Type            TaskType
-	TodayIndex      int
-	DueOrder        int
-	AlarmTimeOffset *int
-	TagIDs          []string
-	RecurrenceIDs   []string
-	DelegateIDs     []string
+	InTrash          bool
+	Schedule         TaskSchedule
+	Type             TaskType
+	TodayIndex       int
+	DueOrder         int
+	AlarmTimeOffset  *int
+	TagIDs           []string
+	RecurrenceIDs    []string
+	DelegateIDs      []string
 }
 
 // TaskActionItemPayload describes the payload for modifying Tasks, and also Projects,
 // as projects are special kind of Tasks
 type TaskActionItemPayload struct {
-	Index             *int                   `json:"ix,omitempty"`
-	CreationDate      *Timestamp             `json:"cd,omitempty"`
-	ModificationDate  *Timestamp             `json:"md,omitempty"` // ok
-	ScheduledDate     *Timestamp             `json:"sr,omitempty"`
-	CompletionDate    *Timestamp             `json:"sp,omitempty"`
-	DeadlineDate      *Timestamp             `json:"dd,omitempty"`  //
-	TaskIR            *Timestamp             `json:"tir,omitempty"` // hm, not sure what tir stands for
-	Status            *TaskStatus            `json:"ss,omitempty"`
-	Type              *TaskType              `json:"tp,omitempty"`
-	Title             *string                `json:"tt,omitempty"`
-	Note              json.RawMessage        `json:"nt,omitempty"`
-	AreaIDs           *[]string              `json:"ar,omitempty"`
-	ParentTaskIDs     *[]string              `json:"pr,omitempty"`
-	TagIDs            []string               `json:"tg,omitempty"`
-	InTrash           *bool                  `json:"tr,omitempty"`
-	TaskIndex         *int                   `json:"ti,omitempty"`
-	RecurrenceTaskIDs *[]string              `json:"rt,omitempty"`
-	Schedule          *TaskSchedule          `json:"st,omitempty"`
-	ActionGroupIDs    *[]string              `json:"agr,omitempty"`
+	Index                     *int                   `json:"ix,omitempty"`
+	CreationDate              *Timestamp             `json:"cd,omitempty"`
+	ModificationDate          *Timestamp             `json:"md,omitempty"` // ok
+	ScheduledDate             *Timestamp             `json:"sr,omitempty"`
+	CompletionDate            *Timestamp             `json:"sp,omitempty"`
+	DeadlineDate              *Timestamp             `json:"dd,omitempty"`  //
+	TaskIR                    *Timestamp             `json:"tir,omitempty"` // hm, not sure what tir stands for
+	Status                    *TaskStatus            `json:"ss,omitempty"`
+	Type                      *TaskType              `json:"tp,omitempty"`
+	Title                     *string                `json:"tt,omitempty"`
+	Note                      json.RawMessage        `json:"nt,omitempty"`
+	AreaIDs                   *[]string              `json:"ar,omitempty"`
+	ParentTaskIDs             *[]string              `json:"pr,omitempty"`
+	TagIDs                    []string               `json:"tg,omitempty"`
+	InTrash                   *bool                  `json:"tr,omitempty"`
+	TaskIndex                 *int                   `json:"ti,omitempty"`
+	RecurrenceTaskIDs         *[]string              `json:"rt,omitempty"`
+	Schedule                  *TaskSchedule          `json:"st,omitempty"`
+	ActionGroupIDs            *[]string              `json:"agr,omitempty"`
 	Repeater                  *RepeaterConfiguration `json:"rr,omitempty"`
 	DueOrder                  *int                   `json:"do,omitempty"`
 	Leavable                  *bool                  `json:"lt,omitempty"`
@@ -306,9 +306,9 @@ type Tag struct {
 // TagActionItemPayload describes the payload for modifying Areas
 type TagActionItemPayload struct {
 	IX            *int            `json:"ix"`
-	Title         *string        `json:"tt"`
-	ShortHand     *string        `json:"sh"`
-	ParentTagIDs  *[]string      `json:"pn"`
+	Title         *string         `json:"tt"`
+	ShortHand     *string         `json:"sh"`
+	ParentTagIDs  *[]string       `json:"pn"`
 	ExtensionData json.RawMessage `json:"xx,omitempty"`
 }
 
@@ -361,14 +361,14 @@ func (item AreaActionItem) UUID() string {
 }
 
 // CheckListItem describes a check list item
-//0|uuid|TEXT|0||1
-//1|userModificationDate|REAL|0||0
-//2|creationDate|REAL|0||0
-//3|title|TEXT|0||0
-//4|status|INTEGER|0||0
-//5|stopDate|REAL|0||0
-//6|index|INTEGER|0||0
-//7|task|TEXT|0||0
+// 0|uuid|TEXT|0||1
+// 1|userModificationDate|REAL|0||0
+// 2|creationDate|REAL|0||0
+// 3|title|TEXT|0||0
+// 4|status|INTEGER|0||0
+// 5|stopDate|REAL|0||0
+// 6|index|INTEGER|0||0
+// 7|task|TEXT|0||0
 type CheckListItem struct {
 	UUID             string
 	CreationDate     time.Time
@@ -382,11 +382,11 @@ type CheckListItem struct {
 
 // CheckListActionItemPayload describes the payload for modifying CheckListItems
 type CheckListActionItemPayload struct {
-	CreationDate     *Timestamp  `json:"cd,omitempty"`
-	ModificationDate *Timestamp  `json:"md,omitempty"`
-	Index            *int        `json:"ix"`
-	Status           *TaskStatus `json:"ss,omitempty"`
-	Title            *string     `json:"tt,omitempty"`
+	CreationDate     *Timestamp      `json:"cd,omitempty"`
+	ModificationDate *Timestamp      `json:"md,omitempty"`
+	Index            *int            `json:"ix"`
+	Status           *TaskStatus     `json:"ss,omitempty"`
+	Title            *string         `json:"tt,omitempty"`
 	CompletionDate   *Timestamp      `json:"sp,omitempty"`
 	TaskIDs          *[]string       `json:"ts,omitempty"`
 	Leavable         *bool           `json:"lt,omitempty"`

--- a/verify.go
+++ b/verify.go
@@ -22,7 +22,7 @@ type VerifyResponse struct {
 	Email              string          `json:"email"`
 	MaildropEmail      string          `json:"maildrop-email"`
 	Status             AccountStatus   `json:"status"`
-	HistoryKey string `json:"history-key"`
+	HistoryKey         string          `json:"history-key"`
 }
 
 // Verify checks that the provided API credentials are valid.


### PR DESCRIPTION
Add a `Makefile` lint target as shared local and CI entrypoint. Configure `golangci-lint` with no default linters and enable only `gofmt` so checks can be added independently.

Assisted-by: Codex