### PR TITLE
Prevent request-construction panics and remove redundant code

### DIFF
--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"flag"
@@ -324,5 +323,3 @@ func fatal(msg string) {
 	fmt.Fprintln(os.Stderr, "soak: "+msg)
 	os.Exit(1)
 }
-
-var _ = bufio.NewReader // reserved for future interactive confirm

--- a/docs/plans/2026-09-05-code-cleanup.md
+++ b/docs/plans/2026-09-05-code-cleanup.md
@@ -1,0 +1,51 @@
+# Code cleanup after v0.5.0
+
+Baseline: `0c748970026507bbbf75936e38ffbc8ce5ed23dd`. `develop` has been rebased onto the released `main` commit.
+
+## First change: request construction and redundant code
+
+1. Add regression tests for invalid account/history identifiers in `Client.Verify`, `History.Items`, and `History.Write`. Require errors instead of panics, no HTTP requests, and unchanged history cursors.
+2. Lock the valid commit request headers and query parameters with a regression test before removing duplicate assignments.
+3. Move request-construction error checks before any request access. Keep existing payloads, response handling, status errors, and authentication behavior.
+4. Remove write headers already supplied by `Client.do`. Replace the test-only `asHTTPError` wrapper with direct `errors.As` calls.
+5. Delete the duplicate task-title assignment and commented-out import in memory replay, covered by the existing title-update and replay tests. Delete the unused `bufio` import and placeholder reference in the soak tool; these have no runtime behavior.
+6. Run focused tests, then build, race-enabled tests, lint, and diff checks. Get an independent review before opening a draft PR against `develop`.
+
+No dependencies or new production abstractions are needed. Changes to the persistent sync schema, CLI architecture, public error types, or debug logging policy belong in separate work.
+
+## Audit findings and follow-up
+
+The following findings are based on code inspection, not live-account testing. They remain outside this first patch. Address correctness before larger structural refactors.
+
+### Next priority: CLI write validation
+
+- `cmd/things-cli/main.go`, `cmdCreateArea` and `cmdCreateTag`: area tag references and parent-tag identifiers bypass `validateIdentifierOpts`. `History.Write` validates only envelope identifiers. Reuse and extend the existing validator, test invalid relationship IDs with a fake server, and assert no commit is sent. Also check that tag whitespace handling produces the same values that validation accepts.
+- `parseDate`, task create/edit, and batch handling silently omit invalid dates or ignore unknown schedule names. Reject invalid options before a write, with tests covering both individual and batch commands. This changes previously permissive CLI behavior and should be documented.
+
+### Sync correctness
+
+- `sync/detect.go`, `detectTaskChanges`: project/area assignment changes are never compared, even though `TaskAssignedToProject` and `TaskAssignedToArea` are public types consumed by `thingsync`. Define assignment, reassignment, and removal event payloads before implementation; test all three.
+- `sync/store.go`, `logChange`, and `sync/sync.go`, `ChangesSince`: storage and query cursors use integer Unix seconds with a strict greater-than comparison. A later event in the same second as a cursor is omitted. Choose a precise cursor/storage contract and a migration strategy; test a cursor between two same-second changes.
+- `sync/process.go`, `processTombstone`: all four entity lookups discard errors. A lookup failure can be treated as absence, letting a batch advance past an unapplied deletion. Propagate failures and verify transaction rollback and unchanged sync position under an injected lookup error.
+- `state/memory/memory.go`, `hasArea`: recursive parent traversal has no cycle detection. Add a visited set and tests for self-cycles, multi-node cycles, and a cycle with another parent reaching an area.
+
+### Decisions needed before broader refactoring
+
+- Memory replay deliberately skips malformed payloads despite returning `error`. Decide whether replay remains best-effort with diagnostics or becomes strict, including partial-state semantics. Do not simply change `continue` to `return` without defining what happens to already-applied items.
+- CLI date writes encode a local calendar date at UTC midnight, but `listTasks` compares against the current UTC day. Around local midnight this can disagree with `--when today`. Specify date-only wire semantics, then test positive and negative time zones with a fixed clock; do not apply a blanket UTC-to-local conversion.
+- SQLite legacy identifier remapping still needs a database migration/rebuild decision, as documented in v0.5.0.
+- Checklist modification dates are applied in memory by the sync processor but are absent from the persistence schema. Area tags and area/tag ordering are also only partially modeled. Group schema changes into a separately tested migration.
+- `thingsync` discards query errors in multiple output builders, which can report incomplete data as a successful result. Refactor those functions to return errors, with closed-database tests, as a separate CLI change.
+
+### Lower-priority simplification candidates
+
+- `cmd/soak`, `runCLI`: every caller ignores its JSON result, and JSON decoding errors are already discarded. Remove the unused return and decoding after locking subprocess success/failure reporting with an offline test.
+- Several debug commands have personal hardcoded task IDs. Confirm continued maintainer use before deleting these entry points; avoid turning them into a new CLI framework merely to retain them.
+- Consolidate or synchronize CLI command documentation, and define deterministic ordering for map-backed area/tag listings if callers need stable output.
+- SDK HTTP status errors mix strings and `HTTPError`; debug output also dumps full requests/responses. Handle error compatibility and logging/redaction policy in a separate patch.
+
+## Verification of the first patch
+
+Before editing production code, the new regression test reproduced nil-request panics in all three affected methods. The valid commit metadata test passed on the baseline. Existing memory replay/title tests passed before removing the duplicate assignment.
+
+After cleanup, `go build ./...`, `go test -race ./...`, `make lint` (zero issues), and `git diff --check` all pass. No live-account or soak test was run.

