### PR TITLE
Recover Task7 state without rewriting the audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ func main() {
 }
 ```
 
+### Task7 reads and recovery
+
+The readers accept Task7 alongside Task6 and older task kinds. Task7 write semantics are still unverified: `History.Write` rejects Task7 and unsupported future task kinds, and the CLI continues to send Task6. New read support does not change the outgoing payload format.
+
+The first read after this upgrade replays state built by an older task reader:
+
+- `things-cli` saves the old JSON cache as `<cache-path>.before-replay-<random>.bak`, then atomically replaces the cache after successful replay.
+- The SQLite sync engine keeps opening databases offline. On the next `Sync()`, it detects the old replay generation even if the cursor is already at the cloud head. It creates a consistent `<database-path>.task7-backup-<random>` backup, rebuilds derived state in memory, and installs it in one transaction.
+- Existing SQLite change-log rows, IDs, and timestamps are retained. Historical replay below the old cursor produces no duplicate log entries or notifications. Old Task7 `UnknownChange` rows remain audit evidence; newly fetched events after that cursor are logged normally.
+- Failed or incomplete replay leaves the existing database/cache available for retry. Backups are kept with owner-only permissions. Each SQLite attempt snapshots the current database; identical validated snapshots are deduplicated by full content so repeated failures do not accumulate identical backups. Staging requires memory proportional to the rebuilt state, and each attempt needs temporary free space for a full database snapshot.
+
+Call `Sync()` before relying on database queries after upgrading: `Open()` does not perform network recovery. A future unsupported task kind returns an incomplete-sync error instead of silently advancing the cursor. Diagnostics do not include task payloads.
+
+CLI cache writes use atomic replacement and optimistic change detection, not a cross-process lock. Concurrent readers can replace one another's complete cache snapshots; a later read catches up from the saved cursor. Give concurrent consumers distinct `THINGS_CLI_CACHE` paths if they must not share cache writes. SQLite recovery separately checks its saved metadata within the installation transaction.
+
+Scheduled dates now use `sr` only; `tir` is a separate Today ordering reference date. Omitted task fields preserve prior values, while explicit nulls clear supported nullable dates, notes, and relationships. Modern repeater (`rp`) semantics remain incompletely verified; unknown wire fields remain available in raw `Item.P` and are not newly interpreted by the task model. The existing `ReminderDate` API field tagged `rmd` is a legacy misnomer for repeater migration date.
+
 ### Semantic Change Types
 
 The sync engine detects 40+ semantic change types:

--- a/cmd/things-cli/cache.go
+++ b/cmd/things-cli/cache.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// A nil snapshot means the file did not exist; an empty but non-nil snapshot
+// represents an existing empty file and still needs preservation on recovery.
+func readCLIStateCacheFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		data = []byte{}
+	}
+	return data, nil
+}
+
+func checkCLIStateCacheSnapshot(path string, expected []byte) error {
+	current, err := readCLIStateCacheFile(path)
+	if err != nil {
+		return err
+	}
+	if (current == nil) != (expected == nil) || !bytes.Equal(current, expected) {
+		return fmt.Errorf("state cache changed during sync; retry the read")
+	}
+	return nil
+}
+
+func createSyncedCacheFile(dir, pattern string, data []byte) (path string, err error) {
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	path = file.Name()
+	defer func() {
+		if err != nil {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+	}()
+	if err = file.Chmod(0o600); err != nil {
+		return path, err
+	}
+	if _, err = file.Write(data); err != nil {
+		return path, err
+	}
+	if err = file.Sync(); err != nil {
+		return path, err
+	}
+	err = file.Close()
+	return path, err
+}
+
+// Save only the state derived from the snapshot the reader actually loaded.
+// Keep obsolete cache bytes in a private backup and rename a complete new file
+// into place; never truncate the usable cache while writing its replacement.
+func saveCLIStateCacheSnapshot(path string, cache *cliStateCache, previous []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := checkCLIStateCacheSnapshot(path, previous); err != nil {
+		return err
+	}
+	cache.Version = cliStateCacheVersion
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	temporary, err := createSyncedCacheFile(dir, "."+filepath.Base(path)+".pending-*", data)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(temporary) }()
+
+	if previous != nil {
+		var old struct {
+			Version     int    `json:"version"`
+			HistoryID   string `json:"historyId"`
+			ServerIndex int    `json:"serverIndex"`
+		}
+		if json.Unmarshal(previous, &old) != nil || old.Version != cliStateCacheVersion || old.HistoryID != cache.HistoryID || old.ServerIndex > cache.ServerIndex {
+			if _, err := createSyncedCacheFile(dir, filepath.Base(path)+".before-replay-*.bak", previous); err != nil {
+				return fmt.Errorf("backing up state cache: %w", err)
+			}
+		}
+	}
+	if err := checkCLIStateCacheSnapshot(path, previous); err != nil {
+		return err
+	}
+	return os.Rename(temporary, path)
+}

--- a/cmd/things-cli/cache_recovery_test.go
+++ b/cmd/things-cli/cache_recovery_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+	"github.com/arthursoares/things-cloud-sdk/state/memory"
+)
+
+func oldReplayCache() []byte {
+	return []byte(`{"version":1,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{}}}`)
+}
+
+func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	old := oldReplayCache()
+	if err := os.WriteFile(path, old, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("THINGS_CLI_CACHE", path)
+	var starts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			starts = append(starts, r.URL.Query().Get("start-index"))
+			fmt.Fprint(w, task7CachePage)
+		} else {
+			fmt.Fprint(w, `{"latest-server-index":2}`)
+		}
+	}))
+	defer server.Close()
+	c := things.New(server.URL, "test@example.com", "test-password")
+	ctx := cliContext{client: c, history: c.HistoryWithID("test-history")}
+	state := ctx.loadState()
+	if len(state.Tasks) != 1 || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"] == nil || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"].Title != "New task" {
+		t.Fatal("old caught-up cache was not rebuilt with the missing Task7 task")
+	}
+	if len(starts) != 1 || starts[0] != "0" {
+		t.Fatalf("replay starts = %v, want [0]", starts)
+	}
+	backups, err := filepath.Glob(path + ".before-replay-*.bak")
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("backups = %v, error %v", backups, err)
+	}
+	got, err := os.ReadFile(backups[0])
+	if err != nil || !bytes.Equal(got, old) {
+		t.Fatal("backup did not preserve original cache bytes")
+	}
+	info, err := os.Stat(backups[0])
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatal("backup permissions are not 0600")
+	}
+	cache, err := loadCLIStateCache(path)
+	if err != nil || cache == nil || cache.Version != things.TaskReplayVersion || cache.ServerIndex != 2 {
+		t.Fatalf("rebuilt cache metadata is invalid: %+v, %v", cache, err)
+	}
+	ctx.loadState()
+	if len(starts) != 1 {
+		t.Fatal("second load replayed an already recovered cache")
+	}
+}
+
+const task7CachePage = `{"items":[{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":0,"p":{"tt":"","tp":0,"st":0,"ss":0}}},{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":1,"p":{"tt":"New task"}}}],"current-item-index":2}`
+
+func TestCLIStateCacheReplacementFailurePreservesOriginal(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission failure requires an unprivileged user")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	old := oldReplayCache()
+	if err := os.WriteFile(path, old, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	err := saveCLIStateCache(path, &cliStateCache{HistoryID: "test-history", ServerIndex: 2, State: memory.NewState()})
+	if err == nil {
+		t.Error("expected failure creating an atomic replacement in a read-only directory")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(got, old) {
+		t.Error("failed replacement changed the original cache")
+	}
+}
+
+func TestCLIRecoveryHelper(t *testing.T) {
+	if os.Getenv("THINGS_CACHE_RECOVERY_HELPER") == "" {
+		return
+	}
+	c := things.New(os.Getenv("THINGS_ENDPOINT"), "test@example.com", "test-password")
+	ctx := cliContext{client: c, history: c.HistoryWithID("test-history")}
+	ctx.loadState()
+}
+
+func TestCLIStateCacheFailedReplayPreservesOriginal(t *testing.T) {
+	cases := []struct {
+		name, page, diagnostic string
+		concurrent             bool
+	}{
+		{"unsupported", `{"items":[{"private-id":{"e":"Task8","t":0,"p":{"tt":"private title"}}}],"current-item-index":2}`, "unsupported task kind Task8", false},
+		{"no progress", `{"items":[],"current-item-index":2}`, "progress", false},
+		{"premature end", `{"items":[{}],"current-item-index":1}`, "incomplete", false},
+		{"concurrent cache", task7CachePage, "changed", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "state.json")
+			// Version 0 forces a replay in the old implementation too.
+			old := []byte(`{"version":0,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{}}}`)
+			if err := os.WriteFile(path, old, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			want := old
+			if tc.concurrent {
+				want = []byte(`{"version":2,"historyId":"test-history","serverIndex":3,"state":{"Tasks":{}}}`)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/items") {
+					if tc.concurrent {
+						if err := os.WriteFile(path, want, 0o600); err != nil {
+							t.Error(err)
+						}
+					}
+					fmt.Fprint(w, tc.page)
+				} else {
+					fmt.Fprint(w, `{"latest-server-index":2}`)
+				}
+			}))
+			defer server.Close()
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, executable, "-test.run=^TestCLIRecoveryHelper$")
+			cmd.Env = append(os.Environ(), "THINGS_CACHE_RECOVERY_HELPER=1", "THINGS_CLI_CACHE="+path, "THINGS_ENDPOINT="+server.URL)
+			output, err := cmd.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), tc.diagnostic) {
+				t.Fatalf("expected %q failure, got %v: %s", tc.diagnostic, err, output)
+			}
+			if strings.Contains(string(output), "private-id") || strings.Contains(string(output), "private title") {
+				t.Fatal("diagnostic exposed private task data")
+			}
+			got, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(got, want) {
+				t.Fatal("failed replay overwrote the original/concurrently updated cache")
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(got, &parsed); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -519,7 +519,7 @@ type cliContext struct {
 // state. Caches with any other version are ignored, forcing a full replay.
 // Bump it whenever replay output changes for the same history, e.g. when
 // object keys or memory.State's representation change.
-const cliStateCacheVersion = 1
+const cliStateCacheVersion = thingscloud.TaskReplayVersion
 
 type cliStateCache struct {
 	Version     int           `json:"version"`
@@ -548,12 +548,14 @@ func cliStateCachePath() string {
 }
 
 func loadCLIStateCache(path string) (*cliStateCache, error) {
-	bs, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
+	cache, _, err := loadCLIStateCacheSnapshot(path)
+	return cache, err
+}
+
+func loadCLIStateCacheSnapshot(path string) (*cliStateCache, []byte, error) {
+	bs, err := readCLIStateCacheFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var cache cliStateCache
 	if err := json.Unmarshal(bs, &cache); err != nil {
@@ -561,17 +563,17 @@ func loadCLIStateCache(path string) (*cliStateCache, error) {
 		// partial write) degrades to a full replay, same as a version
 		// mismatch, instead of an error the user can only clear by deleting
 		// the file by hand.
-		return nil, nil
+		return nil, bs, nil
 	}
 	if cache.Version != cliStateCacheVersion {
-		return nil, nil
+		return nil, bs, nil
 	}
 	if cache.State == nil {
 		cache.State = memory.NewState()
 	} else {
 		normalizeMemoryState(cache.State)
 	}
-	return &cache, nil
+	return &cache, bs, nil
 }
 
 func normalizeMemoryState(state *memory.State) {
@@ -590,15 +592,11 @@ func normalizeMemoryState(state *memory.State) {
 }
 
 func saveCLIStateCache(path string, cache *cliStateCache) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
-	cache.Version = cliStateCacheVersion
-	bs, err := json.MarshalIndent(cache, "", "  ")
+	previous, err := readCLIStateCacheFile(path)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, bs, 0o600)
+	return saveCLIStateCacheSnapshot(path, cache, previous)
 }
 
 func initCLI(syncHistoryHead bool) *cliContext {
@@ -641,7 +639,7 @@ func (ctx *cliContext) serverIndex() int {
 
 func (ctx *cliContext) loadState() *memory.State {
 	cachePath := cliStateCachePath()
-	cache, err := loadCLIStateCache(cachePath)
+	cache, previous, err := loadCLIStateCacheSnapshot(cachePath)
 	if err != nil {
 		fatal("load state cache", err)
 	}
@@ -665,6 +663,12 @@ func (ctx *cliContext) loadState() *memory.State {
 		if err != nil {
 			fatal("fetch items", err)
 		}
+		if ctx.history.LoadedServerIndex <= startIndex {
+			fatalf("incomplete history: item page made no progress")
+		}
+		if ctx.history.LatestServerIndex < latestServerIndex || ctx.history.LoadedServerIndex > ctx.history.LatestServerIndex {
+			fatalf("incomplete history: inconsistent server cursor during replay")
+		}
 		if err := state.Update(items...); err != nil {
 			fatal("update state", err)
 		}
@@ -674,11 +678,11 @@ func (ctx *cliContext) loadState() *memory.State {
 		}
 	}
 
-	if err := saveCLIStateCache(cachePath, &cliStateCache{
+	if err := saveCLIStateCacheSnapshot(cachePath, &cliStateCache{
 		HistoryID:   ctx.history.ID,
 		ServerIndex: startIndex,
 		State:       state,
-	}); err != nil {
+	}, previous); err != nil {
 		fatal("save state cache", err)
 	}
 

--- a/docs/plans/2026-09-05-task7-read-recovery.md
+++ b/docs/plans/2026-09-05-task7-read-recovery.md
@@ -1,0 +1,31 @@
+# Task7 read support and recovery
+
+## Scope and decisions
+
+Implement issue #29 from the v0.5.0 develop baseline. The user approved the proposed approach: retain the active SQLite audit log and rebuild derived state through staged replay. Issue #26's write scheduling is a separate branch/PR. Existing Task6 writes remain unchanged.
+
+Protocol evidence comes from Things 3.23.3 (build 32303501), read-only cloud inspection, and a consistent local database snapshot. The app normalizes Task6 to Task7 without modifying the operation's property dictionary. `sr` is startDate; `tir` is a distinct todayIndexReferenceDate. Modern repeater fields remain incompletely verified and are not a new write contract.
+
+## Plan before production edits
+
+1. Add failing fixtures for Task7 create/partial update, mixed Task6/Task7 identity, notes, relationships, nullable fields, deletion, and future unsupported task kinds.
+2. Add an explicit Task7 read kind and a shared read-only payload helper for null-versus-omitted fields. Preflight unsupported task kinds before a memory batch mutates. SQLite must roll back rejected batches.
+   Add a serialized-envelope guard in `History.Write` so the new Task7 read kind and future task kinds cannot reach the network, including through custom envelope implementations. Retain the existing write kinds and full Task6 wire regression coverage.
+3. Remove SQLite's incorrect `tir` override of `sr`, with a regression distinguishing the two dates.
+4. Introduce a persisted replay generation independent of structural schema. Check it before caught-up returns. Fresh databases use the current generation; old populated state requires recovery.
+5. Take a consistent, permission-restricted SQLite backup. Replay cloud history from zero into empty staging state. Preserve old change-log rows/IDs/timestamps; suppress historical replay events below the original next-batch cursor. Install rebuilt entities, junctions, cursor, generation, and only genuinely new log entries in one transaction after checking that the original database has not advanced concurrently.
+6. Keep the old database unchanged on backup, fetch, decode, progress, or installation failure. Test successful retry, note-delta single application, old-log retention, cutoff boundaries, idempotence, and concurrent-state protection.
+7. Bump the CLI cache generation, back up obsolete cache bytes, and replace the cache atomically only after successful complete replay. Preserve usable old data on failure and report unsupported task kinds without private payloads.
+8. Run build, focused regressions, race tests, lint, and independent review. Re-run the read-only comparison using the actual implementation with disposable local state, documenting remaining gaps. Publish a draft PR and update issue #29.
+
+No dependencies, cloud mutations, or destructive migration of the user's live Things.app database are needed. Private captures and credentials stay outside the repository. Recovery of the user's installed SDK cache/database is tested on copies first.
+
+## Verification record
+
+- New backend/cache/write-guard regressions reproduced the missing Task7 state, stale caught-up cache, unsafe replacement, and unverified write paths before the fixes.
+- Independent review found malformed-note acceptance and repeated full-backup accumulation. Note values are now checked before mutation; every SQLite attempt makes a fresh validated snapshot and removes only its own full-content duplicate. A restored database with the same cursor but different audit content retains its own backup.
+- Real-capture upgrade using the actual implementation restored seven missing tasks and all three inbox tasks. The 265 scheduled-date mismatches disappeared; all 5,352 existing audit rows remained byte-identical, recovery returned no historical notifications, and the next sync returned no changes.
+- Read-only live CLI validation rebuilt a disposable version-1 cache: old reader inbox 0, new reader inbox 3, Things.app inbox 3. A repeated read stayed at 3 and the original cache had an exact 0600 backup.
+- Three orphan Task6 modification-only records remain separate from the Task7 repair. Modern repeater semantics and actual Task7 project/heading wire variants remain incompletely observed; those variant tests are synthetic.
+- The CLI uses optimistic cache-change detection plus atomic replacement, not a cross-process lock. Concurrent complete snapshots may replace one another and catch up on a later read. Separate cache paths avoid shared-writer contention.
+- No live cloud writes have been made. The separate scheduling PR and combined stack require a controlled disposable-account/Things.app check before treating the write behavior as app-verified. Process-kill/power-loss injection has not been performed.

--- a/histories.go
+++ b/histories.go
@@ -242,6 +242,9 @@ func (h *History) Write(items ...Identifiable) error {
 	if err != nil {
 		return err
 	}
+	if err := validateTaskWriteKinds(bs); err != nil {
+		return err
+	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("/version/1/history/%s/commit", h.ID), bytes.NewReader(bs))
 	req.Header.Add("Schema", "301")
 	req.Header.Add("Push-Priority", "5")

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -256,7 +256,31 @@ func (s *State) updateTag(item things.TagActionItem) *things.Tag {
 
 // Update applies all items to update the aggregated state
 func (s *State) Update(items ...things.Item) error {
-	for _, rawItem := range items {
+	if err := things.ValidateTaskReadKinds(items); err != nil {
+		return err
+	}
+
+	// Decode every task create/modify before applying any item. A malformed
+	// task payload late in the batch must not leave earlier mutations behind,
+	// especially note deltas that would be applied twice on retry.
+	taskPayloads := make([]things.TaskReadPayload, len(items))
+	decodedTaskPayload := make([]bool, len(items))
+	for i, rawItem := range items {
+		switch rawItem.Kind {
+		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+			if rawItem.Action != things.ItemActionCreated && rawItem.Action != things.ItemActionModified {
+				continue
+			}
+			payload, err := things.DecodeTaskReadPayload(rawItem.P)
+			if err != nil {
+				return err
+			}
+			taskPayloads[i] = payload
+			decodedTaskPayload[i] = true
+		}
+	}
+
+	for i, rawItem := range items {
 		legacy := isLegacyItemKind(rawItem.Kind)
 		// A legacy-kind item whose key already parses as canonical Base58
 		// carries a current-generation identifier and must not be re-derived
@@ -267,10 +291,12 @@ func (s *State) Update(items ...things.Item) error {
 		}
 
 		switch rawItem.Kind {
-		case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 			item := things.TaskActionItem{Item: rawItem}
-			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
-				continue // Skip items that can't be parsed
+			var payload things.TaskReadPayload
+			if decodedTaskPayload[i] {
+				payload = taskPayloads[i]
+				item.P = payload.TaskActionItemPayload
 			}
 			if legacy {
 				encodeLegacyTaskReferences(&item.P)
@@ -280,7 +306,9 @@ func (s *State) Update(items ...things.Item) error {
 			case things.ItemActionCreated:
 				fallthrough
 			case things.ItemActionModified:
-				s.Tasks[item.UUID()] = s.updateTask(item)
+				task := s.updateTask(item)
+				payload.ApplyNulls(task)
+				s.Tasks[item.UUID()] = task
 			case things.ItemActionDeleted:
 				delete(s.Tasks, item.UUID())
 			default:

--- a/state/memory/task7_test.go
+++ b/state/memory/task7_test.go
@@ -1,0 +1,248 @@
+package memory
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+const task7Kind things.ItemKind = "Task7"
+
+func taskReadItem(id string, kind things.ItemKind, action things.ItemAction, payload string) things.Item {
+	return things.Item{UUID: id, Kind: kind, Action: action, P: json.RawMessage(payload)}
+}
+
+func requireTask(t *testing.T, state *State, id string) *things.Task {
+	t.Helper()
+	task := state.Tasks[id]
+	if task == nil {
+		t.Fatalf("task %q not found", id)
+	}
+	return task
+}
+
+func TestStateUpdateTask7CreateAndModify(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("task-7", task7Kind, things.ItemActionCreated, `{"tt":"","st":0,"tp":0}`),
+		taskReadItem("task-7", task7Kind, things.ItemActionModified, `{"tt":"New task"}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(state.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(state.Tasks))
+	}
+	task := requireTask(t, state, "task-7")
+	if task.Title != "New task" || task.Schedule != things.TaskScheduleInbox {
+		t.Fatalf("task = title %q, schedule %v; want New task in Inbox", task.Title, task.Schedule)
+	}
+}
+
+func TestStateUpdateTask6AndTask7ShareIdentity(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("same-task", things.ItemKindTask, things.ItemActionCreated, `{"tt":"Task6 title","ss":0}`),
+		taskReadItem("same-task", task7Kind, things.ItemActionModified, `{"tt":"Task7 title","ss":3}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(state.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(state.Tasks))
+	}
+	task := requireTask(t, state, "same-task")
+	if task.Title != "Task7 title" || task.Status != things.TaskStatusCompleted {
+		t.Fatalf("mixed-kind task = title %q, status %v", task.Title, task.Status)
+	}
+}
+
+func TestStateUpdateTask7Notes(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("notes", task7Kind, things.ItemActionCreated, `{"nt":{"_t":"Note","t":1,"v":"hello world"}}`),
+		taskReadItem("notes", task7Kind, things.ItemActionModified, `{"nt":{"_t":"Note","t":2,"ps":[{"p":6,"l":5,"r":"Things","ch":0}]}}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := requireTask(t, state, "notes").Note; got != "hello Things" {
+		t.Fatalf("note = %q, want %q", got, "hello Things")
+	}
+}
+
+func TestStateUpdateTask7TitleEmptyAndOmitted(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("title", task7Kind, things.ItemActionCreated, `{"tt":"original"}`),
+		taskReadItem("title", task7Kind, things.ItemActionModified, `{"ss":3}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := requireTask(t, state, "title").Title; got != "original" {
+		t.Fatalf("title = %q after omitted update, want original", got)
+	}
+	if err := state.Update(
+		taskReadItem("title", task7Kind, things.ItemActionModified, `{"tt":""}`),
+		taskReadItem("title", task7Kind, things.ItemActionModified, `{"ss":0}`),
+	); err != nil {
+		t.Fatalf("empty title update: %v", err)
+	}
+	if got := requireTask(t, state, "title").Title; got != "" {
+		t.Fatalf("title = %q, want explicit empty title preserved across omitted update", got)
+	}
+}
+
+func TestStateUpdateTask7NullableFields(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("nullable", task7Kind, things.ItemActionCreated, `{
+			"md":1700000000,"sr":1700000100,"sp":1700000200,"dd":1700000300,"ato":15,
+			"ar":["area"],"pr":["project"],"agr":["heading"],"tg":["tag"],"rt":["repeat"],"dl":["delegate"]
+		}`),
+		taskReadItem("nullable", task7Kind, things.ItemActionModified, `{
+			"md":null,"sr":null,"sp":null,"dd":null,"ato":null,
+			"ar":null,"pr":[],"agr":null,"tg":[],"rt":null,"dl":[]
+		}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	task := requireTask(t, state, "nullable")
+	if task.ModificationDate != nil || task.ScheduledDate != nil || task.CompletionDate != nil || task.DeadlineDate != nil || task.AlarmTimeOffset != nil {
+		t.Fatalf("explicit null did not clear dates/alarm: %+v", task)
+	}
+	if task.AreaIDs != nil || task.ActionGroupIDs != nil || task.RecurrenceIDs != nil {
+		t.Fatalf("null relationships were not cleared to nil: ar=%v agr=%v rt=%v", task.AreaIDs, task.ActionGroupIDs, task.RecurrenceIDs)
+	}
+	if len(task.ParentTaskIDs) != 0 || len(task.TagIDs) != 0 || len(task.DelegateIDs) != 0 {
+		t.Fatalf("empty relationships were not cleared: pr=%v tg=%v dl=%v", task.ParentTaskIDs, task.TagIDs, task.DelegateIDs)
+	}
+}
+
+func TestStateUpdateTask7ScheduleStatusTrashAndDeletion(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		t.Run(string(payload), func(t *testing.T) {
+			t.Parallel()
+			state := NewState()
+			if err := state.Update(taskReadItem("lifecycle", task7Kind, things.ItemActionCreated, `{"st":2,"ss":2,"tr":true}`)); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			task := requireTask(t, state, "lifecycle")
+			if task.Schedule != things.TaskScheduleSomeday || task.Status != things.TaskStatusCanceled || !task.InTrash {
+				t.Fatalf("lifecycle fields = schedule %v status %v trash %v", task.Schedule, task.Status, task.InTrash)
+			}
+			if err := state.Update(things.Item{UUID: "lifecycle", Kind: task7Kind, Action: things.ItemActionDeleted, P: payload}); err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+			if _, ok := state.Tasks["lifecycle"]; ok {
+				t.Fatal("deleted Task7 remains in state")
+			}
+		})
+	}
+}
+
+func TestStateUpdateTask7SyntheticProjectAndHeading(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("project", task7Kind, things.ItemActionCreated, `{"tt":"Project","tp":1}`),
+		taskReadItem("heading", task7Kind, things.ItemActionCreated, `{"tt":"Heading","tp":2,"pr":["project"]}`),
+		taskReadItem("child", task7Kind, things.ItemActionCreated, `{"tt":"Child","tp":0,"pr":["project"],"agr":["heading"]}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := state.Projects(); len(got) != 1 || got[0].UUID != "project" {
+		t.Fatalf("Projects = %+v", got)
+	}
+	if got := state.Headings("project"); len(got) != 1 || got[0].UUID != "heading" {
+		t.Fatalf("Headings = %+v", got)
+	}
+	if got := state.TasksByHeading("heading", ListOption{}); len(got) != 1 || got[0].UUID != "child" {
+		t.Fatalf("TasksByHeading = %+v", got)
+	}
+}
+
+func TestStateUpdateRejectsFutureTaskKindBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	const privateUUID = "PRIVATE-UUID-SHOULD-NOT-LEAK"
+	const privatePayload = "PRIVATE-PAYLOAD-SHOULD-NOT-LEAK"
+	state := NewState()
+	if err := state.Update(taskReadItem("notes", task7Kind, things.ItemActionCreated, `{"nt":"base"}`)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := state.Update(
+		taskReadItem("notes", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":4,"l":0,"r":" once","ch":0}]}}`),
+		taskReadItem(privateUUID, things.ItemKind("Task8"), things.ItemActionCreated, `{"tt":"`+privatePayload+`"}`),
+	)
+	if err == nil {
+		t.Fatal("Update accepted unsupported Task8")
+	}
+	if got := requireTask(t, state, "notes").Note; got != "base" {
+		t.Fatalf("batch mutated before unsupported kind error: note = %q", got)
+	}
+	if strings.Contains(err.Error(), privateUUID) || strings.Contains(err.Error(), privatePayload) {
+		t.Fatalf("error leaked item details: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Task8") {
+		t.Fatalf("error %q does not identify unsupported kind", err)
+	}
+}
+
+func TestStateUpdateRejectsMalformedTaskPayloadBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	const privateUUID = "PRIVATE-MALFORMED-UUID"
+	const privatePayload = "PRIVATE-MALFORMED-PAYLOAD"
+	state := NewState()
+	if err := state.Update(taskReadItem("existing", task7Kind, things.ItemActionCreated, `{"tt":"before"}`)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := state.Update(
+		taskReadItem("existing", task7Kind, things.ItemActionModified, `{"tt":"after"}`),
+		taskReadItem(privateUUID, task7Kind, things.ItemActionCreated, `"`+privatePayload+`"`),
+	)
+	if err == nil {
+		t.Fatal("Update accepted non-object Task7 payload")
+	}
+	if got := requireTask(t, state, "existing").Title; got != "before" {
+		t.Fatalf("batch mutated before malformed payload error: title = %q", got)
+	}
+	if strings.Contains(err.Error(), privateUUID) || strings.Contains(err.Error(), privatePayload) {
+		t.Fatalf("error leaked item details: %v", err)
+	}
+}
+
+func TestStateUpdateTask7DatePrecision(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	if err := state.Update(taskReadItem("date", task7Kind, things.ItemActionCreated, `{"sr":1700000000.25}`)); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	want := time.Unix(1700000000, 250000000).UTC()
+	if got := requireTask(t, state, "date").ScheduledDate; got == nil || !got.Equal(want) {
+		t.Fatalf("scheduled date = %v, want %v", got, want)
+	}
+}

--- a/sync/process.go
+++ b/sync/process.go
@@ -20,8 +20,8 @@ var itemKindArea2 = things.ItemKindArea
 // processItems processes a batch of Things Cloud items into semantic changes.
 // The baseIndex is the starting server index for this batch.
 func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, error) {
-	if len(items) == 0 {
-		return nil, nil
+	if err := things.ValidateTaskReadKinds(items); err != nil {
+		return nil, err
 	}
 
 	// Wrap entire batch in a transaction for massive performance improvement
@@ -47,7 +47,12 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 
 		changes, err := s.processItem(item, serverIndex, ts)
 		if err != nil {
-			return nil, fmt.Errorf("processing item %s: %w", item.UUID, err)
+			return nil, fmt.Errorf("processing item at server index %d: %w", serverIndex, err)
+		}
+		// Recovery replays old operations to reconstruct state, but their
+		// audit records and notifications already belong to the live database.
+		if serverIndex < s.replayLogCutoff {
+			continue
 		}
 
 		// Log each change
@@ -80,7 +85,7 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 // processItem routes an item to the correct handler based on its Kind.
 func (s *Syncer) processItem(item things.Item, serverIndex int, ts time.Time) ([]Change, error) {
 	switch item.Kind {
-	case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+	case things.ItemKindTask7, things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 		return s.processTaskItem(item, serverIndex, ts)
 	case itemKindArea2, things.ItemKindArea3, things.ItemKindAreaPlain:
 		return s.processAreaItem(item, serverIndex, ts)
@@ -109,7 +114,7 @@ func (s *Syncer) processTaskItem(item things.Item, serverIndex int, ts time.Time
 	// Get the old state
 	old, err := s.getTask(item.UUID)
 	if err != nil {
-		return nil, fmt.Errorf("getting task %s: %w", item.UUID, err)
+		return nil, fmt.Errorf("getting task: %w", err)
 	}
 
 	// Handle deletion
@@ -123,13 +128,14 @@ func (s *Syncer) processTaskItem(item things.Item, serverIndex int, ts time.Time
 	}
 
 	// Unmarshal the payload
-	var payload things.TaskActionItemPayload
-	if err := json.Unmarshal(item.P, &payload); err != nil {
+	payload, err := things.DecodeTaskReadPayload(item.P)
+	if err != nil {
 		return nil, fmt.Errorf("unmarshaling task payload: %w", err)
 	}
 
 	// Apply payload to build new state
-	newTask := applyTaskPayload(old, item.UUID, payload)
+	newTask := applyTaskPayload(old, item.UUID, payload.TaskActionItemPayload)
+	payload.ApplyNulls(newTask)
 
 	// Save the new state
 	if err := s.saveTask(newTask); err != nil {
@@ -414,10 +420,6 @@ func applyTaskPayload(old *things.Task, uuid string, p things.TaskActionItemPayl
 	}
 	if p.ScheduledDate != nil {
 		t.ScheduledDate = p.ScheduledDate.Time()
-	}
-	if p.TaskIR != nil {
-		// TaskIR (tir) is an alternative scheduled date field
-		t.ScheduledDate = p.TaskIR.Time()
 	}
 	if p.CompletionDate != nil {
 		t.CompletionDate = p.CompletionDate.Time()

--- a/sync/replay.go
+++ b/sync/replay.go
@@ -1,0 +1,323 @@
+package sync
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// Replay semantics evolve independently of the physical schema. Opening an
+// old database records its generation without clearing any usable offline data.
+func (s *Syncer) ensureTaskReplayState() error {
+	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS task_replay_state (
+		id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL
+	)`)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`INSERT OR IGNORE INTO task_replay_state (id, version)
+		SELECT 1, CASE WHEN
+			EXISTS(SELECT 1 FROM sync_state) OR EXISTS(SELECT 1 FROM tasks) OR
+			EXISTS(SELECT 1 FROM areas) OR EXISTS(SELECT 1 FROM tags) OR
+			EXISTS(SELECT 1 FROM checklist_items) OR EXISTS(SELECT 1 FROM change_log) OR
+			EXISTS(SELECT 1 FROM task_tags) OR EXISTS(SELECT 1 FROM area_tags)
+		THEN 1 ELSE ? END`, things.TaskReplayVersion)
+	return err
+}
+
+func (s *Syncer) taskReplayVersion() (int, error) {
+	var version int
+	err := s.db.QueryRow(`SELECT version FROM task_replay_state WHERE id = 1`).Scan(&version)
+	return version, err
+}
+
+// backupForReplay makes a consistent SQLite snapshot including committed WAL
+// content. The reserved, exclusive filename is permission restricted before
+// SQLite writes any data. Every attempt snapshots the actual current database;
+// only a byte-identical, validated retained snapshot can replace the new copy.
+// This bounds retained copies across identical retries, including process
+// restarts, while protecting externally restored databases with the same cursor.
+// Each retry still requires temporary space and I/O for a complete snapshot.
+// In-memory/temporary databases have no persistent source file to protect;
+// their original state stays in memory until the final atomic installation.
+func (s *Syncer) backupForReplay() error {
+	rows, err := s.rawDB.Query(`PRAGMA database_list`)
+	if err != nil {
+		return err
+	}
+	var path string
+	for rows.Next() {
+		var seq int
+		var name, file string
+		if err := rows.Scan(&seq, &name, &file); err != nil {
+			rows.Close()
+			return err
+		}
+		if name == "main" {
+			path = file
+		}
+	}
+	err = rows.Err()
+	rows.Close()
+	if err != nil || path == "" {
+		return err
+	}
+	before, err := readReplayBackupState(s.rawDB)
+	if err != nil {
+		return err
+	}
+	// Hash the tuple so backup filenames never expose the private history ID.
+	key := sha256.Sum256([]byte(fmt.Sprintf("%q:%d:%d", before.historyID, before.cursor, before.generation)))
+	prefix := fmt.Sprintf("%s.task7-backup-%x-", filepath.Base(path), key)
+	// Capture candidates before creating our file: never deduplicate against
+	// ourselves or a younger concurrent attempt that could also be removed.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), prefix+"*")
+	if err != nil {
+		return err
+	}
+	backupPath := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if _, err := s.rawDB.Exec(`VACUUM INTO ?`, backupPath); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if !validReplayBackup(backupPath, before) {
+		// This file was exclusively created by this attempt. Replay has not
+		// started, so removing an invalid snapshot cannot remove its safety net.
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("task replay backup failed integrity or source-state validation")
+	}
+	currentHash, err := replayBackupHash(backupPath)
+	if err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	duplicate := false
+	for _, entry := range entries {
+		candidate := filepath.Join(filepath.Dir(path), entry.Name())
+		if !strings.HasPrefix(entry.Name(), prefix) || !validReplayBackup(candidate, before) {
+			continue
+		}
+		candidateHash, err := replayBackupHash(candidate)
+		if err == nil && candidateHash == currentHash {
+			duplicate = true
+			break
+		}
+	}
+	if err := s.checkReplayBackupState(before); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if duplicate {
+		// Delete only this attempt's exclusive snapshot, after proving a valid
+		// retained copy contains every byte. Never remove a previous backup.
+		return os.Remove(backupPath)
+	}
+	return nil
+}
+
+func replayBackupHash(path string) ([sha256.Size]byte, error) {
+	var sum [sha256.Size]byte
+	f, err := os.Open(path)
+	if err != nil {
+		return sum, err
+	}
+	defer f.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return sum, err
+	}
+	copy(sum[:], hash.Sum(nil))
+	return sum, nil
+}
+
+type replayBackupState struct {
+	historyID          string
+	cursor, generation int
+}
+
+// One SELECT observes a coherent metadata tuple even if another writer syncs.
+func readReplayBackupState(db dbExecutor) (replayBackupState, error) {
+	var state replayBackupState
+	err := db.QueryRow(`SELECT COALESCE(s.history_id, ''), COALESCE(s.server_index, 0), r.version
+		FROM task_replay_state r LEFT JOIN sync_state s ON s.id = r.id WHERE r.id = 1`).Scan(&state.historyID, &state.cursor, &state.generation)
+	return state, err
+}
+
+func (s *Syncer) checkReplayBackupState(before replayBackupState) error {
+	after, err := readReplayBackupState(s.rawDB)
+	if err != nil {
+		return err
+	}
+	if after != before {
+		return fmt.Errorf("sync state changed while backing up task replay; retry sync")
+	}
+	return nil
+}
+
+func validReplayBackup(path string, expected replayBackupState) bool {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+		return false
+	}
+	// Standalone VACUUM snapshots need no WAL. Read-only immutable mode avoids
+	// modifying the retained snapshot or creating journal/SHM sidecar files.
+	dsn := (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro&immutable=1"}).String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+	var integrity string
+	if err := db.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil || integrity != "ok" {
+		return false
+	}
+	actual, err := readReplayBackupState(db)
+	return err == nil && actual == expected
+}
+
+func (s *Syncer) recoverTaskReplay(historyID string, cutoff, generation, target int) ([]Change, error) {
+	if cutoff < 0 || target < cutoff {
+		return nil, fmt.Errorf("cannot recover task replay: server cursor %d is behind stored cursor %d", target, cutoff)
+	}
+	if err := s.backupForReplay(); err != nil {
+		return nil, fmt.Errorf("backing up task replay database: %w", err)
+	}
+	staged, err := Open(":memory:", s.client)
+	if err != nil {
+		return nil, fmt.Errorf("opening task replay staging database: %w", err)
+	}
+	defer staged.Close()
+	// Staging never runs nested state queries; pin its private in-memory DB
+	// to one connection without restricting live readers of a file database.
+	staged.rawDB.SetMaxOpenConns(1)
+	staged.history = s.client.HistoryWithID(s.history.ID)
+	staged.replayLogCutoff = cutoff
+	var changes []Change
+	start := 0
+	for start < target {
+		var items []things.Item
+		var more bool
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			items, more, err = staged.history.Items(things.ItemsOptions{StartIndex: start})
+			if err == nil || !isRetryableError(err) {
+				break
+			}
+			time.Sleep(retryBaseWait * time.Duration(1<<attempt))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("fetching task replay: %w", err)
+		}
+		if err := validateReplayPage(staged.history, start, target); err != nil {
+			return nil, err
+		}
+		batchChanges, err := staged.processItems(items, start)
+		if err != nil {
+			return nil, fmt.Errorf("replaying task history: %w", err)
+		}
+		changes = append(changes, batchChanges...)
+		start = staged.history.LoadedServerIndex
+		// Include growth observed in a page, following complete outer batches.
+		if more {
+			target = staged.history.LatestServerIndex
+		}
+	}
+	if err := s.installTaskReplay(staged, historyID, cutoff, generation, start); err != nil {
+		return nil, fmt.Errorf("installing task replay: %w", err)
+	}
+	return changes, nil
+}
+
+// installTaskReplay preserves the active WAL database and every original audit
+// row. Reading the guard and replacing tables in one transaction makes a
+// concurrent advance either fail the guard or fail SQLite's write upgrade.
+func (s *Syncer) installTaskReplay(staged *Syncer, historyID string, cutoff, generation, next int) error {
+	tx, err := s.rawDB.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	guard := &Syncer{db: tx}
+	actualHistory, actualIndex, err := guard.getSyncState()
+	if err != nil {
+		return err
+	}
+	actualGeneration, err := guard.taskReplayVersion()
+	if err != nil {
+		return err
+	}
+	if actualHistory != historyID || actualIndex != cutoff || actualGeneration != generation {
+		return fmt.Errorf("sync state changed during task replay; retry sync")
+	}
+	for _, table := range []string{"task_tags", "area_tags", "checklist_items", "tasks", "areas", "tags"} {
+		if _, err := tx.Exec(`DELETE FROM ` + table); err != nil {
+			return err
+		}
+		if err := copyReplayRows(tx, staged.rawDB, table, "*"); err != nil {
+			return err
+		}
+	}
+	// Omit staging IDs so SQLite allocates new IDs after the retained history.
+	if err := copyReplayRows(tx, staged.rawDB, "change_log", "server_index,synced_at,change_type,entity_type,entity_uuid,payload"); err != nil {
+		return err
+	}
+	if err := guard.saveSyncState(staged.history.ID, next); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE task_replay_state SET version = ? WHERE id = 1`, things.TaskReplayVersion); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// Only fixed internal table/column names reach this row copier. Copying the
+// complete stored rows also retains deleted flags and junction relationships.
+func copyReplayRows(tx *sql.Tx, staged *sql.DB, table, columns string) error {
+	query := `SELECT ` + columns + ` FROM ` + table
+	if table == "change_log" {
+		query += " ORDER BY id"
+	}
+	rows, err := staged.Query(query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	names, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = `"` + name + `"`
+	}
+	query = `INSERT INTO ` + table + ` (` + strings.Join(quoted, ",") + `) VALUES (` + strings.TrimSuffix(strings.Repeat("?,", len(names)), ",") + `)`
+	for rows.Next() {
+		values := make([]any, len(names))
+		refs := make([]any, len(names))
+		for i := range values {
+			refs[i] = &values[i]
+		}
+		if err := rows.Scan(refs...); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(query, values...); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}

--- a/sync/replay_backup_test.go
+++ b/sync/replay_backup_test.go
@@ -1,0 +1,301 @@
+package sync
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+func replayBackupFiles(t *testing.T, path string) []string {
+	t.Helper()
+	files, err := filepath.Glob(path + ".task7-backup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+func TestReplayBackupReusedAcrossFailedRetriesAndReopen(t *testing.T) {
+	for _, failure := range []string{"fetch", "decode"} {
+		t.Run(failure, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/items") {
+					fmt.Fprint(w, `{"latest-server-index":2}`)
+					return
+				}
+				if failure == "fetch" {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":1,"p":17}}],"current-item-index":2}`)
+			}))
+			defer server.Close()
+			path := filepath.Join(t.TempDir(), "live.db")
+			client := things.New(server.URL, "test@example.com", "password")
+			s := legacyReplayDB(t, path, client, 2)
+			var original []byte
+			for attempt := 0; attempt < 4; attempt++ {
+				if _, err := s.Sync(); err == nil {
+					t.Fatal("expected replay failure")
+				}
+				files := replayBackupFiles(t, path)
+				if len(files) != 1 {
+					t.Fatalf("attempt %d created %d backups", attempt, len(files))
+				}
+				data, err := os.ReadFile(files[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+				if attempt == 0 {
+					original = data
+				} else if !bytes.Equal(original, data) {
+					t.Fatal("reused backup changed")
+				}
+				if err := s.Close(); err != nil {
+					t.Fatal(err)
+				}
+				s, err = Open(path, client)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			defer s.Close()
+			got, err := s.getTask("task")
+			if err != nil || got.Title != "old" || s.LastSyncedIndex() != 2 {
+				t.Fatalf("failed retries changed state: %+v %v", got, err)
+			}
+		})
+	}
+}
+
+func TestReplayBackupNewCursorGetsNewSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	oldFiles := replayBackupFiles(t, path)
+	oldBytes, err := os.ReadFile(oldFiles[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.saveSyncState("history", 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if files := replayBackupFiles(t, path); len(files) != 2 {
+		t.Fatalf("want one snapshot per cursor, got %v", files)
+	}
+	got, err := os.ReadFile(oldFiles[0])
+	if err != nil || !bytes.Equal(oldBytes, got) {
+		t.Fatalf("previous backup changed: %v", err)
+	}
+}
+
+func TestReplayBackupCorruptCandidateIsPreservedAndNotReused(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	files := replayBackupFiles(t, path)
+	corrupt := []byte("user existing or damaged backup")
+	if err := os.WriteFile(files[0], corrupt, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if all := replayBackupFiles(t, path); len(all) != 2 {
+		t.Fatalf("want corrupt original plus one valid backup, got %v", all)
+	}
+	got, err := os.ReadFile(files[0])
+	if err != nil || !bytes.Equal(corrupt, got) {
+		t.Fatalf("corrupt original overwritten: %v", err)
+	}
+}
+
+func TestReplayBackupUnsafeCandidatesAreNotReused(t *testing.T) {
+	for _, condition := range []string{"metadata", "symlink", "permissions"} {
+		t.Run(condition, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "live.db")
+			s := legacyReplayDB(t, path, nil, 2)
+			defer s.Close()
+			if err := s.backupForReplay(); err != nil {
+				t.Fatal(err)
+			}
+			candidate := replayBackupFiles(t, path)[0]
+			switch condition {
+			case "metadata":
+				db, err := sql.Open("sqlite", candidate)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := db.Exec(`UPDATE sync_state SET history_id='other-history'`); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Close(); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink":
+				foreign := filepath.Join(filepath.Dir(path), "foreign.db")
+				if err := os.Rename(candidate, foreign); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(foreign, candidate); err != nil {
+					t.Fatal(err)
+				}
+			case "permissions":
+				if err := os.Chmod(candidate, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := os.ReadFile(candidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := s.backupForReplay(); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.backupForReplay(); err != nil {
+				t.Fatal(err)
+			}
+			if files := replayBackupFiles(t, path); len(files) != 2 {
+				t.Fatalf("unsafe candidate reused or retries unbounded: %v", files)
+			}
+			after, err := os.ReadFile(candidate)
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("unsafe candidate changed: %v", err)
+			}
+			if condition == "symlink" {
+				info, err := os.Lstat(candidate)
+				if err != nil || info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("symlink changed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestReplayBackupSourceGuardRejectsConcurrentAdvance(t *testing.T) {
+	for _, mutation := range []string{`UPDATE sync_state SET server_index=3`, `UPDATE sync_state SET history_id='other-history'`, `UPDATE task_replay_state SET version=2`} {
+		t.Run(mutation, func(t *testing.T) {
+			s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), nil, 2)
+			defer s.Close()
+			before, err := readReplayBackupState(s.rawDB)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.rawDB.Exec(mutation); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.checkReplayBackupState(before); err == nil {
+				t.Fatal("concurrent source advance accepted")
+			}
+		})
+	}
+}
+
+func TestReplayBackupSameTupleChangedAuditGetsCurrentSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	original := replayBackupFiles(t, path)[0]
+	originalBytes, err := os.ReadFile(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A restored/replaced database can have the identical history/cursor/read
+	// generation but a different audit trail. Metadata alone cannot identify it.
+	if _, err := s.rawDB.Exec(`UPDATE change_log SET id=84, synced_at=456, payload='{"restored":true}' WHERE id=41`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	files := replayBackupFiles(t, path)
+	if len(files) != 2 {
+		t.Fatalf("want snapshots of both distinct states, got %v", files)
+	}
+	for _, file := range files {
+		if file == original {
+			continue
+		}
+		db, err := sql.Open("sqlite", file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var id, syncedAt int
+		var payload string
+		if err := db.QueryRow(`SELECT id, synced_at, payload FROM change_log`).Scan(&id, &syncedAt, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if id != 84 || syncedAt != 456 || payload != `{"restored":true}` {
+			t.Fatalf("backup does not protect current audit: %d %d %s", id, syncedAt, payload)
+		}
+	}
+	after, err := os.ReadFile(original)
+	if err != nil || !bytes.Equal(originalBytes, after) {
+		t.Fatalf("original backup changed: %v", err)
+	}
+}
+
+func TestReplayBackupFailurePreservesRetainedSnapshot(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires effective filesystem permission checks")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	retained := replayBackupFiles(t, path)[0]
+	before, err := os.ReadFile(retained)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0700); err != nil {
+			t.Error(err)
+		}
+	}()
+	if err := s.backupForReplay(); err == nil {
+		t.Fatal("reused metadata without obtaining a current snapshot")
+	}
+	after, err := os.ReadFile(retained)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("backup failure damaged retained snapshot: %v", err)
+	}
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -5,6 +5,7 @@ package sync
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -25,10 +26,11 @@ type dbExecutor interface {
 
 // Syncer manages persistent sync with Things Cloud
 type Syncer struct {
-	rawDB   *sql.DB    // underlying connection for Close() and Begin()
-	db      dbExecutor // current executor (db or tx)
-	client  *things.Client
-	history *things.History
+	rawDB           *sql.DB    // underlying connection for Close() and Begin()
+	db              dbExecutor // current executor (db or tx)
+	client          *things.Client
+	history         *things.History
+	replayLogCutoff int // staging only: suppress events below the old next-batch cursor
 }
 
 // Open creates or opens a sync database and connects to Things Cloud
@@ -37,7 +39,6 @@ func Open(dbPath string, client *things.Client) (*Syncer, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	// Enable WAL mode for better concurrent performance
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		db.Close()
@@ -51,6 +52,10 @@ func Open(dbPath string, client *things.Client) (*Syncer, error) {
 	}
 
 	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if err := s.ensureTaskReplayState(); err != nil {
 		db.Close()
 		return nil, err
 	}
@@ -77,6 +82,10 @@ func isRetryableError(err error) bool {
 func (s *Syncer) Sync() ([]Change, error) {
 	// Get current sync state first
 	storedHistoryID, startIndex, err := s.getSyncState()
+	if err != nil {
+		return nil, err
+	}
+	generation, err := s.taskReplayVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +128,9 @@ func (s *Syncer) Sync() ([]Change, error) {
 	if err != nil {
 		return nil, err
 	}
+	if generation < things.TaskReplayVersion {
+		return s.recoverTaskReplay(storedHistoryID, startIndex, generation, serverIndex)
+	}
 
 	// If our cursor is already at or beyond the server's index, nothing to fetch
 	if startIndex >= serverIndex {
@@ -148,9 +160,8 @@ func (s *Syncer) Sync() ([]Change, error) {
 			return nil, fetchErr
 		}
 
-		// No items returned means we're caught up
-		if len(items) == 0 {
-			break
+		if err := validateReplayPage(s.history, startIndex, serverIndex); err != nil {
+			return nil, err
 		}
 
 		// Process each item
@@ -172,6 +183,15 @@ func (s *Syncer) Sync() ([]Change, error) {
 	// duplicate change_log rows).
 
 	return allChanges, nil
+}
+
+// validateReplayPage checks batch cursors, including empty outer batches that
+// legitimately advance the cursor without yielding expanded entity items.
+func validateReplayPage(h *things.History, start, target int) error {
+	if h.LoadedServerIndex <= start || h.LatestServerIndex < h.LoadedServerIndex || h.LatestServerIndex < target {
+		return fmt.Errorf("invalid sync progress: start %d, loaded %d, latest %d, target %d", start, h.LoadedServerIndex, h.LatestServerIndex, target)
+	}
+	return nil
 }
 
 // LastSyncedIndex returns the server index we've synced up to

--- a/sync/task7_test.go
+++ b/sync/task7_test.go
@@ -1,0 +1,452 @@
+package sync
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+func TestTask7ReadAndNulls(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	apply := func(kind, payload string) {
+		t.Helper()
+		if _, err := s.processItems([]things.Item{{UUID: "task", Kind: things.ItemKind(kind), P: json.RawMessage(payload)}}, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	apply("Task6", `{"tt":"before","nt":"note","sr":100,"tir":200,"dd":300,"ato":10,"ar":["area"],"pr":["project"],"agr":["heading"],"tg":["tag"]}`)
+	old, err := s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if old.ScheduledDate == nil || old.ScheduledDate.Unix() != 100 {
+		t.Fatalf("sr was replaced by tir: %+v", old.ScheduledDate)
+	}
+	apply("Task7", `{"tt":"after"}`)
+	got, err := s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "after" || got.Note != "note" || got.ScheduledDate == nil || len(got.TagIDs) != 1 {
+		t.Fatalf("partial Task7 update: %+v", got)
+	}
+	apply("Task7", `{"sr":null,"dd":null,"ato":null,"ar":null,"pr":null,"agr":null,"tg":null,"nt":null}`)
+	got, err = s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ScheduledDate != nil || got.DeadlineDate != nil || got.AlarmTimeOffset != nil || len(got.AreaIDs)+len(got.ParentTaskIDs)+len(got.ActionGroupIDs)+len(got.TagIDs) != 0 || got.Note != "" {
+		t.Fatalf("nulls not cleared: %+v", got)
+	}
+	if _, err := s.processItems([]things.Item{{UUID: "task", Kind: "Task7", Action: things.ItemActionDeleted}}, 1); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.getTask("task")
+	if err != nil || got != nil {
+		t.Fatalf("delete: %+v %v", got, err)
+	}
+}
+
+func TestTask7ReplayFailurePreservesStateAndRetry(t *testing.T) {
+	for _, failure := range []string{"fetch", "decode", "note", "unknown", "empty", "cursor", "install", "concurrent"} {
+		t.Run(failure, func(t *testing.T) {
+			var retry atomic.Bool
+			var s *Syncer
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/items") {
+					fmt.Fprint(w, `{"latest-server-index":2}`)
+					return
+				}
+				if r.URL.Query().Get("start-index") == "0" {
+					fmt.Fprint(w, `{"items":[{"task":{"e":"Task6","t":0,"p":{"tt":"staged","nt":"there"}}}],"current-item-index":2}`)
+					return
+				}
+				if !retry.Load() {
+					switch failure {
+					case "fetch":
+						w.WriteHeader(http.StatusForbidden)
+						return
+					case "decode":
+						fmt.Fprint(w, `{"items":[{"private-uuid":{"e":"Task7","t":1,"p":17}}],"current-item-index":2}`)
+						return
+					case "note":
+						fmt.Fprint(w, `{"items":[{"private-uuid":{"e":"Task7","t":1,"p":{"nt":42}}}],"current-item-index":2}`)
+						return
+					case "unknown":
+						fmt.Fprint(w, `{"items":[{"private-uuid":{"e":"Task8","t":1,"p":{"tt":"private-title"}}}],"current-item-index":2}`)
+						return
+					case "empty":
+						fmt.Fprint(w, `{"items":[],"current-item-index":2}`)
+						return
+					case "cursor":
+						fmt.Fprint(w, `{"items":[{}],"current-item-index":1}`)
+						return
+					case "concurrent":
+						// A separate SQLite connection advances the live state while
+						// network replay is in progress; installation must reject it.
+						if _, err := s.rawDB.Exec(`UPDATE sync_state SET server_index=3 WHERE id=1`); err != nil {
+							t.Error(err)
+						}
+					}
+				}
+				fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":1,"p":{"tt":"recovered","nt":{"t":2,"ps":[{"p":0,"l":0,"r":"Hi "}]}}}}],"current-item-index":2}`)
+			}))
+			defer server.Close()
+			path := filepath.Join(t.TempDir(), "live.db")
+			s = legacyReplayDB(t, path, things.New(server.URL, "test@example.com", "password"), 2)
+			defer s.Close()
+			before := replayLog(t, s)
+			if failure == "install" {
+				if _, err := s.db.Exec(`CREATE TRIGGER fail_replay BEFORE DELETE ON tasks BEGIN SELECT RAISE(ABORT, 'injected install failure'); END`); err != nil {
+					t.Fatal(err)
+				}
+			}
+			changes, err := s.Sync()
+			if err == nil || len(changes) != 0 {
+				t.Fatalf("failure accepted: %v %v", changes, err)
+			}
+			if (failure == "unknown" || failure == "decode" || failure == "note") && strings.Contains(err.Error(), "private-") {
+				t.Fatalf("private error: %v", err)
+			}
+			old, getErr := s.getTask("task")
+			if getErr != nil || old.Title != "old" || old.Note != "Hi there" {
+				t.Fatalf("old state damaged: %+v %v", old, getErr)
+			}
+			wantIndex := 2
+			if failure == "concurrent" {
+				wantIndex = 3
+			}
+			generation, getErr := s.taskReplayVersion()
+			if getErr != nil || generation != 1 || s.LastSyncedIndex() != wantIndex || !reflect.DeepEqual(before, replayLog(t, s)) {
+				t.Fatalf("metadata/audit changed: gen=%d idx=%d err=%v", generation, s.LastSyncedIndex(), getErr)
+			}
+			if failure == "install" {
+				if _, err := s.db.Exec(`DROP TRIGGER fail_replay`); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if failure == "concurrent" {
+				if err := s.saveSyncState("history", 2); err != nil {
+					t.Fatal(err)
+				}
+			}
+			retry.Store(true)
+			if _, err := s.Sync(); err != nil {
+				t.Fatalf("retry: %v", err)
+			}
+			got, getErr := s.getTask("task")
+			if getErr != nil || got.Title != "recovered" || got.Note != "Hi there" {
+				t.Fatalf("retry state: %+v %v", got, getErr)
+			}
+			if !reflect.DeepEqual(before, replayLog(t, s)) {
+				t.Fatal("retry duplicated logs")
+			}
+		})
+	}
+}
+
+func TestTask7ReplayBackupFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires effective filesystem permission checks")
+	}
+	var fetches atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			fetches.Add(1)
+		}
+		fmt.Fprint(w, `{"latest-server-index":2}`)
+	}))
+	defer server.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "live.db")
+	s := legacyReplayDB(t, path, things.New(server.URL, "test@example.com", "password"), 2)
+	defer s.Close()
+	before := replayLog(t, s)
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0700); err != nil {
+			t.Error(err)
+		}
+	}()
+	if _, err := s.Sync(); err == nil {
+		t.Fatal("backup failure ignored")
+	}
+	if fetches.Load() != 0 {
+		t.Fatal("replay started before backup")
+	}
+	got, err := s.getTask("task")
+	if err != nil || got.Title != "old" || s.LastSyncedIndex() != 2 || !reflect.DeepEqual(before, replayLog(t, s)) {
+		t.Fatalf("backup failure damaged state: %+v %v", got, err)
+	}
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != 1 {
+		t.Fatalf("generation=%d err=%v", generation, err)
+	}
+}
+
+func TestTask7ReplayEmptyOuterBatchesAndGrowth(t *testing.T) {
+	var starts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprint(w, `{"latest-server-index":1}`)
+			return
+		}
+		start := r.URL.Query().Get("start-index")
+		starts = append(starts, start)
+		if start == "0" {
+			fmt.Fprint(w, `{"items":[{}],"current-item-index":3}`)
+			return
+		}
+		fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":0,"p":{"tt":"grown"}}},{}],"current-item-index":3}`)
+	}))
+	defer server.Close()
+	s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), things.New(server.URL, "test@example.com", "password"), 1)
+	defer s.Close()
+	changes, err := s.Sync()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 || s.LastSyncedIndex() != 3 || !reflect.DeepEqual(starts, []string{"0", "1"}) {
+		t.Fatalf("changes=%d cursor=%d starts=%v", len(changes), s.LastSyncedIndex(), starts)
+	}
+}
+
+func TestTask7ReplayGuardsAllMetadata(t *testing.T) {
+	for _, mutation := range []string{`UPDATE sync_state SET history_id='other'`, `UPDATE sync_state SET server_index=3`, `UPDATE task_replay_state SET version=2`} {
+		t.Run(mutation, func(t *testing.T) {
+			s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), nil, 2)
+			defer s.Close()
+			stage, err := Open(":memory:", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stage.Close()
+			stage.history = &things.History{ID: "history"}
+			mustSaveTask(t, stage, &things.Task{UUID: "task", Title: "staged"})
+			if _, err := s.rawDB.Exec(mutation); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.installTaskReplay(stage, "history", 2, 1, 2); err == nil {
+				t.Fatal("stale installation accepted")
+			}
+			got, err := s.getTask("task")
+			if err != nil || got.Title != "old" {
+				t.Fatalf("stale state installed: %+v %v", got, err)
+			}
+		})
+	}
+}
+
+func TestTaskReplayGenerationFreshAndMemoryBackup(t *testing.T) {
+	s, err := Open(":memory:", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != things.TaskReplayVersion {
+		t.Fatalf("fresh generation=%d err=%v", generation, err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatalf("memory backup: %v", err)
+	}
+}
+
+func TestTaskReplayFinalFailureRollsBackEntitiesLogsAndCursor(t *testing.T) {
+	s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), nil, 2)
+	defer s.Close()
+	before := replayLog(t, s)
+	staged, err := Open(":memory:", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer staged.Close()
+	staged.history = &things.History{ID: "history", LoadedServerIndex: 3}
+	if _, err := staged.processItems([]things.Item{{UUID: "task", Kind: "Task7", P: json.RawMessage(`{"tt":"staged","tg":["new-tag"]}`)}}, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`CREATE TRIGGER fail_generation BEFORE UPDATE ON task_replay_state BEGIN SELECT RAISE(ABORT, 'injected final failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.installTaskReplay(staged, "history", 2, 1, 3); err == nil {
+		t.Fatal("final failure ignored")
+	}
+	got, err := s.getTask("task")
+	if err != nil || got.Title != "old" || len(got.TagIDs) != 0 || s.LastSyncedIndex() != 2 || !reflect.DeepEqual(before, replayLog(t, s)) {
+		t.Fatalf("partial install: %+v %v", got, err)
+	}
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != 1 {
+		t.Fatalf("generation=%d err=%v", generation, err)
+	}
+}
+
+func TestUnknownTaskRollsBackSanitized(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	_, err = s.processItems([]things.Item{{UUID: "valid", Kind: "Task6", P: json.RawMessage(`{"tt":"valid"}`)}, {UUID: "private-uuid", Kind: "Task8", P: json.RawMessage(`{"tt":"private-title"}`)}}, 0)
+	if err == nil {
+		t.Fatal("unsupported task accepted")
+	}
+	if strings.Contains(err.Error(), "private-") {
+		t.Fatalf("private data in error: %v", err)
+	}
+	got, getErr := s.getTask("valid")
+	if getErr != nil || got != nil {
+		t.Fatalf("partial batch committed: %+v %v", got, getErr)
+	}
+}
+
+// legacyReplayDB simulates the previous reader after it saved a Task6 delta
+// and skipped a later Task7 update, including its original audit records.
+func legacyReplayDB(t *testing.T, path string, client *things.Client, cursor int) *Syncer {
+	t.Helper()
+	s, err := Open(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustSaveTask(t, s, &things.Task{UUID: "task", Title: "old", Note: "Hi there"})
+	if err := s.saveSyncState("history", cursor); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO change_log(id,server_index,synced_at,change_type,entity_type,entity_uuid,payload) VALUES(41,1,123,'TaskNoteChanged','Task','task','{"original":true}')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`DROP TABLE IF EXISTS task_replay_state`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = Open(path, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func replayLog(t *testing.T, s *Syncer) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT id,server_index,synced_at,change_type,entity_type,entity_uuid,payload FROM change_log ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var id, idx, ts int
+		var kind, entity, uuid, payload string
+		if err := rows.Scan(&id, &idx, &ts, &kind, &entity, &uuid, &payload); err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, fmt.Sprint(id, "|", idx, "|", ts, "|", kind, "|", entity, "|", uuid, "|", payload))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestTask7ReplayPreservesAuditAndReopens(t *testing.T) {
+	for _, cutoff := range []int{3, 4} {
+		t.Run(fmt.Sprint(cutoff), func(t *testing.T) {
+			var starts []string
+			heads := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/items") {
+					heads++
+					fmt.Fprint(w, `{"latest-server-index":4}`)
+					return
+				}
+				starts = append(starts, r.URL.Query().Get("start-index"))
+				fmt.Fprint(w, `{"items":[{"task":{"e":"Task6","t":0,"p":{"tt":"old","nt":"there"}}},{"task":{"e":"Task6","t":1,"p":{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"Hi "}]}}}},{"task":{"e":"Task7","t":1,"p":{"tt":"recovered"}}},{"task":{"e":"Task7","t":1,"p":{"tt":"new"}}}],"current-item-index":4}`)
+			}))
+			defer server.Close()
+			path := filepath.Join(t.TempDir(), "live.db")
+			client := things.New(server.URL, "test@example.com", "password")
+			s := legacyReplayDB(t, path, client, cutoff)
+			before := replayLog(t, s)
+			old, _ := s.getTask("task")
+			if old.Title != "old" || s.LastSyncedIndex() != cutoff {
+				t.Fatal("Open rebuilt offline")
+			}
+			changes, err := s.Sync()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := s.getTask("task")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Title != "new" || got.Note != "Hi there" {
+				t.Fatalf("replay state: %+v", got)
+			}
+			after := replayLog(t, s)
+			if !reflect.DeepEqual(before, after[:len(before)]) {
+				t.Fatalf("audit changed: %v -> %v", before, after)
+			}
+			if len(changes) != 4-cutoff || len(after) != len(before)+4-cutoff {
+				t.Fatalf("cutoff changes=%d logs=%d", len(changes), len(after))
+			}
+			if s.LastSyncedIndex() != 4 || !reflect.DeepEqual(starts, []string{"0"}) || heads != 1 {
+				t.Fatalf("cursor=%d starts=%v heads=%d", s.LastSyncedIndex(), starts, heads)
+			}
+			backups, err := filepath.Glob(path + ".task7-backup-*")
+			if err != nil || len(backups) != 1 {
+				t.Fatalf("backups: %v %v", backups, err)
+			}
+			info, err := os.Stat(backups[0])
+			if err != nil || info.Mode().Perm() != 0600 {
+				t.Fatalf("backup permissions: %v %v", info, err)
+			}
+			backup, err := sql.Open("sqlite", backups[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			var backupTitle string
+			if err := backup.QueryRow(`SELECT title FROM tasks WHERE uuid='task'`).Scan(&backupTitle); err != nil {
+				t.Fatal(err)
+			}
+			if backupTitle != "old" || !reflect.DeepEqual(before, replayLog(t, &Syncer{db: backup})) {
+				t.Fatal("backup did not retain pre-recovery WAL state")
+			}
+			if err := backup.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.Close(); err != nil {
+				t.Fatal(err)
+			}
+			s, err = Open(path, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer s.Close()
+			changes, err = s.Sync()
+			if err != nil || len(changes) != 0 {
+				t.Fatalf("repeat: %v %v", changes, err)
+			}
+			if !reflect.DeepEqual(after, replayLog(t, s)) || len(starts) != 1 {
+				t.Fatal("repeat replayed history")
+			}
+		})
+	}
+}

--- a/task_read.go
+++ b/task_read.go
@@ -1,0 +1,151 @@
+package thingscloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TaskReplayVersion identifies the task read semantics used to build derived
+// state. Cached state from older generations must be replayed from scratch.
+const TaskReplayVersion = 2
+
+// UnsupportedTaskKindError means the task state would be incomplete if replay
+// continued. ServerIndex is -1 when the source did not provide an index.
+type UnsupportedTaskKindError struct {
+	Kind        ItemKind
+	ServerIndex int
+}
+
+func (e *UnsupportedTaskKindError) Error() string {
+	kind := taskKindDiagnostic(e.Kind)
+	if e.ServerIndex >= 0 {
+		return fmt.Sprintf("incomplete sync: unsupported task kind %s at server index %d", kind, e.ServerIndex)
+	}
+	return fmt.Sprintf("incomplete sync: unsupported task kind %s", kind)
+}
+
+func taskKindDiagnostic(value ItemKind) string {
+	// Only print the protocol's Task<number> shape. Do not let an arbitrary
+	// server-supplied kind embed private text or control characters in logs.
+	kind := string(value)
+	suffix := strings.TrimPrefix(kind, "Task")
+	if suffix == kind || suffix == "" || len(suffix) > 12 || strings.Trim(suffix, "0123456789") != "" {
+		kind = "Task*"
+	}
+	return kind
+}
+
+// ValidateTaskReadKinds preflights an entire batch before any task state is
+// mutated. Unrelated unknown entities retain their existing handling.
+func ValidateTaskReadKinds(items []Item) error {
+	for _, item := range items {
+		switch item.Kind {
+		case ItemKindTask, ItemKindTask7, ItemKindTask4, ItemKindTask3, ItemKindTaskPlain:
+			continue
+		}
+		if strings.HasPrefix(string(item.Kind), "Task") {
+			index := -1
+			if item.HasServerIndex {
+				index = item.ServerIndex
+			}
+			return &UnsupportedTaskKindError{Kind: item.Kind, ServerIndex: index}
+		}
+	}
+	return nil
+}
+
+// TaskReadPayload adds explicit-null tracking to the existing wire payload
+// without changing its write representation. Unknown properties remain
+// available in the original Item.P; this helper interprets supported fields.
+type TaskReadPayload struct {
+	TaskActionItemPayload
+	nullFields map[string]bool
+}
+
+// DecodeTaskReadPayload distinguishes an omitted property (preserve existing
+// state) from an explicit null (clear a nullable property).
+func DecodeTaskReadPayload(raw json.RawMessage) (TaskReadPayload, error) {
+	var result TaskReadPayload
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 || data[0] != '{' {
+		return result, fmt.Errorf("task payload must be a JSON object")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return result, fmt.Errorf("decoding task payload: %w", err)
+	}
+	if err := json.Unmarshal(data, &result.TaskActionItemPayload); err != nil {
+		return result, fmt.Errorf("decoding task payload: %w", err)
+	}
+	if note, ok := fields["nt"]; ok {
+		if err := validateTaskReadNote(note); err != nil {
+			return result, err
+		}
+	}
+	for key, value := range fields {
+		if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			if result.nullFields == nil {
+				result.nullFields = make(map[string]bool)
+			}
+			result.nullFields[key] = true
+		}
+	}
+	return result, nil
+}
+
+func validateTaskReadNote(raw json.RawMessage) error {
+	value := bytes.TrimSpace(raw)
+	if bytes.Equal(value, []byte("null")) || (len(value) > 0 && value[0] == '"') {
+		return nil // The enclosing JSON decoder already checked string syntax.
+	}
+	if len(value) == 0 || value[0] != '{' {
+		return fmt.Errorf("task note must be text, null, or a supported structured note")
+	}
+	var note Note
+	if err := json.Unmarshal(value, &note); err != nil {
+		return fmt.Errorf("decoding task note: %w", err)
+	}
+	if note.Type != NoteTypeFullText && note.Type != NoteTypeDelta {
+		return fmt.Errorf("unsupported task note type %d", note.Type)
+	}
+	return nil
+}
+
+// ApplyNulls clears nullable fields after the ordinary non-nil payload fields
+// have been applied. In particular, tir is a reference date and never changes
+// ScheduledDate; only sr controls that field.
+func (p TaskReadPayload) ApplyNulls(task *Task) {
+	for key := range p.nullFields {
+		switch key {
+		case "cd":
+			task.CreationDate = time.Time{}
+		case "md":
+			task.ModificationDate = nil
+		case "sr":
+			task.ScheduledDate = nil
+		case "sp":
+			task.CompletionDate = nil
+		case "dd":
+			task.DeadlineDate = nil
+		case "ato":
+			task.AlarmTimeOffset = nil
+		case "ar":
+			task.AreaIDs = nil
+		case "pr":
+			task.ParentTaskIDs = nil
+		case "agr":
+			task.ActionGroupIDs = nil
+		case "tg":
+			task.TagIDs = nil
+		case "rt":
+			task.RecurrenceIDs = nil
+		case "dl":
+			task.DelegateIDs = nil
+		case "nt":
+			task.Note = ""
+		}
+	}
+}

--- a/task_read_test.go
+++ b/task_read_test.go
@@ -1,0 +1,69 @@
+package thingscloud
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTaskReadPayloadNullsAndOmissions(t *testing.T) {
+	date := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	alarm := 30
+	task := Task{Title: "keep", Note: "clear", ScheduledDate: &date, DeadlineDate: &date,
+		CompletionDate: &date, ModificationDate: &date, AlarmTimeOffset: &alarm,
+		AreaIDs: []string{"area"}, ParentTaskIDs: []string{"project"}, ActionGroupIDs: []string{"heading"}, TagIDs: []string{"tag"}}
+	omitted, err := DecodeTaskReadPayload([]byte(`{"tt":"unrelated","tir":null}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	omitted.ApplyNulls(&task)
+	if task.ScheduledDate != &date || task.Note != "clear" || len(task.AreaIDs) != 1 {
+		t.Fatal("omitted fields or null tir changed existing state")
+	}
+	cleared, err := DecodeTaskReadPayload([]byte(`{"sr":null,"dd":null,"sp":null,"md":null,"ato":null,"ar":null,"pr":null,"agr":null,"tg":null,"nt":null}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleared.ApplyNulls(&task)
+	if task.ScheduledDate != nil || task.DeadlineDate != nil || task.CompletionDate != nil || task.ModificationDate != nil || task.AlarmTimeOffset != nil {
+		t.Error("explicit null did not clear optional dates/alarm")
+	}
+	if len(task.AreaIDs)+len(task.ParentTaskIDs)+len(task.ActionGroupIDs)+len(task.TagIDs) != 0 || task.Note != "" || task.Title != "keep" {
+		t.Error("explicit null did not clear relationships/notes or changed unrelated title")
+	}
+}
+
+func TestTaskReadPayloadRejectsNonObjects(t *testing.T) {
+	for _, raw := range []string{"", "null", "[]", `"text"`, `{"tt":[]}`, `{"nt":42}`, `{"nt":true}`, `{"nt":[]}`, `{"nt":{"t":"bad"}}`, `{"nt":{"t":3,"v":"private"}}`, `{"nt":{"t":2,"ps":"bad"}}`} {
+		if _, err := DecodeTaskReadPayload([]byte(raw)); err == nil {
+			t.Errorf("accepted invalid task payload %q", raw)
+		}
+	}
+}
+
+func TestTaskReadPayloadAcceptsKnownNoteFormats(t *testing.T) {
+	for _, raw := range []string{`{"nt":null}`, `{"nt":"legacy text"}`, `{"nt":{"t":1,"v":""}}`, `{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"hello"}]}}`} {
+		if _, err := DecodeTaskReadPayload([]byte(raw)); err != nil {
+			t.Errorf("known note format rejected: %v", err)
+		}
+	}
+}
+
+func TestTaskReadKindsAndSanitizedError(t *testing.T) {
+	if err := ValidateTaskReadKinds([]Item{{Kind: "Task6"}, {Kind: "Task7"}, {Kind: "Task4"}, {Kind: "Settings5"}}); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateTaskReadKinds([]Item{{Kind: "Task8", UUID: "private-id", P: []byte(`{"tt":"private title"}`), ServerIndex: 42, HasServerIndex: true}})
+	var unsupported *UnsupportedTaskKindError
+	if !errors.As(err, &unsupported) || unsupported.Kind != "Task8" || unsupported.ServerIndex != 42 {
+		t.Fatalf("expected indexed unsupported-task error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "private") || !strings.Contains(err.Error(), "Task8") {
+		t.Fatalf("unexpected diagnostic: %v", err)
+	}
+	err = ValidateTaskReadKinds([]Item{{Kind: "Task8\nprivate payload"}})
+	if err == nil || strings.Contains(err.Error(), "private") || strings.Contains(err.Error(), "\n") {
+		t.Fatalf("unsafe kind diagnostic: %v", err)
+	}
+}

--- a/task_write.go
+++ b/task_write.go
@@ -1,0 +1,29 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// validateTaskWriteKinds checks the serialized envelopes, including custom
+// Identifiable implementations. Supporting a new kind for reads must not
+// accidentally enable writes whose contract has not been verified.
+func validateTaskWriteKinds(body []byte) error {
+	var envelopes map[string]struct {
+		Kind ItemKind `json:"e"`
+	}
+	if err := json.Unmarshal(body, &envelopes); err != nil {
+		return fmt.Errorf("refusing to write an invalid item envelope")
+	}
+	for _, envelope := range envelopes {
+		switch envelope.Kind {
+		case "Task6", "Task4", "Task3", "Task":
+			continue // Preserve existing write kinds; the CLI still emits Task6.
+		}
+		if strings.HasPrefix(string(envelope.Kind), "Task") {
+			return fmt.Errorf("refusing to write unverified task kind %s", taskKindDiagnostic(envelope.Kind))
+		}
+	}
+	return nil
+}

--- a/task_write_test.go
+++ b/task_write_test.go
@@ -1,0 +1,45 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type taskWriteProbe struct {
+	id   string
+	kind ItemKind
+}
+
+func (p taskWriteProbe) UUID() string { return p.id }
+
+func (p taskWriteProbe) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{"e": p.kind, "t": 0, "p": map[string]any{"tt": "private fixture title"}})
+}
+
+func TestHistoryWriteRejectsUnverifiedTaskKinds(t *testing.T) {
+	for _, kind := range []ItemKind{"Task7", "Task8", "Task8\nprivate fixture title"} {
+		t.Run(string(kind), func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				fmt.Fprint(w, `{"server-head-index":1}`)
+			}))
+			defer server.Close()
+			history := New(server.URL, "test@example.com", "test-password").HistoryWithID("test-history")
+			err := history.Write(taskWriteProbe{id: NewUUID(), kind: kind})
+			if err == nil {
+				t.Error("unverified task kind was accepted for writing")
+			} else if strings.Contains(err.Error(), "private fixture title") {
+				t.Error("write diagnostic exposed fixture contents")
+			}
+			if requests.Load() != 0 {
+				t.Errorf("sent %d requests, want zero", requests.Load())
+			}
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -59,7 +59,10 @@ var (
 	ItemKindChecklistItem2 ItemKind = "ChecklistItem2"
 	ItemKindChecklistItem3 ItemKind = "ChecklistItem3"
 	// ItemKindTask identifies a Task or Subtask
-	ItemKindTask      ItemKind = "Task6"
+	ItemKindTask ItemKind = "Task6"
+	// ItemKindTask7 is supported for reading current histories. Writes continue
+	// to use ItemKindTask until the Task7 write contract is verified.
+	ItemKindTask7     ItemKind = "Task7"
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"
 	ItemKindTaskPlain ItemKind = "Task"
@@ -241,7 +244,7 @@ type TaskActionItemPayload struct {
 	SubtaskBehavior           *int                   `json:"sb,omitempty"`
 	DelegateIDs               *[]string              `json:"dl,omitempty"`
 	LastActionItemID          *Timestamp             `json:"lai,omitempty"`
-	ReminderDate              *Timestamp             `json:"rmd,omitempty"`
+	ReminderDate              *Timestamp             `json:"rmd,omitempty"` // legacy API name: repeater migration date, not a reminder
 	AlarmTimeOffset           *int                   `json:"ato,omitempty"`
 	ActionRequiredDate        *Timestamp             `json:"acrd,omitempty"`
 	DeadlineSuppression       *Timestamp             `json:"dds,omitempty"`


### PR DESCRIPTION
Task7 records were skipped while both readers advanced their cursors, leaving inbox tasks missing even after a subsequent successful sync. This PR reads Task7, repairs already-derived state through versioned replay, and preserves the existing SQLite audit log.

## Reader and payload behavior

- Add an explicit Task7 read kind while retaining Task6 and older supported task kinds.
- Distinguish omitted fields from explicit nulls for supported nullable task dates, notes, and relationships. Validate supported note representations before mutation.
- Keep `sr` (startDate) separate from `tir` (todayIndexReferenceDate). The previous SQLite fallback produced 265 wrong scheduled dates in the comparison dataset.
- Preflight unknown future task kinds and malformed task payloads before a memory batch changes state; SQLite rolls back rejected batches. Diagnostics exclude private task payloads and IDs.
- Add a serialized-envelope write guard: Task7 and unsupported future task kinds are rejected before HTTP, including custom `Identifiable` implementations. The CLI still emits Task6, and existing serialized write bytes are not rewritten by the guard.

## Recovery and backups

- Replay generation 2 is separate from the SQLite schema version. `Open()` remains offline; `Sync()` checks generation before its caught-up fast path.
- For old SQLite state, take a consistent private snapshot including WAL contents, replay into empty staging state, and atomically install derived entity/junction tables and the new cursor/generation.
- Preserve existing change-log rows, IDs, timestamps, and payloads exactly. If the old next-batch cursor is `C`, replay events below `C` are neither logged again nor returned as new notifications. Only events at or above `C` are appended.
- Guard installation against changed history/cursor/generation. Backup, fetch, decode, progress, or installation failure preserves the existing state for retry.
- Every attempt snapshots the current database. Only full-content-identical validated snapshots are deduplicated, so repeated failures do not accumulate identical copies and an externally restored same-cursor database gets its own backup.
- CLI cache generation is bumped. Old cache bytes receive a 0600 backup; a complete new cache is installed by atomic rename after replay. Observed concurrent cache changes cause a retry error.

## Protocol evidence

Read-only inspection of Things 3.23.3 (build 32303501) showed its Task6-to-Task7 normalizer retains the operation type and entire property dictionary. Binary registration and local/cloud comparisons separately confirm `sr` versus `tir`, and UTC-midnight calendar-date encoding. This is evidence for the read mapping, not verification of Task7 writes or every modern repeater value. See #29 for the sanitized investigation and framework addresses.

## Verification

- New regressions reproduced missing Task7 state, stale caught-up caches, unsafe cache replacement, unverified writes, malformed notes, and backup retry/restore gaps before the corresponding fixes.
- Fixtures cover mixed Task6/Task7 identity, title/note snapshots and deltas, null/omitted/empty updates, relationships, deletion without payloads, and synthetic project/heading variants.
- Recovery tests cover exact audit retention, cutoff boundaries, one-time note patches, retry/reopen/idempotence, backup failures, malformed/future records, no progress, concurrent metadata changes, and failure at final installation.
- Full build, race-enabled tests, lint (zero issues), and independent review passed.
- Actual-implementation upgrade of a disposable old-reader database restored seven missing tasks and all three inbox tasks. All 265 date mismatches disappeared; **5,352 audit rows stayed byte-identical**, historical notifications were suppressed, and the second sync returned no changes.
- Read-only live CLI comparison using a disposable cache: old inbox 0, new inbox 3, Things.app inbox 3; repeated read remained 3, and original cache bytes had an exact private backup.
- The combined local candidate containing #28, #30, #31, and #32 passed the full build, race suite, lint, and final independent integration/wire review. PR #31 is stacked on #30 to reuse its validator; this PR continues to target `develop` independently.
- Task7/recovery validation used read-only cloud requests and disposable local state. A subsequent controlled Task6 scheduling smoke test created one task in a separate disposable account (see below). The original account received no SDK writes, and the app database was not edited directly. Private captures and credentials are excluded from the repository.

## Limits and operational considerations

- Modern non-null `rp` repeater semantics and actual Task7 project/heading variants remain incompletely observed. Unsupported properties remain available in raw `Item.P`; no new repeater write contract is claimed.
- Three older orphan Task6 modification-only records remain a separate issue; full-state counts are not claimed to match exactly despite all local tasks being present.
- Staging uses memory proportional to rebuilt state. Each attempt requires snapshot/hash I/O and temporary space for one full database copy. Retained backups have owner-only permissions.
- CLI cache replacement uses optimistic change detection, not a cross-process lock. Another process can replace a complete cache snapshot; a later read catches up. Separate cache paths avoid shared-writer contention. SQLite installation has its own transactional metadata guard.
- Process-kill/power-loss injection has not been performed. The initial plain future-create smoke test passed for the separate scheduling fix in #31; the expanded live write coverage is recorded below. This PR does not implement #26's write-side schedule selection.

Changed areas: shared read/write guards and task kind metadata; memory replay; SQLite replay/backup; CLI cache recovery; regressions and README/implementation-plan documentation.

Fixes #29

## Disposable-account smoke test — 6 September 2026

The verified combined candidate (`05cf188`) created exactly one plain Task6 task scheduled for 7 September 2026 in a disposable account confirmed distinct from the original account.

- Cloud readback contained the expected 34-field create payload: `st=2`, correct `sr`/`tir`, `md=null`, pending status, and plain-task type. The SDK's Upcoming read included the task.
- Things.app 3.23.3 was visibly signed into the disposable account. After **Update with Things Cloud**, the task appeared under **Upcoming → Tomorrow**.
- Opening its details showed Tomorrow. After a deliberate quit/relaunch, the task remained in the same group and the app remained usable; no crash was observed.
- A read-only query of the app's database confirmed schedule 2 and the correct packed calendar date. A repeated SDK read still returned the task.
- The cloud cursor advanced from 12 to 13 and remained 13 after the restart check. No second SDK write was attempted.

This verifies this plain future-create case on the tested app build. It is not a complete payload safety guarantee: the initial smoke did not cover edit, batch, relationships, or recurrence; the later matrix below adds edit/batch/relationship coverage, while recurrence remains untested. The test task is retained for inspection. Credentials, account identifiers, private task data, and screenshots are excluded from this report.

## Expanded disposable-account validation — 6 September 2026

The approved live matrix passed on Things 3.23.3:

- Direct scheduling edit moved the original smoke task to 8 September.
- Batch creation produced a task on 9 September.
- Dedicated test area, project, and heading creation succeeded.
- A three-operation batch created future tasks assigned to the area, project, and heading; all remained scheduled for 10 September.
- Cloud readback checked the Task6 task envelopes, expected fields, dates, and references. The app database independently matched all eight test objects involved in the matrix, and Upcoming visibly placed the five scheduled tasks on their expected days.
- Opening the heading-assigned task and a final deliberate app quit/relaunch succeeded. No Things crash was observed. A UI-control service interruption was resolved by reconnecting to the same app window; the app process remained alive and no crash reports appeared.

The four fixes are merged into `develop`, whose tree exactly matches the reviewed combined candidate; post-merge CI passed. Release PR #33 and the draft v0.6.0 release prepare promotion to `main`. The release is not published yet.

This remains bounded acceptance coverage. Modern recurrence writes, arbitrary payload fuzzing against the live app, and process-kill/power-loss recovery injection are not claimed verified. Credentials, account identifiers, private task content, and screenshots are excluded from this report.
