### PR TITLE
Keep future scheduled tasks in Upcoming

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ things-cli create-area "Name"
 things-cli create-tag "Name" [--shorthand KEY] [--parent UUID]
 
 # Modify
-things-cli edit <uuid> [--title ...] [--note ...] [--when ...] [--deadline ...]
+things-cli edit <uuid> [--title ...] [--note ...] [--when ...] [--deadline ...] [--scheduled YYYY-MM-DD]
 things-cli complete <uuid>
 things-cli trash <uuid>
 things-cli purge <uuid>
@@ -177,6 +177,12 @@ things-cli move-to-today <uuid>
 # UUIDs must be canonical Base58 identifiers, as returned by create/list
 echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":"VJ1edXTP9q3PmFDUuy8EQh"}]' | things-cli batch
 ```
+
+`--scheduled` uses the local calendar date: future dates appear in Upcoming,
+while today and past dates use the Today/Anytime schedule. If `--when` is also
+provided, its schedule takes precedence and `--scheduled` still supplies the
+date. For batch creates, pass the date as
+`"extra":{"scheduled":"YYYY-MM-DD"}`.
 
 ### Examples
 

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -217,6 +217,13 @@ func todayMidnightUTC() int64 {
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).Unix()
 }
 
+func taskScheduleForDate(scheduledDate, today int64) int {
+	if scheduledDate > today {
+		return 2
+	}
+	return 1
+}
+
 func parseDate(s string) *time.Time {
 	t, err := time.Parse("2006-01-02", s)
 	if err != nil {
@@ -344,14 +351,15 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 		}
 	}
 
-	// --scheduled (overrides sr/tir; sets st=1 with dates if not already set by --when)
+	// --scheduled overrides sr/tir. Without --when, future dates are Upcoming
+	// (st=2), while today and past dates use Today/Anytime (st=1).
 	if v, ok := opts["scheduled"]; ok {
 		if t := parseDate(v); t != nil {
 			ts := t.Unix()
 			sr = &ts
 			tir = &ts
 			if _, hasWhen := opts["when"]; !hasWhen {
-				st = 1 // default to anytime+date
+				st = taskScheduleForDate(ts, todayMidnightUTC())
 			}
 		}
 	}
@@ -359,8 +367,9 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 	// --project
 	if v, ok := opts["project"]; ok && v != "" {
 		pr = []string{v}
-		// Tasks in projects are already triaged — auto-set anytime (st=1) unless --when was explicit
-		if _, hasWhen := opts["when"]; !hasWhen {
+		// Tasks in projects are already triaged — auto-set anytime (st=1)
+		// unless the caller supplied a schedule.
+		if !hasExplicitSchedule(opts) {
 			st = 1
 		}
 	}
@@ -368,8 +377,9 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 	// --heading
 	if v, ok := opts["heading"]; ok && v != "" {
 		agr = []string{v}
-		// Tasks under headings are structural — auto-set anytime (st=1) unless --when was explicit
-		if _, hasWhen := opts["when"]; !hasWhen {
+		// Tasks under headings are structural — auto-set anytime (st=1)
+		// unless the caller supplied a schedule.
+		if !hasExplicitSchedule(opts) {
 			st = 1
 		}
 	}
@@ -377,8 +387,9 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 	// --area
 	if v, ok := opts["area"]; ok && v != "" {
 		ar = []string{v}
-		// Tasks in areas are already triaged — auto-set anytime (st=1) unless --when was explicit
-		if _, hasWhen := opts["when"]; !hasWhen {
+		// Tasks in areas are already triaged — auto-set anytime (st=1)
+		// unless the caller supplied a schedule.
+		if !hasExplicitSchedule(opts) {
 			st = 1
 		}
 	}
@@ -497,7 +508,7 @@ func (u *taskUpdate) Inbox() *taskUpdate {
 }
 
 func (u *taskUpdate) ScheduleDate(ts int64) *taskUpdate {
-	return u.Schedule(1, ts, ts)
+	return u.Schedule(taskScheduleForDate(ts, todayMidnightUTC()), ts, ts)
 }
 
 func (u *taskUpdate) Deadline(dd int64) *taskUpdate {
@@ -1541,6 +1552,9 @@ Write commands (fast — skip state loading):
   edit <uuid> [--title ...] [--note ...] [--when ...] [--deadline ...]
          [--scheduled ...] [--area UUID] [--project UUID]
          [--heading UUID] [--tags UUID,...]
+
+  --scheduled uses Upcoming for future local dates and Today/Anytime for today
+  or past dates. An explicit --when takes precedence over that classification.
   complete <uuid>
   trash <uuid>
   purge <uuid>
@@ -1553,7 +1567,8 @@ Batch command (reads JSON from stdin, sends all ops in one HTTP request):
 
   Supported operations:
     {"cmd": "create", "title": "...", "note": "...", "when": "today|anytime|someday|inbox",
-     "project": "uuid", "area": "uuid", "heading": "uuid", "tags": ["uuid",...]}
+     "project": "uuid", "area": "uuid", "heading": "uuid", "tags": ["uuid",...],
+     "extra": {"scheduled": "YYYY-MM-DD"}}
     {"cmd": "complete", "uuid": "..."}
     {"cmd": "trash", "uuid": "..."}
     {"cmd": "purge", "uuid": "..."}

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,6 +55,173 @@ func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
 	}
 }
 
+func TestTaskScheduleForDate(t *testing.T) {
+	today := time.Date(2026, time.September, 5, 0, 0, 0, 0, time.UTC).Unix()
+	tests := []struct {
+		name string
+		date int64
+		want int
+	}{
+		{name: "past", date: today - 86400, want: 1},
+		{name: "today", date: today, want: 1},
+		{name: "future", date: today + 86400, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := taskScheduleForDate(tt.date, today); got != tt.want {
+				t.Fatalf("taskScheduleForDate() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewTaskCreatePayloadScheduledDateClassification(t *testing.T) {
+	today := time.Now()
+	tests := []struct {
+		name string
+		date time.Time
+		want int
+	}{
+		{name: "past", date: today.AddDate(0, 0, -1), want: 1},
+		{name: "today", date: today, want: 1},
+		{name: "future", date: today.AddDate(0, 0, 1), want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date := tt.date.Format("2006-01-02")
+			wantDate := parseDate(date).Unix()
+			payload := newTaskCreatePayload("scheduled", map[string]string{"scheduled": date})
+			if payload.St != tt.want {
+				t.Fatalf("st = %d, want %d", payload.St, tt.want)
+			}
+			if payload.Sr == nil || *payload.Sr != wantDate || payload.Tir == nil || *payload.Tir != wantDate {
+				t.Fatalf("sr/tir = %v/%v, want UTC midnight %d", payload.Sr, payload.Tir, wantDate)
+			}
+		})
+	}
+}
+
+func TestNewTaskCreatePayloadExplicitWhenOverridesScheduledClassification(t *testing.T) {
+	today := time.Now()
+	tests := []struct {
+		name string
+		when string
+		date time.Time
+		want int
+	}{
+		{name: "future anytime", when: "anytime", date: today.AddDate(0, 0, 1), want: 1},
+		{name: "today someday", when: "someday", date: today, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date := tt.date.Format("2006-01-02")
+			wantDate := parseDate(date).Unix()
+			payload := newTaskCreatePayload("scheduled", map[string]string{
+				"scheduled": date,
+				"when":      tt.when,
+			})
+			if payload.St != tt.want {
+				t.Fatalf("st = %d, want explicit --when status %d", payload.St, tt.want)
+			}
+			if payload.Sr == nil || *payload.Sr != wantDate || payload.Tir == nil || *payload.Tir != wantDate {
+				t.Fatalf("sr/tir = %v/%v, want scheduled date %d", payload.Sr, payload.Tir, wantDate)
+			}
+		})
+	}
+}
+
+func TestNewTaskCreatePayloadRelationshipsPreserveScheduledStatus(t *testing.T) {
+	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	tests := []struct {
+		name string
+		opts map[string]string
+	}{
+		{name: "project", opts: map[string]string{"scheduled": future, "project": testProjectID}},
+		{name: "area", opts: map[string]string{"scheduled": future, "area": testAreaID}},
+		{name: "heading", opts: map[string]string{"scheduled": future, "heading": testHeadingID}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := newTaskCreatePayload("scheduled", tt.opts)
+			if payload.St != 2 {
+				t.Fatalf("st = %d, want 2", payload.St)
+			}
+			if payload.Sr == nil || payload.Tir == nil {
+				t.Fatalf("sr/tir = %v/%v, want scheduled date", payload.Sr, payload.Tir)
+			}
+		})
+	}
+}
+
+func TestTaskUpdateScheduleDateClassification(t *testing.T) {
+	today := todayMidnightUTC()
+	for _, tt := range []struct {
+		name string
+		date int64
+		want int
+	}{
+		{name: "past", date: today - 86400, want: 1},
+		{name: "today", date: today, want: 1},
+		{name: "future", date: today + 86400, want: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := newTaskUpdate().ScheduleDate(tt.date).build()
+			if payload["st"] != tt.want || payload["sr"] != tt.date || payload["tir"] != tt.date {
+				t.Fatalf("schedule = st:%v sr:%v tir:%v, want %d/%d/%d", payload["st"], payload["sr"], payload["tir"], tt.want, tt.date, tt.date)
+			}
+		})
+	}
+}
+
+func TestBatchCreateScheduledDateMatchesCreate(t *testing.T) {
+	today := time.Now()
+	tests := []struct {
+		name string
+		date time.Time
+		when string
+	}{
+		{name: "past", date: today.AddDate(0, 0, -1)},
+		{name: "today", date: today},
+		{name: "future", date: today.AddDate(0, 0, 1)},
+		{name: "explicit someday", date: today, when: "someday"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date := tt.date.Format("2006-01-02")
+			opts := map[string]string{"scheduled": date, "project": testProjectID}
+			if tt.when != "" {
+				opts["when"] = tt.when
+			}
+			want := newTaskCreatePayload("scheduled", opts)
+
+			env, _, err := buildBatchCreate(BatchOp{
+				Title:   "scheduled",
+				When:    tt.when,
+				Project: testProjectID,
+				Extra:   map[string]string{"scheduled": date},
+			})
+			if err != nil {
+				t.Fatalf("buildBatchCreate failed: %v", err)
+			}
+			payload, ok := env.(writeEnvelope).payload.(TaskCreatePayload)
+			if !ok {
+				t.Fatalf("batch payload = %T, want TaskCreatePayload", env.(writeEnvelope).payload)
+			}
+			if payload.St != want.St || payload.Sr == nil || want.Sr == nil || *payload.Sr != *want.Sr || payload.Tir == nil || want.Tir == nil || *payload.Tir != *want.Tir {
+				t.Fatalf("batch schedule = st:%d sr:%v tir:%v, want create schedule st:%d sr:%v tir:%v", payload.St, payload.Sr, payload.Tir, want.St, want.Sr, want.Tir)
+			}
+			if len(payload.Pr) != 1 || payload.Pr[0] != testProjectID {
+				t.Fatalf("batch project = %v, want [%s]", payload.Pr, testProjectID)
+			}
+		})
+	}
+}
+
 func TestHasExplicitSchedule(t *testing.T) {
 	tests := []struct {
 		name string
@@ -80,6 +249,82 @@ func TestHasExplicitSchedule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := hasExplicitSchedule(tt.opts); got != tt.want {
 				t.Fatalf("hasExplicitSchedule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduledOptionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		wantErr bool
+	}{
+		{name: "absent", opts: map[string]string{}},
+		{name: "valid", opts: map[string]string{"scheduled": "2026-09-06"}},
+		{name: "missing value", opts: map[string]string{"scheduled": "true"}, wantErr: true},
+		{name: "empty", opts: map[string]string{"scheduled": ""}, wantErr: true},
+		{name: "malformed", opts: map[string]string{"scheduled": "tomorrow"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTaskOpts(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateTaskOpts(%v) error = %v, wantErr %v", tt.opts, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDirectCommandsRejectInvalidScheduledBeforeWrite(t *testing.T) {
+	if command := os.Getenv("THINGS_CLI_INVALID_SCHEDULE_COMMAND"); command != "" {
+		h, commits := newWireRecorder(t)
+		switch command {
+		case "create":
+			cmdCreate(h, []string{"invalid", "--scheduled", "tomorrow", "--project", testProjectID})
+		case "edit":
+			cmdEdit(h, testTaskID, []string{"--scheduled", "--area", testAreaID})
+		default:
+			t.Fatalf("unknown helper command %q", command)
+		}
+		if len(*commits) != 0 {
+			t.Fatalf("invalid schedule wrote %d commits, want zero", len(*commits))
+		}
+		return
+	}
+
+	for _, command := range []string{"create", "edit"} {
+		t.Run(command, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestDirectCommandsRejectInvalidScheduledBeforeWrite$")
+			cmd.Env = append(os.Environ(), "THINGS_CLI_INVALID_SCHEDULE_COMMAND="+command)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("%s with invalid --scheduled succeeded; output: %s", command, output)
+			}
+			if !strings.Contains(string(output), "--scheduled") {
+				t.Fatalf("%s error = %s, want scheduled-date validation error", command, output)
+			}
+		})
+	}
+}
+
+func TestBuildBatchCreateRejectsInvalidScheduled(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		scheduled string
+	}{
+		{name: "missing value", scheduled: ""},
+		{name: "malformed", scheduled: "tomorrow"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := buildBatchCreate(BatchOp{
+				Title:   "invalid",
+				Project: testProjectID,
+				Extra:   map[string]string{"scheduled": tt.scheduled},
+			})
+			if err == nil || !strings.Contains(err.Error(), "--scheduled") {
+				t.Fatalf("buildBatchCreate error = %v, want scheduled-date validation error", err)
 			}
 		})
 	}

--- a/cmd/things-cli/wire_test.go
+++ b/cmd/things-cli/wire_test.go
@@ -457,6 +457,50 @@ func TestCmdEditWire(t *testing.T) {
 	}
 }
 
+func TestCmdEditFutureScheduledWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	proj := thingscloud.NewUUID()
+	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	wantDate := float64(parseDate(future).Unix())
+
+	cmdEdit(h, id, []string{"--scheduled", future, "--project", proj})
+
+	gotID, action, kind, p := singleItem(t, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task6" {
+		t.Fatalf("edit envelope = (%s, %d, %s), want (%s, 1, Task6)", gotID, action, kind, id)
+	}
+	if p["st"] != float64(2) || p["sr"] != wantDate || p["tir"] != wantDate {
+		t.Fatalf("future schedule = st:%v sr:%v tir:%v, want 2/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
+	}
+	pr, ok := p["pr"].([]any)
+	if !ok || len(pr) != 1 || pr[0] != proj {
+		t.Fatalf("pr = %v, want [%s]", p["pr"], proj)
+	}
+	if len(p) != 5 {
+		t.Fatalf("edit payload fields = %v, want only md, st, sr, tir, pr", p)
+	}
+}
+
+func TestCmdEditExplicitWhenOverridesScheduledClassification(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	area := thingscloud.NewUUID()
+	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	wantDate := float64(parseDate(future).Unix())
+
+	cmdEdit(h, id, []string{"--scheduled", future, "--when", "anytime", "--area", area})
+
+	_, _, _, p := singleItem(t, (*commits)[0])
+	if p["st"] != float64(1) || p["sr"] != wantDate || p["tir"] != wantDate {
+		t.Fatalf("explicit anytime schedule = st:%v sr:%v tir:%v, want 1/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
+	}
+	areas, ok := p["ar"].([]any)
+	if !ok || len(areas) != 1 || areas[0] != area {
+		t.Fatalf("ar = %v, want [%s]", p["ar"], area)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // initCLI / loadState / cmdBatch — full command plumbing against a fake server
 // ---------------------------------------------------------------------------

--- a/docs/plans/2026-09-05-future-scheduling.md
+++ b/docs/plans/2026-09-05-future-scheduling.md
@@ -1,0 +1,32 @@
+# Future scheduled task fix
+
+## Scope
+
+Correct CLI Task6 payloads so a scheduled local calendar date in the future is
+classified as Upcoming (`st=2`), while today and past dates remain
+Today/Anytime (`st=1`). Keep `--when` authoritative when it is supplied and
+preserve the existing UTC-midnight encoding for `sr` and `tir`.
+
+This change is stacked on PR #30 and reuses its shared task-option validation.
+
+## Implementation plan
+
+1. Add deterministic regression coverage for future, today, and past scheduled
+   dates using a fixed-day helper, including explicit `--when` precedence.
+2. Cover create, edit, and batch-create payloads, plus project, heading, and
+   area relationships, while asserting the existing Task6 fields stay intact.
+3. Centralize the date-to-schedule classification and use it from create and
+   update payload builders. Prevent relationship auto-Anytime behavior from
+   replacing either an explicit `--when` or an explicit scheduled date.
+4. Retain PR #30's rejection of malformed or valueless scheduled options at
+   direct create, edit, and batch-create boundaries. Reuse the shared validator
+   instead of adding a second validation implementation.
+5. Document the interaction between `--scheduled` and `--when`, then run the
+   focused CLI tests followed by the repository's normal build and lint checks.
+
+## Constraints
+
+- No new dependencies or cloud writes.
+- Do not change the 34-field create payload or the UTC-midnight civil-date
+  representation.
+- Preserve the safety rule that projects and headings cannot be Inbox items.


### PR DESCRIPTION
`things-cli create "Task" --scheduled <future-date>` sent `st=1`, placing the task in Today/Anytime instead of Upcoming. This PR uses `st=2` for future local calendar dates and keeps `st=1` for today/past dates. The date values remain UTC-midnight Unix timestamps.

## Behavior

- Direct create/edit and batch create (`extra.scheduled`) share the classification.
- Explicit `--when` retains precedence over the automatic schedule classification; `--scheduled` still supplies the date fields.
- Project, area, and heading assignment no longer overwrite a scheduled task with automatic Anytime.
- PR #30's shared validator rejects invalid, empty, or valueless scheduled options before writing, including after batch `extra` overrides. This PR reuses that validation instead of adding a second implementation.
- Outgoing Task6 kinds, complete create payload keys, and existing note/UUID/null representations remain unchanged.

## Verification

- Future/today/past, local-day/time-zone/DST, explicit precedence, and relationship tests.
- Create/edit/batch wire tests, including full create field set and edit field shape.
- Subprocess tests reject malformed scheduled commands before a write.
- Full tests, build, lint (zero issues), and independent review passed. Review found an invalid-date/relationship regression; it was fixed and retested.
- **The initial plain-task future-create smoke test passed in Things.app; see the dated result below.** The initially pending live matrix has since passed; see the expanded validation update below.

This is a separate write-side fix from #29's Task7 read/recovery work. **It is stacked on PR #30 (`fix/cli-write-validation`)** so the scheduling diff contains only the additional behavior and tests. Merge #30 first, then retarget this PR to `develop`.

The combined local candidate containing #28, #30, #31, and #32 passed the full build, race suite, lint, and a final independent scheduling/validation/wire review. The initial plain-task disposable-account check passed; the subsequently completed matrix is documented below.

Changed files: CLI implementation/tests, README scheduling guidance, and `docs/plans/2026-09-05-future-scheduling.md`.

Fixes #26

## Disposable-account smoke test — 6 September 2026

The verified combined candidate (`05cf188`) created exactly one plain Task6 task scheduled for 7 September 2026 in a disposable account confirmed distinct from the original account.

- Cloud readback contained the expected 34-field create payload: `st=2`, correct `sr`/`tir`, `md=null`, pending status, and plain-task type. The SDK's Upcoming read included the task.
- Things.app 3.23.3 was visibly signed into the disposable account. After **Update with Things Cloud**, the task appeared under **Upcoming → Tomorrow**.
- Opening its details showed Tomorrow. After a deliberate quit/relaunch, the task remained in the same group and the app remained usable; no crash was observed.
- A read-only query of the app's database confirmed schedule 2 and the correct packed calendar date. A repeated SDK read still returned the task.
- The cloud cursor advanced from 12 to 13 and remained 13 after the restart check. No second SDK write was attempted.

This verifies this plain future-create case on the tested app build. It is not a complete payload safety guarantee: the initial smoke did not cover edit, batch, relationships, or recurrence; the later matrix below adds edit/batch/relationship coverage, while recurrence remains untested. The test task is retained for inspection. Credentials, account identifiers, private task data, and screenshots are excluded from this report.

## Expanded disposable-account validation — 6 September 2026

The approved live matrix passed on Things 3.23.3:

- Direct scheduling edit moved the original smoke task to 8 September.
- Batch creation produced a task on 9 September.
- Dedicated test area, project, and heading creation succeeded.
- A three-operation batch created future tasks assigned to the area, project, and heading; all remained scheduled for 10 September.
- Cloud readback checked the Task6 task envelopes, expected fields, dates, and references. The app database independently matched all eight test objects involved in the matrix, and Upcoming visibly placed the five scheduled tasks on their expected days.
- Opening the heading-assigned task and a final deliberate app quit/relaunch succeeded. No Things crash was observed. A UI-control service interruption was resolved by reconnecting to the same app window; the app process remained alive and no crash reports appeared.

The four fixes are merged into `develop`, whose tree exactly matches the reviewed combined candidate; post-merge CI passed. Release PR #33 and the draft v0.6.0 release prepare promotion to `main`. The release is not published yet.

This remains bounded acceptance coverage. Modern recurrence writes, arbitrary payload fuzzing against the live app, and process-kill/power-loss recovery injection are not claimed verified. Credentials, account identifiers, private task content, and screenshots are excluded from this report.