--- a/histories.go
+++ b/histories.go
@@ -243,21 +243,18 @@ func (h *History) Write(items ...Identifiable) error {
 		return err
 	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("/version/1/history/%s/commit", h.ID), bytes.NewReader(bs))
+	if err != nil {
+		return err
+	}
 	req.Header.Add("Schema", "301")
 	req.Header.Add("Push-Priority", "5")
 	// Full App-Instance-Id matching Things format: {hash}-{bundleId}-{hash}
 	req.Header.Add("App-Instance-Id", "000000000000000000000000000000000000000000000000000000000000000-com.culturedcode.ThingsMac-000000000000000000000000000000000000000000000000000000000000000")
 	req.Header.Add("App-Id", "com.culturedcode.ThingsMac")
-	req.Header.Add("Content-Encoding", "UTF-8")
-	req.Header.Add("Host", "cloud.culturedcode.com")
-	req.Header.Add("Accept", "application/json")
 	query := req.URL.Query()
 	query.Add("ancestor-index", strconv.Itoa(h.LatestServerIndex))
 	query.Add("_cnt", "1")
 	req.URL.RawQuery = query.Encode()
-	if err != nil {
-		return err
-	}
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return err

--- a/histories_coverage_test.go
+++ b/histories_coverage_test.go
@@ -6,12 +6,6 @@ import (
 	"testing"
 )
 
