### PR TITLE
Reject malformed CLI write options before committing changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":
 
 ### Examples
 
+Write commands reject invalid relationship identifiers, schedule/type names, and calendar dates before sending a commit. Tag IDs must be canonical Base58 with no surrounding whitespace. Batch input is validated in full before its single commit; see [CLI write validation](cmd/README.md#write-validation) for supported options and batch `extra` rules.
+
 ```bash
 # Create a project with tasks
 things-cli create "My Project" --type project --when anytime

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -40,8 +40,8 @@ things-cli move-to-today <uuid>
 echo '[
   {"cmd": "create", "title": "Task 1"},
   {"cmd": "create", "title": "Task 2"},
-  {"cmd": "complete", "uuid": "abc123"},
-  {"cmd": "move-to-project", "uuid": "def456", "project": "proj-uuid"}
+  {"cmd": "complete", "uuid": "BXmAcvS6yK1eDhW31MuZrL"},
+  {"cmd": "move-to-project", "uuid": "VJ1edXTP9q3PmFDUuy8EQh", "project": "FQxaqvLBkbR5q2Q5oRoknc"}
 ]' | things-cli batch
 
 # Batch commands: create, complete, trash, purge, move-to-today,
@@ -61,6 +61,22 @@ echo '[
 #   --tags UUID,UUID,...    Add tags
 #   --type task|project|heading
 #   --checklist "Item 1,Item 2,..."
+```
+
+#### Write validation
+
+Replace the sample UUIDs above with IDs returned by `create` or `list` for your account.
+
+Invalid identifiers, schedule names, task types, and dates cause a nonzero exit before any commit is sent. Identifiers must be canonical Base58 exactly as supplied, including `create-area --tags`, `create-tag --parent`, and purge targets. Do not include spaces around comma-separated tag IDs.
+
+`--when` accepts `today`, `anytime`, `someday`, or `inbox`; `--type` accepts `task`, `project`, or `heading`. Dates must be real calendar dates in `YYYY-MM-DD` format. Invalid or missing option values are rejected instead of silently producing default or partial writes.
+
+A batch is submitted only after every operation passes validation. Its input must contain one JSON array, with no unknown top-level operation fields or trailing input. Empty optional top-level batch strings retain their existing meaning of "not supplied." Explicitly empty identifier options in individual commands or `extra` are rejected; omit an optional identifier instead.
+
+Batch `create` also accepts an `extra` object containing `note`, `when`, `deadline`, `scheduled`, `project`, `area`, `heading`, `tags`, or `type`. These values override the corresponding create options and are validated after merging. `extra.tags` is comma-separated text; top-level `tags` is a JSON array. Other operations reject an `extra` object, including `{}`; `extra: null` is treated as absent. For example:
+
+```json
+[{"cmd":"create","title":"Plan launch","extra":{"scheduled":"2026-10-15"}}]
 ```
 
 ### thingsync

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -140,18 +141,46 @@ func generateUUID() string {
 // identifier. Invalid identifiers written to the cloud poison the sync
 // history irreparably, so they must be rejected before any write.
 func validateIdentifierOpts(opts map[string]string) error {
-	for _, key := range []string{"uuid", "project", "heading", "area"} {
-		if v, ok := opts[key]; ok && v != "" {
+	for _, key := range []string{"uuid", "project", "heading", "area", "parent"} {
+		if v, ok := opts[key]; ok {
 			if err := thingscloud.ValidateUUID(v); err != nil {
 				return fmt.Errorf("--%s: %w", key, err)
 			}
 		}
 	}
-	if v, ok := opts["tags"]; ok && v != "" {
+	if v, ok := opts["tags"]; ok {
 		for _, tag := range strings.Split(v, ",") {
-			if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+			if err := thingscloud.ValidateUUID(tag); err != nil {
 				return fmt.Errorf("--tags: %w", err)
 			}
+		}
+	}
+	return nil
+}
+
+// validateTaskOpts runs before building a task payload so unsupported values
+// cannot silently fall back to a default or omit a requested update.
+func validateTaskOpts(opts map[string]string) error {
+	if err := validateIdentifierOpts(opts); err != nil {
+		return err
+	}
+	if v, ok := opts["when"]; ok {
+		switch v {
+		case "today", "anytime", "someday", "inbox":
+		default:
+			return fmt.Errorf("--when: %q is invalid; expected today, anytime, someday, or inbox", v)
+		}
+	}
+	if v, ok := opts["type"]; ok {
+		switch v {
+		case "task", "project", "heading":
+		default:
+			return fmt.Errorf("--type: %q is invalid; expected task, project, or heading", v)
+		}
+	}
+	for _, key := range []string{"deadline", "scheduled"} {
+		if v, ok := opts[key]; ok && parseDate(v) == nil {
+			return fmt.Errorf("--%s: %q is invalid; expected a calendar date in YYYY-MM-DD format", key, v)
 		}
 	}
 	return nil
@@ -172,7 +201,7 @@ func validateBatchOpIdentifiers(op BatchOp) error {
 		}
 	}
 	for _, tag := range op.Tags {
-		if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+		if err := thingscloud.ValidateUUID(tag); err != nil {
 			return fmt.Errorf("tags: %w", err)
 		}
 	}
@@ -931,7 +960,7 @@ func cmdCreate(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
-	if err := validateIdentifierOpts(opts); err != nil {
+	if err := validateTaskOpts(opts); err != nil {
 		fatal("create task", err)
 	}
 
@@ -974,7 +1003,7 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
 		fatal("edit", err)
 	}
-	if err := validateIdentifierOpts(opts); err != nil {
+	if err := validateTaskOpts(opts); err != nil {
 		fatal("edit", err)
 	}
 
@@ -1073,6 +1102,9 @@ func cmdTrash(history *thingscloud.History, taskUUID string) {
 }
 
 func cmdPurge(history *thingscloud.History, taskUUID string) {
+	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
+		fatal("purge uuid", err)
+	}
 	tombstoneUUID := generateUUID()
 	payload := map[string]any{
 		"dloid": taskUUID,
@@ -1103,6 +1135,9 @@ func cmdCreateArea(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("create area", err)
+	}
 
 	areaUUID := opts["uuid"]
 	if areaUUID == "" {
@@ -1134,6 +1169,9 @@ func cmdCreateTag(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("create tag", err)
+	}
 
 	tagUUID := opts["uuid"]
 	if tagUUID == "" {
@@ -1184,14 +1222,20 @@ type BatchOp struct {
 	Heading  string            `json:"heading,omitempty"`
 	Tags     []string          `json:"tags,omitempty"`
 	Type     string            `json:"type,omitempty"`
-	Extra    map[string]string `json:"extra,omitempty"` // for any additional opts
+	Extra    map[string]string `json:"extra,omitempty"` // supported create options; overrides top-level values
 }
 
 func cmdBatch(history *thingscloud.History) {
 	// Read JSON from stdin
 	var ops []BatchOp
-	if err := json.NewDecoder(os.Stdin).Decode(&ops); err != nil {
+	decoder := json.NewDecoder(os.Stdin)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&ops); err != nil {
 		fatalf("parsing batch JSON: %v", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		fatalf("parsing batch JSON: expected a single array with no trailing input")
 	}
 
 	if len(ops) == 0 {
@@ -1224,6 +1268,9 @@ func cmdBatch(history *thingscloud.History) {
 }
 
 func buildBatchEnvelope(op BatchOp) (thingscloud.Identifiable, map[string]string, error) {
+	if op.Cmd != "create" && op.Extra != nil {
+		return nil, nil, fmt.Errorf("extra options are only supported for create")
+	}
 	switch op.Cmd {
 	case "create":
 		return buildBatchCreate(op)
@@ -1286,7 +1333,15 @@ func buildBatchCreate(op BatchOp) (thingscloud.Identifiable, map[string]string, 
 		opts["type"] = op.Type
 	}
 	for k, v := range op.Extra {
-		opts[k] = v
+		switch k {
+		case "note", "when", "deadline", "scheduled", "project", "area", "heading", "tags", "type":
+			opts[k] = v
+		default:
+			return nil, nil, fmt.Errorf("unsupported create extra option: %s", k)
+		}
+	}
+	if err := validateTaskOpts(opts); err != nil {
+		return nil, nil, err
 	}
 
 	payload := newTaskCreatePayload(op.Title, opts)
@@ -1321,6 +1376,9 @@ func buildBatchTrash(op BatchOp) (thingscloud.Identifiable, map[string]string, e
 func buildBatchPurge(op BatchOp) (thingscloud.Identifiable, map[string]string, error) {
 	if op.UUID == "" {
 		return nil, nil, fmt.Errorf("purge requires uuid")
+	}
+	if err := thingscloud.ValidateUUID(op.UUID); err != nil {
+		return nil, nil, fmt.Errorf("uuid: %w", err)
 	}
 
 	tombstoneUUID := generateUUID()
@@ -1383,6 +1441,16 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 		return nil, nil, fmt.Errorf("edit requires uuid")
 	}
 	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
+	opts := make(map[string]string)
+	if op.When != "" {
+		opts["when"] = op.When
+	}
+	if op.Deadline != "" {
+		opts["deadline"] = op.Deadline
+	}
+	if err := validateTaskOpts(opts); err != nil {
 		return nil, nil, err
 	}
 
@@ -1481,7 +1549,7 @@ Write commands (fast — skip state loading):
 Batch command (reads JSON from stdin, sends all ops in one HTTP request):
   batch
 
-  Example: echo '[{"cmd":"complete","uuid":"abc"},{"cmd":"trash","uuid":"def"}]' | things-cli batch
+  Example: echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":"VJ1edXTP9q3PmFDUuy8EQh"}]' | things-cli batch
 
   Supported operations:
     {"cmd": "create", "title": "...", "note": "...", "when": "today|anytime|someday|inbox",

--- a/cmd/things-cli/validation_test.go
+++ b/cmd/things-cli/validation_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+)
+
+const cliValidationHelper = "THINGS_CLI_VALIDATION_HELPER"
+
+// TestCLIValidationHelper runs the real main function in a subprocess so its
+// os.Exit paths can be asserted without changing production error handling.
+func TestCLIValidationHelper(t *testing.T) {
+	if os.Getenv(cliValidationHelper) == "" {
+		return
+	}
+	var args []string
+	if err := json.Unmarshal([]byte(os.Getenv("THINGS_CLI_VALIDATION_ARGS")), &args); err != nil {
+		t.Fatal(err)
+	}
+	os.Args = append([]string{"things-cli"}, args...)
+	main()
+}
+
+type cliValidationCloud struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func newCLIValidationCloud(t *testing.T) *cliValidationCloud {
+	t.Helper()
+	c := &cliValidationCloud{}
+	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/commit"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read commit: %v", err)
+			}
+			c.mu.Lock()
+			c.bodies = append(c.bodies, body)
+			c.mu.Unlock()
+			_, _ = io.WriteString(w, `{"server-head-index":2}`)
+		case strings.HasSuffix(r.URL.Path, "/items"):
+			_, _ = io.WriteString(w, `{"items":[],"current-item-index":1,"schema":301}`)
+		case strings.Contains(r.URL.Path, "/account/"):
+			_, _ = io.WriteString(w, `{"email":"validation@example.com","status":"SYAccountStatusActive","history-key":"validation-history"}`)
+		default:
+			_, _ = io.WriteString(w, `{}`)
+		}
+	}))
+	t.Cleanup(c.server.Close)
+	return c
+}
+
+func (c *cliValidationCloud) commits() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]byte(nil), c.bodies...)
+}
+
+func runValidationCLI(t *testing.T, cloud *cliValidationCloud, stdin string, args ...string) (int, string) {
+	t.Helper()
+	encodedArgs, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestCLIValidationHelper$")
+	cmd.Env = append(os.Environ(),
+		cliValidationHelper+"=1",
+		"THINGS_CLI_VALIDATION_ARGS="+string(encodedArgs),
+		"THINGS_ENDPOINT="+cloud.server.URL,
+		"THINGS_USERNAME=validation@example.com",
+		"THINGS_PASSWORD=test-password",
+	)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("CLI subprocess timed out: %v\n%s", ctx.Err(), out)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), string(out)
+	}
+	t.Fatalf("run CLI: %v", err)
+	return -1, ""
+}
+
+func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
+	id := thingscloud.NewUUID()
+	otherID := thingscloud.NewUUID()
+	validCreate := fmt.Sprintf(`{"cmd":"create","title":"valid","uuid":%q}`, otherID)
+
+	tests := []struct {
+		name  string
+		args  []string
+		stdin string
+		field string
+	}{
+		{"area malformed tag", []string{"create-area", "Area", "--tags", "bad-tag"}, "", "tags"},
+		{"area padded tag", []string{"create-area", "Area", "--tags", " " + id + " "}, "", "tags"},
+		{"area empty tag component", []string{"create-area", "Area", "--tags", id + ",," + otherID}, "", "tags"},
+		{"area empty tags value", []string{"create-area", "Area", "--tags", ""}, "", "tags"},
+		{"tag malformed parent", []string{"create-tag", "Tag", "--parent", "bad-parent"}, "", "parent"},
+		{"tag padded parent", []string{"create-tag", "Tag", "--parent", " " + id + " "}, "", "parent"},
+		{"tag empty parent value", []string{"create-tag", "Tag", "--parent", ""}, "", "parent"},
+		{"create empty project value", []string{"create", "Task", "--project", ""}, "", "project"},
+		{"create empty uuid value", []string{"create", "Task", "--uuid", ""}, "", "uuid"},
+		{"create padded tag", []string{"create", "Task", "--tags", " " + id + " "}, "", "tags"},
+		{"edit padded tag", []string{"edit", id, "--tags", " " + otherID + " "}, "", "tags"},
+		{"edit empty tags value", []string{"edit", id, "--tags", ""}, "", "tags"},
+		{"create invalid when", []string{"create", "Task", "--when", "tomorrow"}, "", "when"},
+		{"create empty when", []string{"create", "Task", "--when", ""}, "", "when"},
+		{"create missing when value", []string{"create", "Task", "--when"}, "", "when"},
+		{"edit invalid when", []string{"edit", id, "--when", "tomorrow"}, "", "when"},
+		{"edit empty when", []string{"edit", id, "--when", ""}, "", "when"},
+		{"edit missing when value", []string{"edit", id, "--when"}, "", "when"},
+		{"create impossible deadline", []string{"create", "Task", "--deadline", "2026-02-30"}, "", "deadline"},
+		{"create malformed deadline", []string{"create", "Task", "--deadline", "02/28/2026"}, "", "deadline"},
+		{"create empty deadline", []string{"create", "Task", "--deadline", ""}, "", "deadline"},
+		{"create missing deadline value", []string{"create", "Task", "--deadline"}, "", "deadline"},
+		{"edit impossible deadline", []string{"edit", id, "--deadline", "2026-02-30"}, "", "deadline"},
+		{"edit malformed deadline", []string{"edit", id, "--deadline", "02/28/2026"}, "", "deadline"},
+		{"edit empty deadline", []string{"edit", id, "--deadline", ""}, "", "deadline"},
+		{"edit missing deadline value", []string{"edit", id, "--deadline"}, "", "deadline"},
+		{"create impossible scheduled", []string{"create", "Task", "--scheduled", "2026-02-30"}, "", "scheduled"},
+		{"create malformed scheduled", []string{"create", "Task", "--scheduled", "next-week"}, "", "scheduled"},
+		{"create empty scheduled", []string{"create", "Task", "--scheduled", ""}, "", "scheduled"},
+		{"create missing scheduled value", []string{"create", "Task", "--scheduled"}, "", "scheduled"},
+		{"edit impossible scheduled", []string{"edit", id, "--scheduled", "2026-02-30"}, "", "scheduled"},
+		{"edit malformed scheduled", []string{"edit", id, "--scheduled", "next-week"}, "", "scheduled"},
+		{"edit empty scheduled", []string{"edit", id, "--scheduled", ""}, "", "scheduled"},
+		{"edit missing scheduled value", []string{"edit", id, "--scheduled"}, "", "scheduled"},
+		{"create invalid type", []string{"create", "Task", "--type", "area"}, "", "type"},
+		{"purge invalid target", []string{"purge", "bad-target"}, "", "uuid"},
+		{"batch create invalid when", []string{"batch"}, `[{"cmd":"create","title":"x","when":"tomorrow"}]`, "when"},
+		{"batch create invalid deadline", []string{"batch"}, `[{"cmd":"create","title":"x","deadline":"2026-02-30"}]`, "deadline"},
+		{"batch create padded tag", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q]}]`, " "+id+" "), "tags"},
+		{"batch edit invalid when", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"when":"tomorrow"}]`, id), "when"},
+		{"batch edit invalid deadline", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"deadline":"bad-date"}]`, id), "deadline"},
+		{"batch edit padded tag", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"tags":[%q]}]`, id, " "+otherID+" "), "tags"},
+		{"batch extra project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":"bad-project"}}]`, id), "project"},
+		{"batch extra empty project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":""}}]`, id), "project"},
+		{"batch extra tags overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q],"extra":{"tags":"bad-tag"}}]`, id), "tags"},
+		{"batch extra empty tags overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q],"extra":{"tags":""}}]`, id), "tags"},
+		{"batch extra invalid when", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"when":"tomorrow"}}]`, "when"},
+		{"batch extra invalid deadline", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"deadline":"bad-date"}}]`, "deadline"},
+		{"batch extra invalid scheduled", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"scheduled":"bad-date"}}]`, "scheduled"},
+		{"batch extra invalid type", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"type":"area"}}]`, "type"},
+		{"batch create rejects unknown extra", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"checklist":"ignored"}}]`, "checklist"},
+		{"batch purge invalid target", []string{"batch"}, `[{"cmd":"purge","uuid":"bad-target"}]`, "uuid"},
+		{"batch unknown scheduled field", []string{"batch"}, `[{"cmd":"create","title":"x","scheduled":"2026-10-12"}]`, "scheduled"},
+		{"batch edit rejects extra", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"extra":{"scheduled":"2026-10-12"}}]`, id), "extra"},
+		{"batch edit rejects empty extra object", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"extra":{}}]`, id), "extra"},
+		{"batch rejects trailing JSON", []string{"batch"}, fmt.Sprintf(`[%s] {"extra":"value"}`, validCreate), "json"},
+		{"batch validates all operations atomically", []string{"batch"}, fmt.Sprintf(`[%s,{"cmd":"edit","uuid":%q,"deadline":"bad-date"}]`, validCreate, id), "deadline"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newCLIValidationCloud(t)
+			exitCode, output := runValidationCLI(t, cloud, tc.stdin, tc.args...)
+			if exitCode == 0 {
+				t.Errorf("exit code = 0, want nonzero; output:\n%s", output)
+			}
+			if !strings.Contains(strings.ToLower(output), tc.field) {
+				t.Errorf("output does not identify %q: %s", tc.field, output)
+			}
+			if got := len(cloud.commits()); got != 0 {
+				t.Errorf("commit requests = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestCLIWriteValidationAcceptsCanonicalReferencesExactly(t *testing.T) {
+	t.Run("area tags", func(t *testing.T) {
+		areaID, tag1, tag2 := thingscloud.NewUUID(), thingscloud.NewUUID(), thingscloud.NewUUID()
+		cloud := newCLIValidationCloud(t)
+		exitCode, output := runValidationCLI(t, cloud, "", "create-area", "Area", "--uuid", areaID, "--tags", tag1+","+tag2)
+		if exitCode != 0 {
+			t.Fatalf("exit code = %d: %s", exitCode, output)
+		}
+		payload := validationCommitPayload(t, cloud, areaID)
+		want := []string{tag1, tag2}
+		var got []string
+		if err := json.Unmarshal(payload["tg"], &got); err != nil {
+			t.Fatal(err)
+		}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("tg = %q, want exact refs %q", got, want)
+		}
+	})
+
+	t.Run("tag parent", func(t *testing.T) {
+		tagID, parentID := thingscloud.NewUUID(), thingscloud.NewUUID()
+		cloud := newCLIValidationCloud(t)
+		exitCode, output := runValidationCLI(t, cloud, "", "create-tag", "Tag", "--uuid", tagID, "--parent", parentID)
+		if exitCode != 0 {
+			t.Fatalf("exit code = %d: %s", exitCode, output)
+		}
+		payload := validationCommitPayload(t, cloud, tagID)
+		var got []string
+		if err := json.Unmarshal(payload["pn"], &got); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0] != parentID {
+			t.Errorf("pn = %q, want exact ref [%q]", got, parentID)
+		}
+	})
+}
+
+func TestCLIWriteValidationAcceptsBatchDatesAndScheduledExtra(t *testing.T) {
+	createID, editID := thingscloud.NewUUID(), thingscloud.NewUUID()
+	projectID, tagID := thingscloud.NewUUID(), thingscloud.NewUUID()
+	input := fmt.Sprintf(`[
+		{"cmd":"create","title":"dated","uuid":%q,"when":"someday","deadline":"2026-10-14","project":%q,"tags":[%q],"extra":{"when":"anytime","deadline":"2026-10-15","scheduled":"2026-10-12"}},
+		{"cmd":"edit","uuid":%q,"when":"someday","deadline":"2026-10-20"}
+	]`, createID, projectID, tagID, editID)
+	cloud := newCLIValidationCloud(t)
+	exitCode, output := runValidationCLI(t, cloud, input, "batch")
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d: %s", exitCode, output)
+	}
+
+	create := validationCommitPayload(t, cloud, createID)
+	edit := validationCommitPayload(t, cloud, editID)
+	requireWireUnixDate(t, create, "dd", "2026-10-15")
+	requireWireUnixDate(t, create, "sr", "2026-10-12")
+	requireWireUnixDate(t, create, "tir", "2026-10-12")
+	requireWireUnixDate(t, edit, "dd", "2026-10-20")
+	if string(create["st"]) != "1" || string(edit["st"]) != "2" {
+		t.Errorf("schedules create/edit = %s/%s, want 1/2", create["st"], edit["st"])
+	}
+	if string(create["pr"]) != fmt.Sprintf(`[%q]`, projectID) || string(create["tg"]) != fmt.Sprintf(`[%q]`, tagID) {
+		t.Errorf("create refs changed: pr=%s tg=%s", create["pr"], create["tg"])
+	}
+}
+
+func TestCLIWriteValidationAcceptsUnsetBatchOptionals(t *testing.T) {
+	id := thingscloud.NewUUID()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			"empty top-level strings without extra",
+			`[{"cmd":"create","title":"empty optionals","uuid":"","note":"","when":"","deadline":"","project":"","area":"","heading":"","tags":[],"type":""}]`,
+		},
+		{
+			"null extra",
+			fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"title":"updated","extra":null}]`, id),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newCLIValidationCloud(t)
+			exitCode, output := runValidationCLI(t, cloud, tc.input, "batch")
+			if exitCode != 0 {
+				t.Fatalf("exit code = %d: %s", exitCode, output)
+			}
+			if got := len(cloud.commits()); got != 1 {
+				t.Errorf("commit requests = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func validationCommitPayload(t *testing.T, cloud *cliValidationCloud, id string) map[string]json.RawMessage {
+	t.Helper()
+	bodies := cloud.commits()
+	if len(bodies) != 1 {
+		t.Fatalf("commit requests = %d, want 1", len(bodies))
+	}
+	var envelope map[string]struct {
+		Payload map[string]json.RawMessage `json:"p"`
+	}
+	if err := json.Unmarshal(bodies[0], &envelope); err != nil {
+		t.Fatalf("decode commit: %v", err)
+	}
+	item, ok := envelope[id]
+	if !ok {
+		t.Fatalf("commit has no item %q: %s", id, bodies[0])
+	}
+	return item.Payload
+}
+
+func requireWireUnixDate(t *testing.T, payload map[string]json.RawMessage, field, date string) {
+	t.Helper()
+	want, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int64
+	if err := json.Unmarshal(payload[field], &got); err != nil {
+		t.Fatalf("decode %s: %v", field, err)
+	}
+	if got != want.Unix() {
+		t.Errorf("%s = %d, want %d for %s", field, got, want.Unix(), date)
+	}
+}

--- a/docs/plans/2026-09-05-cli-write-validation.md
+++ b/docs/plans/2026-09-05-cli-write-validation.md
@@ -1,0 +1,20 @@
+# CLI write validation
+
+Based on the v0.5.0 `develop` branch. The request-handling cleanup remains a separate draft PR.
+
+## Plan before implementation
+
+1. Add subprocess tests against a fake Things Cloud endpoint. Invalid inputs must exit with an actionable error and send no commit. Include a batch with a valid operation followed by an invalid one to protect all-or-nothing submission.
+2. Reuse the existing identifier validator for area tags and parent tags, and validate purge target IDs before constructing tombstones. Check tag IDs exactly as written; do not validate trimmed text and then send the untrimmed value.
+3. Add one shared validator for the supported task schedule names, task types, and calendar dates. Apply it before task create/edit payload construction and in batch create/edit handling. Preserve existing schedule precedence and date encoding for valid inputs.
+4. Validate batch create options after merging `extra`, so overrides cannot bypass validation. Validate purge IDs as well. Reject ignored `extra` options on non-create operations and unsupported keys inside create `extra`. Reject unknown batch JSON fields and trailing input to catch unsupported or misspelled fields and incomplete submissions.
+5. Document the stricter validation and existing batch `extra.scheduled` support. Keep CLI parsing, payload builders, the SDK API, and date/time-zone semantics otherwise intact; no new dependencies.
+6. Run new regressions before production edits, then focused wire tests, build, race tests, lint, and independent review. Open a separate draft PR against `develop`.
+
+## Compatibility
+
+Previously accepted malformed dates, unrecognized schedule/type names, whitespace-padded tag IDs, and invalid relationship references now fail before a commit is sent. Absent options and empty optional top-level batch strings retain their existing defaults; explicitly empty identifiers in CLI options or `extra` fail validation. Batch create retains its existing `extra` override precedence, but final values must pass validation. Non-create operations reject even an empty `extra` object, while JSON null is treated as absent. Batch scheduling uses `extra.scheduled`; this patch does not add a top-level `scheduled` field or new edit scheduling features.
+
+## Verification
+
+Before production edits, subprocess regressions demonstrated rejected-input cases exiting successfully and sending commits; valid cases passed on the baseline. After implementation, the CLI subprocess/wire tests, `go build ./...`, `go test -race ./...`, `make lint` (zero issues), and `git diff --check` pass. The tests use a fake cloud endpoint; no live-account writes or soak test were run.


### PR DESCRIPTION
Malformed CLI options could produce unintended cloud writes: unsupported schedules silently became defaults, invalid dates were omitted, and some relationship identifiers bypassed validation. This PR makes those inputs fail with an actionable error before a commit is sent.

## Implemented behavior

- `create-area --tags` and `create-tag --parent` use the existing identifier validator. Purge validates the target identifier inside its tombstone payload, rather than relying on validation of the separately generated envelope ID.
- Task create/edit commands validate schedule names and real calendar dates before building payloads; creation also validates task type. Identifiers are checked exactly as submitted, including whitespace and explicitly empty values.
- Batch create validates the effective options after merging `extra`, closing the override bypass. Unknown operation fields, trailing JSON/input, unsupported create `extra` keys, and `extra` objects on other operations are rejected.
- Every batch operation is built and validated before the single `History.Write` call. For example, a valid create followed by an edit with an invalid deadline now sends zero commits.

Examples of corrected behavior:

| Input | Previous behavior | New behavior |
| --- | --- | --- |
| `create "Task" --when tomorrow` | Creates with the default schedule | Exits with a `--when` validation error |
| `edit <valid-id> --deadline 2026-02-30` | Omits the requested deadline and can report success | Exits with a date validation error |
| `create-area "Area" --tags <invalid-id>` | Sends the invalid relationship | Exits before the commit |
| `purge <invalid-id>` | Generates a valid envelope around an invalid target | Rejects the target UUID |
| Batch create with invalid `extra.project` | Override bypasses earlier validation | Rejects the merged value |

## Compatibility and scope

- Supported `when` values: `today`, `anytime`, `someday`, `inbox`. Supported create `type` values: `task`, `project`, `heading`.
- Dates must be real dates in `YYYY-MM-DD` format. Explicitly empty or missing single-command date/schedule values are errors.
- Identifiers with surrounding whitespace or explicitly empty identifier options are errors; omit an optional identifier instead.
- Empty optional top-level batch strings retain their existing unset semantics. Batch create retains valid `extra` override precedence and supports scheduling through `extra.scheduled`.
- Non-create operations reject an `extra` object, including `{}`. `extra: null` is treated as absent.
- Valid payloads, scheduling precedence, and date encoding remain the same. No dependencies or new batch fields were added; the shared validators reuse the existing UUID and date parsing code.
- This PR **does not implement Task7 reads, cache/database recovery, or the SQLite `tir`/`sr` correction**. Those belong to #29. It also does not fix #26: a valid future `--scheduled` date is still encoded with the wrong default schedule enum (`st=1` instead of Upcoming's `st=2`) in create, edit, and batch create. Validation success does not establish correct future-scheduling behavior; that correction needs a separate patch. This PR is independent of the request-construction cleanup in #28.

## Changed files

- `cmd/things-cli/main.go`: validation and batch parsing.
- `cmd/things-cli/validation_test.go`: subprocess regressions and valid wire-value checks.
- `README.md` and `cmd/README.md`: stricter input rules and corrected canonical-ID examples.
- `docs/plans/2026-09-05-cli-write-validation.md`: implementation plan, compatibility decisions, and verification record.

## Verification

- New subprocess regressions reproduced the bugs before production edits: invalid inputs exited successfully and reached the fake commit endpoint.
- The real CLI `main` runs in timeout-bounded subprocesses against a fake cloud. Rejection tests assert nonzero exit, a relevant field in the error, and zero commits, including invalid later operations in a batch.
- Success cases check exact relationship IDs, date values, override precedence, empty optional top-level batch strings, and `extra: null` compatibility.
- Independent review identified empty identifier/override and empty `extra` object boundaries; additional regressions reproduced those failures before the fixes.
- `go build ./...`, `go test -race ./...`, `make lint` (zero issues), and `git diff --check` passed. GitHub build/lint checks passed for both branch and PR runs. Final independent review found no remaining actionable defects in scope.
- No live Things Cloud writes or soak tests were performed. The later read-only Task7 investigation is separate from validation of this write-path change.

Implementation commit: `375a9f1a7e9b5c0e4028b5e97ab88a5dbf82d2fa`. Draft PR targeting `develop`; not merged or released.