-// asHTTPError reports whether err (or a wrapped error) is an *HTTPError, and if
-// so stores it in *target.
-func asHTTPError(err error, target **HTTPError) bool {
-	return errors.As(err, target)
-}
-
 func TestClient_History(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
@@ -58,7 +52,7 @@ func TestClient_History(t *testing.T) {
 		c := New(server.URL, "martin@example.com", "")
 		_, err := c.History("id")
 		var httpErr *HTTPError
-		if !asHTTPError(err, &httpErr) {
+		if !errors.As(err, &httpErr) {
 			t.Fatalf("History err = %v, want *HTTPError", err)
 		}
 		if httpErr.StatusCode != http.StatusInternalServerError {
@@ -142,7 +136,7 @@ func TestHistory_Sync_ErrorStatus(t *testing.T) {
 	h := History{Client: c, ID: "id"}
 	err := h.Sync()
 	var httpErr *HTTPError
-	if !asHTTPError(err, &httpErr) {
+	if !errors.As(err, &httpErr) {
 		t.Fatalf("Sync err = %v, want *HTTPError", err)
 	}
 }

--- a/items.go
+++ b/items.go
@@ -40,14 +40,14 @@ type ItemsOptions struct {
 // Note that if a item was changed multiple times it will be present multiple times in the result too.
 func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("/version/1/history/%s/items", h.ID), nil)
+	if err != nil {
+		return nil, false, err
+	}
 
 	values := req.URL.Query()
 	values.Set("start-index", strconv.Itoa(opts.StartIndex))
 	req.URL.RawQuery = values.Encode()
 
-	if err != nil {
-		return nil, false, err
-	}
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return nil, false, err

--- a/request_regression_test.go
+++ b/request_regression_test.go
@@ -1,0 +1,103 @@
+package thingscloud
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestInvalidRequestIdentifiersReturnErrors(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"Verify", "Items", "Write"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("%s panicked instead of returning a request error: %v", operation, p)
+				}
+			}()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("invalid identifier reached the HTTP server")
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			c := New(server.URL, "bad\nemail", "password")
+			h := c.HistoryWithID("bad\nhistory")
+			h.LatestServerIndex = 42
+			h.LoadedServerIndex = 21
+
+			var err error
+			switch operation {
+			case "Verify":
+				var response *VerifyResponse
+				response, err = c.Verify()
+				if response != nil {
+					t.Error("Verify returned a response for an invalid request")
+				}
+			case "Items":
+				var items []Item
+				var more bool
+				items, more, err = h.Items(ItemsOptions{StartIndex: 21})
+				if items != nil || more {
+					t.Errorf("Items returned (%v, %v) for an invalid request", items, more)
+				}
+			case "Write":
+				err = h.Write(TaskActionItem{
+					Item: Item{UUID: NewUUID(), Kind: ItemKindTask, Action: ItemActionCreated},
+					P:    TaskActionItemPayload{Title: String("test")},
+				})
+			}
+			var urlErr *url.Error
+			if !errors.As(err, &urlErr) {
+				t.Fatalf("%s error = %v, want request URL error", operation, err)
+			}
+			if h.LatestServerIndex != 42 || h.LoadedServerIndex != 21 {
+				t.Errorf("invalid request changed history cursors: %+v", h)
+			}
+		})
+	}
+}
+
+func TestHistoryWritePreservesRequestMetadata(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/version/1/history/history-id/commit" {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+		}
+		for key, want := range map[string]string{
+			"Schema": "301", "Push-Priority": "5", "App-Id": "com.culturedcode.ThingsMac",
+			"Accept": "application/json", "Content-Encoding": "UTF-8",
+			"Content-Type": "application/json; charset=UTF-8", "User-Agent": ThingsUserAgent,
+		} {
+			if got := r.Header.Get(key); got != want {
+				t.Errorf("%s = %q, want %q", key, got, want)
+			}
+		}
+		if r.Header.Get("App-Instance-Id") == "" || r.Header.Get("Things-Client-Info") == "" {
+			t.Error("missing app instance or client info header")
+		}
+		if got := r.URL.Query().Get("ancestor-index"); got != "42" {
+			t.Errorf("ancestor-index = %q, want 42", got)
+		}
+		if got := r.URL.Query().Get("_cnt"); got != "1" {
+			t.Errorf("_cnt = %q, want 1", got)
+		}
+		_, _ = w.Write([]byte(`{"server-head-index":43}`))
+	}))
+	defer server.Close()
+	c := New(server.URL, "test@example.com", "password")
+	h := c.HistoryWithID("history-id")
+	h.LatestServerIndex = 42
+	if err := h.Write(TaskActionItem{
+		Item: Item{UUID: NewUUID(), Kind: ItemKindTask, Action: ItemActionCreated},
+		P:    TaskActionItemPayload{Title: String("test")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if h.LatestServerIndex != 43 {
+		t.Errorf("LatestServerIndex = %d, want 43", h.LatestServerIndex)
+	}
+}

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"encoding/json"
-	// "fmt"
 	"sort"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -162,9 +161,6 @@ func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 				}
 			}
 		}
-	}
-	if item.P.Title != nil {
-		t.Title = *item.P.Title
 	}
 	if item.P.AlarmTimeOffset != nil {
 		t.AlarmTimeOffset = item.P.AlarmTimeOffset

--- a/verify.go
+++ b/verify.go
@@ -28,10 +28,10 @@ type VerifyResponse struct {
 // Verify checks that the provided API credentials are valid.
 func (c *Client) Verify() (*VerifyResponse, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("/version/1/account/%s", c.EMail), nil)
-	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Invalid account or history identifiers can make `http.NewRequest` fail, leaving a nil request. `Verify`, `Items`, and `Write` accessed that request before checking the error, so malformed input panicked instead of returning an error. This patch checks construction errors first and keeps failed requests from reaching the server or changing history cursors.

The cleanup also removes write headers already supplied by `Client.do`, a test wrapper around `errors.As`, a duplicate title assignment and commented import in memory replay, and an unused import/placeholder in the soak tool. No dependencies or production abstractions were added.

## Validation

- New regression tests reproduced all three panics before production edits; the valid commit metadata test passed before cleanup.
- `go build ./...`
- `go test -race ./...`
- `make lint` (zero issues)
- `git diff --check`
- Existing title-update/replay tests cover the duplicate assignment removal.
- No live Things Cloud account or soak test was used.

## Audit follow-up

The [cleanup plan](docs/plans/2026-09-05-code-cleanup.md) records the broader SDK, CLI, and sync audit and separates follow-up defects from design choices. Highest priorities include CLI relationship-ID/date validation, missing project/area change events, second-resolution change cursors, discarded tombstone lookup errors, and cyclic parent traversal. Those issues remain outside this patch.

Based on `develop` after rebasing it onto the v0.5.0 main commit. Draft for review; this is preparation for the next development cycle.
