### PR TITLE
Release v0.6.0: verified Task7 writes and reliable state recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ things-cli create-area "Name"
 things-cli create-tag "Name" [--shorthand KEY] [--parent UUID]
 
 # Modify
-things-cli edit <uuid> [--title ...] [--note ...] [--when ...] [--deadline ...]
+things-cli edit <uuid> [--title ...] [--note ...] [--when ...] [--deadline ...] [--scheduled YYYY-MM-DD]
 things-cli complete <uuid>
 things-cli trash <uuid>
 things-cli purge <uuid>
@@ -177,6 +177,12 @@ things-cli move-to-today <uuid>
 # UUIDs must be canonical Base58 identifiers, as returned by create/list
 echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":"VJ1edXTP9q3PmFDUuy8EQh"}]' | things-cli batch
 ```
+
+`--scheduled` uses the local calendar date: future dates appear in Upcoming,
+while today and past dates use the Today/Anytime schedule. If `--when` is also
+provided, its schedule takes precedence and `--scheduled` still supplies the
+date. For batch creates, pass the date as
+`"extra":{"scheduled":"YYYY-MM-DD"}`.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ func main() {
 }
 ```
 
+### Task7 reads and recovery
+
+The readers accept Task7 alongside Task6 and older task kinds. Task7 write semantics are still unverified: `History.Write` rejects Task7 and unsupported future task kinds, and the CLI continues to send Task6. New read support does not change the outgoing payload format.
+
+The first read after this upgrade replays state built by an older task reader:
+
+- `things-cli` saves the old JSON cache as `<cache-path>.before-replay-<random>.bak`, then atomically replaces the cache after successful replay.
+- The SQLite sync engine keeps opening databases offline. On the next `Sync()`, it detects the old replay generation even if the cursor is already at the cloud head. It creates a consistent `<database-path>.task7-backup-<random>` backup, rebuilds derived state in memory, and installs it in one transaction.
+- Existing SQLite change-log rows, IDs, and timestamps are retained. Historical replay below the old cursor produces no duplicate log entries or notifications. Old Task7 `UnknownChange` rows remain audit evidence; newly fetched events after that cursor are logged normally.
+- Failed or incomplete replay leaves the existing database/cache available for retry. Backups are kept with owner-only permissions. Each SQLite attempt snapshots the current database; identical validated snapshots are deduplicated by full content so repeated failures do not accumulate identical backups. Staging requires memory proportional to the rebuilt state, and each attempt needs temporary free space for a full database snapshot.
+
+Call `Sync()` before relying on database queries after upgrading: `Open()` does not perform network recovery. A future unsupported task kind returns an incomplete-sync error instead of silently advancing the cursor. Diagnostics do not include task payloads.
+
+CLI cache writes use atomic replacement and optimistic change detection, not a cross-process lock. Concurrent readers can replace one another's complete cache snapshots; a later read catches up from the saved cursor. Give concurrent consumers distinct `THINGS_CLI_CACHE` paths if they must not share cache writes. SQLite recovery separately checks its saved metadata within the installation transaction.
+
+Scheduled dates now use `sr` only; `tir` is a separate Today ordering reference date. Omitted task fields preserve prior values, while explicit nulls clear supported nullable dates, notes, and relationships. Modern repeater (`rp`) semantics remain incompletely verified; unknown wire fields remain available in raw `Item.P` and are not newly interpreted by the task model. The existing `ReminderDate` API field tagged `rmd` is a legacy misnomer for repeater migration date.
+
 ### Semantic Change Types
 
 The sync engine detects 40+ semantic change types:

--- a/README.md
+++ b/README.md
@@ -310,9 +310,13 @@ func main() {
 }
 ```
 
-### Task7 reads and recovery
+### Task7 writes, reads, and recovery
 
-The readers accept Task7 alongside Task6 and older task kinds. Task7 write semantics are still unverified: `History.Write` rejects Task7 and unsupported future task kinds, and the CLI continues to send Task6. New read support does not change the outgoing payload format.
+The CLI uses Task7 for validated ordinary task, project, and heading creation and modification. `History.Write` also accepts explicit `ItemKindTask7` envelopes within that scope. It checks existing update targets against raw history and rejects recurring or unknown targets before posting. This adds a history read for update requests. Direct recurrence configuration, note-delta writes, and Task7 deletion events remain unsupported; other entity formats, including Tombstone2 purge, are unchanged.
+
+Older or sparse task histories that never explicitly establish `rr`, `rp`, and `rt` are also rejected by CLI updates, even when the task may be ordinary. This is a compatibility limit of the first Task7 rollout: the checker does not guess missing recurrence state and does not silently retry through Task6.
+
+Existing SDK callers retain `ItemKindTask == "Task6"` and their previous write behavior. The readers accept both versions and older task kinds. Migrating outgoing writes does not rewrite stored tasks or history. See [Task7 write policy](docs/task7-write-policy.md) for the exact boundary, SDK usage, and mixed-version live evidence.
 
 The first read after this upgrade replays state built by an older task reader:
 
@@ -393,7 +397,7 @@ Key findings from reverse engineering the Things Cloud sync protocol:
 - **Status field (`ss`)**: `0` = Pending, `2` = Canceled, `3` = Completed. Don't confuse with `st` (schedule)!
 - **Headings (`tp=2`) must have `st=1`** (anytime). `st=0` (inbox) crashes Things.app.
 - **Tasks in projects, headings, or areas** should default to `st=1` (anytime) — they've been triaged out of inbox.
-- **Kind strings**: `Task6`, `Tag4`, `ChecklistItem3`, `Area3`, `Tombstone2`
+- **Kind strings**: `Task7` for verified CLI task writes; `Task6` remains supported for existing SDK callers; `Tag4`, `ChecklistItem3`, `Area3`, `Tombstone2` for other entities.
 
 Since v0.3.0 the SDK enforces the identifier rules instead of trusting callers: `things.NewUUID()` generates canonical Base58 identifiers (one leading `1` per leading zero byte — a subtlety whose absence used to corrupt ~1 in 256 creates), `things.ValidateUUID()` checks any identifier, and `History.Write()` refuses items with invalid or duplicate UUIDs before anything reaches the server.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":
 
 ### Examples
 
+Write commands reject invalid relationship identifiers, schedule/type names, and calendar dates before sending a commit. Tag IDs must be canonical Base58 with no surrounding whitespace. Batch input is validated in full before its single commit; see [CLI write validation](cmd/README.md#write-validation) for supported options and batch `extra` rules.
+
 ```bash
 # Create a project with tasks
 things-cli create "My Project" --type project --when anytime

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -40,8 +40,8 @@ things-cli move-to-today <uuid>
 echo '[
   {"cmd": "create", "title": "Task 1"},
   {"cmd": "create", "title": "Task 2"},
-  {"cmd": "complete", "uuid": "abc123"},
-  {"cmd": "move-to-project", "uuid": "def456", "project": "proj-uuid"}
+  {"cmd": "complete", "uuid": "BXmAcvS6yK1eDhW31MuZrL"},
+  {"cmd": "move-to-project", "uuid": "VJ1edXTP9q3PmFDUuy8EQh", "project": "FQxaqvLBkbR5q2Q5oRoknc"}
 ]' | things-cli batch
 
 # Batch commands: create, complete, trash, purge, move-to-today,
@@ -61,6 +61,22 @@ echo '[
 #   --tags UUID,UUID,...    Add tags
 #   --type task|project|heading
 #   --checklist "Item 1,Item 2,..."
+```
+
+#### Write validation
+
+Replace the sample UUIDs above with IDs returned by `create` or `list` for your account.
+
+Invalid identifiers, schedule names, task types, and dates cause a nonzero exit before any commit is sent. Identifiers must be canonical Base58 exactly as supplied, including `create-area --tags`, `create-tag --parent`, and purge targets. Do not include spaces around comma-separated tag IDs.
+
+`--when` accepts `today`, `anytime`, `someday`, or `inbox`; `--type` accepts `task`, `project`, or `heading`. Dates must be real calendar dates in `YYYY-MM-DD` format. Invalid or missing option values are rejected instead of silently producing default or partial writes.
+
+A batch is submitted only after every operation passes validation. Its input must contain one JSON array, with no unknown top-level operation fields or trailing input. Empty optional top-level batch strings retain their existing meaning of "not supplied." Explicitly empty identifier options in individual commands or `extra` are rejected; omit an optional identifier instead.
+
+Batch `create` also accepts an `extra` object containing `note`, `when`, `deadline`, `scheduled`, `project`, `area`, `heading`, `tags`, or `type`. These values override the corresponding create options and are validated after merging. `extra.tags` is comma-separated text; top-level `tags` is a JSON array. Other operations reject an `extra` object, including `{}`; `extra: null` is treated as absent. For example:
+
+```json
+[{"cmd":"create","title":"Plan launch","extra":{"scheduled":"2026-10-15"}}]
 ```
 
 ### thingsync

--- a/cmd/soak/main.go
+++ b/cmd/soak/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"flag"
@@ -324,5 +323,3 @@ func fatal(msg string) {
 	fmt.Fprintln(os.Stderr, "soak: "+msg)
 	os.Exit(1)
 }
-
-var _ = bufio.NewReader // reserved for future interactive confirm

--- a/cmd/things-cli/cache.go
+++ b/cmd/things-cli/cache.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// A nil snapshot means the file did not exist; an empty but non-nil snapshot
+// represents an existing empty file and still needs preservation on recovery.
+func readCLIStateCacheFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		data = []byte{}
+	}
+	return data, nil
+}
+
+func checkCLIStateCacheSnapshot(path string, expected []byte) error {
+	current, err := readCLIStateCacheFile(path)
+	if err != nil {
+		return err
+	}
+	if (current == nil) != (expected == nil) || !bytes.Equal(current, expected) {
+		return fmt.Errorf("state cache changed during sync; retry the read")
+	}
+	return nil
+}
+
+func createSyncedCacheFile(dir, pattern string, data []byte) (path string, err error) {
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", err
+	}
+	path = file.Name()
+	defer func() {
+		if err != nil {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+	}()
+	if err = file.Chmod(0o600); err != nil {
+		return path, err
+	}
+	if _, err = file.Write(data); err != nil {
+		return path, err
+	}
+	if err = file.Sync(); err != nil {
+		return path, err
+	}
+	err = file.Close()
+	return path, err
+}
+
+// Save only the state derived from the snapshot the reader actually loaded.
+// Keep obsolete cache bytes in a private backup and rename a complete new file
+// into place; never truncate the usable cache while writing its replacement.
+func saveCLIStateCacheSnapshot(path string, cache *cliStateCache, previous []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := checkCLIStateCacheSnapshot(path, previous); err != nil {
+		return err
+	}
+	cache.Version = cliStateCacheVersion
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	temporary, err := createSyncedCacheFile(dir, "."+filepath.Base(path)+".pending-*", data)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(temporary) }()
+
+	if previous != nil {
+		var old struct {
+			Version     int    `json:"version"`
+			HistoryID   string `json:"historyId"`
+			ServerIndex int    `json:"serverIndex"`
+		}
+		if json.Unmarshal(previous, &old) != nil || old.Version != cliStateCacheVersion || old.HistoryID != cache.HistoryID || old.ServerIndex > cache.ServerIndex {
+			if _, err := createSyncedCacheFile(dir, filepath.Base(path)+".before-replay-*.bak", previous); err != nil {
+				return fmt.Errorf("backing up state cache: %w", err)
+			}
+		}
+	}
+	if err := checkCLIStateCacheSnapshot(path, previous); err != nil {
+		return err
+	}
+	return os.Rename(temporary, path)
+}

--- a/cmd/things-cli/cache_recovery_test.go
+++ b/cmd/things-cli/cache_recovery_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func oldReplayCache() []byte {
-	return []byte(`{"version":1,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{}}}`)
+	return []byte(`{"version":2,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{"BXmAcvS6yK1eDhW31MuZrL":{"UUID":"BXmAcvS6yK1eDhW31MuZrL","Title":"Native task","Note":"Native Task7 note α 🚀\nSecoUpdatene."}}}}`)
 }
 
-func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
+func TestCLIStateCacheRebuildsByteOffsetNotesAtHead(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.json")
 	old := oldReplayCache()
 	if err := os.WriteFile(path, old, 0o600); err != nil {
@@ -42,8 +42,9 @@ func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
 	c := things.New(server.URL, "test@example.com", "test-password")
 	ctx := cliContext{client: c, history: c.HistoryWithID("test-history")}
 	state := ctx.loadState()
-	if len(state.Tasks) != 1 || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"] == nil || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"].Title != "New task" {
-		t.Fatal("old caught-up cache was not rebuilt with the missing Task7 task")
+	task := state.Tasks["BXmAcvS6yK1eDhW31MuZrL"]
+	if len(state.Tasks) != 1 || task == nil || task.Title != "Native task" || task.Note != "Native Task7 note α 🚀\nUpdated line." {
+		t.Fatalf("old caught-up cache was not rebuilt with the byte-offset note: %+v", task)
 	}
 	if len(starts) != 1 || starts[0] != "0" {
 		t.Fatalf("replay starts = %v, want [0]", starts)
@@ -70,7 +71,7 @@ func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
 	}
 }
 
-const task7CachePage = `{"items":[{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":0,"p":{"tt":"","tp":0,"st":0,"ss":0}}},{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":1,"p":{"tt":"New task"}}}],"current-item-index":2}`
+const task7CachePage = `{"items":[{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":0,"p":{"tt":"Native task","tp":0,"st":0,"ss":0,"nt":{"t":1,"v":"Native Task7 note α 🚀\nSecond line."}}}},{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":1,"p":{"nt":{"t":2,"ps":[{"r":"Update","p":26,"l":5,"ch":3672733299}]}}}}],"current-item-index":2}`
 
 func TestCLIStateCacheReplacementFailurePreservesOriginal(t *testing.T) {
 	if os.Geteuid() == 0 {

--- a/cmd/things-cli/cache_recovery_test.go
+++ b/cmd/things-cli/cache_recovery_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+	"github.com/arthursoares/things-cloud-sdk/state/memory"
+)
+
+func oldReplayCache() []byte {
+	return []byte(`{"version":1,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{}}}`)
+}
+
+func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	old := oldReplayCache()
+	if err := os.WriteFile(path, old, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("THINGS_CLI_CACHE", path)
+	var starts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			starts = append(starts, r.URL.Query().Get("start-index"))
+			fmt.Fprint(w, task7CachePage)
+		} else {
+			fmt.Fprint(w, `{"latest-server-index":2}`)
+		}
+	}))
+	defer server.Close()
+	c := things.New(server.URL, "test@example.com", "test-password")
+	ctx := cliContext{client: c, history: c.HistoryWithID("test-history")}
+	state := ctx.loadState()
+	if len(state.Tasks) != 1 || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"] == nil || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"].Title != "New task" {
+		t.Fatal("old caught-up cache was not rebuilt with the missing Task7 task")
+	}
+	if len(starts) != 1 || starts[0] != "0" {
+		t.Fatalf("replay starts = %v, want [0]", starts)
+	}
+	backups, err := filepath.Glob(path + ".before-replay-*.bak")
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("backups = %v, error %v", backups, err)
+	}
+	got, err := os.ReadFile(backups[0])
+	if err != nil || !bytes.Equal(got, old) {
+		t.Fatal("backup did not preserve original cache bytes")
+	}
+	info, err := os.Stat(backups[0])
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatal("backup permissions are not 0600")
+	}
+	cache, err := loadCLIStateCache(path)
+	if err != nil || cache == nil || cache.Version != things.TaskReplayVersion || cache.ServerIndex != 2 {
+		t.Fatalf("rebuilt cache metadata is invalid: %+v, %v", cache, err)
+	}
+	ctx.loadState()
+	if len(starts) != 1 {
+		t.Fatal("second load replayed an already recovered cache")
+	}
+}
+
+const task7CachePage = `{"items":[{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":0,"p":{"tt":"","tp":0,"st":0,"ss":0}}},{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":1,"p":{"tt":"New task"}}}],"current-item-index":2}`
+
+func TestCLIStateCacheReplacementFailurePreservesOriginal(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission failure requires an unprivileged user")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	old := oldReplayCache()
+	if err := os.WriteFile(path, old, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	err := saveCLIStateCache(path, &cliStateCache{HistoryID: "test-history", ServerIndex: 2, State: memory.NewState()})
+	if err == nil {
+		t.Error("expected failure creating an atomic replacement in a read-only directory")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil || !bytes.Equal(got, old) {
+		t.Error("failed replacement changed the original cache")
+	}
+}
+
+func TestCLIRecoveryHelper(t *testing.T) {
+	if os.Getenv("THINGS_CACHE_RECOVERY_HELPER") == "" {
+		return
+	}
+	c := things.New(os.Getenv("THINGS_ENDPOINT"), "test@example.com", "test-password")
+	ctx := cliContext{client: c, history: c.HistoryWithID("test-history")}
+	ctx.loadState()
+}
+
+func TestCLIStateCacheFailedReplayPreservesOriginal(t *testing.T) {
+	cases := []struct {
+		name, page, diagnostic string
+		concurrent             bool
+	}{
+		{"unsupported", `{"items":[{"private-id":{"e":"Task8","t":0,"p":{"tt":"private title"}}}],"current-item-index":2}`, "unsupported task kind Task8", false},
+		{"no progress", `{"items":[],"current-item-index":2}`, "progress", false},
+		{"premature end", `{"items":[{}],"current-item-index":1}`, "incomplete", false},
+		{"concurrent cache", task7CachePage, "changed", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "state.json")
+			// Version 0 forces a replay in the old implementation too.
+			old := []byte(`{"version":0,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{}}}`)
+			if err := os.WriteFile(path, old, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			want := old
+			if tc.concurrent {
+				want = []byte(`{"version":2,"historyId":"test-history","serverIndex":3,"state":{"Tasks":{}}}`)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/items") {
+					if tc.concurrent {
+						if err := os.WriteFile(path, want, 0o600); err != nil {
+							t.Error(err)
+						}
+					}
+					fmt.Fprint(w, tc.page)
+				} else {
+					fmt.Fprint(w, `{"latest-server-index":2}`)
+				}
+			}))
+			defer server.Close()
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, executable, "-test.run=^TestCLIRecoveryHelper$")
+			cmd.Env = append(os.Environ(), "THINGS_CACHE_RECOVERY_HELPER=1", "THINGS_CLI_CACHE="+path, "THINGS_ENDPOINT="+server.URL)
+			output, err := cmd.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), tc.diagnostic) {
+				t.Fatalf("expected %q failure, got %v: %s", tc.diagnostic, err, output)
+			}
+			if strings.Contains(string(output), "private-id") || strings.Contains(string(output), "private title") {
+				t.Fatal("diagnostic exposed private task data")
+			}
+			got, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(got, want) {
+				t.Fatal("failed replay overwrote the original/concurrently updated cache")
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(got, &parsed); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -43,6 +43,8 @@ type writeEnvelope struct {
 	payload any
 }
 
+const task7WriteKind = "Task7"
+
 func (w writeEnvelope) UUID() string { return w.id }
 
 func (w writeEnvelope) MarshalJSON() ([]byte, error) {
@@ -182,6 +184,13 @@ func validateTaskOpts(opts map[string]string) error {
 		if v, ok := opts[key]; ok && parseDate(v) == nil {
 			return fmt.Errorf("--%s: %q is invalid; expected a calendar date in YYYY-MM-DD format", key, v)
 		}
+	}
+	return nil
+}
+
+func validateEditContainers(area, project, heading string) error {
+	if area != "" && (project != "" || heading != "") {
+		return fmt.Errorf("--area cannot be combined with --project or --heading when editing a task")
 	}
 	return nil
 }
@@ -524,11 +533,15 @@ func (u *taskUpdate) Scheduled(sr, tir int64) *taskUpdate {
 
 func (u *taskUpdate) Area(uuid string) *taskUpdate {
 	u.fields["ar"] = []string{uuid}
+	u.fields["pr"] = []string{}
+	u.fields["agr"] = []string{}
 	return u
 }
 
 func (u *taskUpdate) Project(uuid string) *taskUpdate {
 	u.fields["pr"] = []string{uuid}
+	u.fields["ar"] = []string{}
+	u.fields["agr"] = []string{}
 	return u
 }
 
@@ -985,7 +998,7 @@ func cmdCreate(history *thingscloud.History, args []string) {
 	}
 
 	payload := newTaskCreatePayload(title, opts)
-	env := writeEnvelope{id: taskUUID, action: 0, kind: "Task6", payload: payload}
+	env := writeEnvelope{id: taskUUID, action: 0, kind: task7WriteKind, payload: payload}
 	if err := history.Write(env); err != nil {
 		fatal("create task", err)
 	}
@@ -1019,6 +1032,9 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 		fatal("edit", err)
 	}
 	if err := validateTaskOpts(opts); err != nil {
+		fatal("edit", err)
+	}
+	if err := validateEditContainers(opts["area"], opts["project"], opts["heading"]); err != nil {
 		fatal("edit", err)
 	}
 
@@ -1085,7 +1101,7 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 		u.Tags(strings.Split(v, ","))
 	}
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("edit task", err)
 	}
@@ -1097,7 +1113,7 @@ func cmdComplete(history *thingscloud.History, taskUUID string) {
 	ts := nowTs()
 	u := newTaskUpdate().Status(3).StopDate(ts)
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("complete task", err)
 	}
@@ -1108,7 +1124,7 @@ func cmdComplete(history *thingscloud.History, taskUUID string) {
 func cmdTrash(history *thingscloud.History, taskUUID string) {
 	u := newTaskUpdate().Trash(true)
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("trash task", err)
 	}
@@ -1137,7 +1153,7 @@ func cmdPurge(history *thingscloud.History, taskUUID string) {
 func cmdMoveToToday(history *thingscloud.History, taskUUID string) {
 	u := newTaskUpdate().Today()
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("move to today", err)
 	}
@@ -1360,7 +1376,7 @@ func buildBatchCreate(op BatchOp) (thingscloud.Identifiable, map[string]string, 
 	}
 
 	payload := newTaskCreatePayload(op.Title, opts)
-	env := writeEnvelope{id: taskUUID, action: 0, kind: "Task6", payload: payload}
+	env := writeEnvelope{id: taskUUID, action: 0, kind: task7WriteKind, payload: payload}
 
 	return env, map[string]string{"cmd": "create", "uuid": taskUUID, "title": op.Title}, nil
 }
@@ -1372,7 +1388,7 @@ func buildBatchComplete(op BatchOp) (thingscloud.Identifiable, map[string]string
 
 	ts := nowTs()
 	u := newTaskUpdate().Status(3).StopDate(ts)
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "complete", "uuid": op.UUID}, nil
 }
@@ -1383,7 +1399,7 @@ func buildBatchTrash(op BatchOp) (thingscloud.Identifiable, map[string]string, e
 	}
 
 	u := newTaskUpdate().Trash(true)
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "trash", "uuid": op.UUID}, nil
 }
@@ -1412,7 +1428,7 @@ func buildBatchMoveToToday(op BatchOp) (thingscloud.Identifiable, map[string]str
 	}
 
 	u := newTaskUpdate().Today()
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-today", "uuid": op.UUID}, nil
 }
@@ -1429,7 +1445,7 @@ func buildBatchMoveToProject(op BatchOp) (thingscloud.Identifiable, map[string]s
 	}
 
 	u := newTaskUpdate().Project(op.Project).Anytime()
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-project", "uuid": op.UUID, "project": op.Project}, nil
 }
@@ -1446,7 +1462,7 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 	}
 
 	u := newTaskUpdate().Area(op.Area).Anytime()
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-area", "uuid": op.UUID, "area": op.Area}, nil
 }
@@ -1466,6 +1482,9 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 		opts["deadline"] = op.Deadline
 	}
 	if err := validateTaskOpts(opts); err != nil {
+		return nil, nil, err
+	}
+	if err := validateEditContainers(op.Area, op.Project, op.Heading); err != nil {
 		return nil, nil, err
 	}
 
@@ -1516,7 +1535,7 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 		u.Tags(op.Tags)
 	}
 
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "edit", "uuid": op.UUID}, nil
 }

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -519,7 +519,7 @@ type cliContext struct {
 // state. Caches with any other version are ignored, forcing a full replay.
 // Bump it whenever replay output changes for the same history, e.g. when
 // object keys or memory.State's representation change.
-const cliStateCacheVersion = 1
+const cliStateCacheVersion = thingscloud.TaskReplayVersion
 
 type cliStateCache struct {
 	Version     int           `json:"version"`
@@ -548,12 +548,14 @@ func cliStateCachePath() string {
 }
 
 func loadCLIStateCache(path string) (*cliStateCache, error) {
-	bs, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
+	cache, _, err := loadCLIStateCacheSnapshot(path)
+	return cache, err
+}
+
+func loadCLIStateCacheSnapshot(path string) (*cliStateCache, []byte, error) {
+	bs, err := readCLIStateCacheFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var cache cliStateCache
 	if err := json.Unmarshal(bs, &cache); err != nil {
@@ -561,17 +563,17 @@ func loadCLIStateCache(path string) (*cliStateCache, error) {
 		// partial write) degrades to a full replay, same as a version
 		// mismatch, instead of an error the user can only clear by deleting
 		// the file by hand.
-		return nil, nil
+		return nil, bs, nil
 	}
 	if cache.Version != cliStateCacheVersion {
-		return nil, nil
+		return nil, bs, nil
 	}
 	if cache.State == nil {
 		cache.State = memory.NewState()
 	} else {
 		normalizeMemoryState(cache.State)
 	}
-	return &cache, nil
+	return &cache, bs, nil
 }
 
 func normalizeMemoryState(state *memory.State) {
@@ -590,15 +592,11 @@ func normalizeMemoryState(state *memory.State) {
 }
 
 func saveCLIStateCache(path string, cache *cliStateCache) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
-	cache.Version = cliStateCacheVersion
-	bs, err := json.MarshalIndent(cache, "", "  ")
+	previous, err := readCLIStateCacheFile(path)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, bs, 0o600)
+	return saveCLIStateCacheSnapshot(path, cache, previous)
 }
 
 func initCLI(syncHistoryHead bool) *cliContext {
@@ -641,7 +639,7 @@ func (ctx *cliContext) serverIndex() int {
 
 func (ctx *cliContext) loadState() *memory.State {
 	cachePath := cliStateCachePath()
-	cache, err := loadCLIStateCache(cachePath)
+	cache, previous, err := loadCLIStateCacheSnapshot(cachePath)
 	if err != nil {
 		fatal("load state cache", err)
 	}
@@ -665,6 +663,12 @@ func (ctx *cliContext) loadState() *memory.State {
 		if err != nil {
 			fatal("fetch items", err)
 		}
+		if ctx.history.LoadedServerIndex <= startIndex {
+			fatalf("incomplete history: item page made no progress")
+		}
+		if ctx.history.LatestServerIndex < latestServerIndex || ctx.history.LoadedServerIndex > ctx.history.LatestServerIndex {
+			fatalf("incomplete history: inconsistent server cursor during replay")
+		}
 		if err := state.Update(items...); err != nil {
 			fatal("update state", err)
 		}
@@ -674,11 +678,11 @@ func (ctx *cliContext) loadState() *memory.State {
 		}
 	}
 
-	if err := saveCLIStateCache(cachePath, &cliStateCache{
+	if err := saveCLIStateCacheSnapshot(cachePath, &cliStateCache{
 		HistoryID:   ctx.history.ID,
 		ServerIndex: startIndex,
 		State:       state,
-	}); err != nil {
+	}, previous); err != nil {
 		fatal("save state cache", err)
 	}
 

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -140,18 +141,46 @@ func generateUUID() string {
 // identifier. Invalid identifiers written to the cloud poison the sync
 // history irreparably, so they must be rejected before any write.
 func validateIdentifierOpts(opts map[string]string) error {
-	for _, key := range []string{"uuid", "project", "heading", "area"} {
-		if v, ok := opts[key]; ok && v != "" {
+	for _, key := range []string{"uuid", "project", "heading", "area", "parent"} {
+		if v, ok := opts[key]; ok {
 			if err := thingscloud.ValidateUUID(v); err != nil {
 				return fmt.Errorf("--%s: %w", key, err)
 			}
 		}
 	}
-	if v, ok := opts["tags"]; ok && v != "" {
+	if v, ok := opts["tags"]; ok {
 		for _, tag := range strings.Split(v, ",") {
-			if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+			if err := thingscloud.ValidateUUID(tag); err != nil {
 				return fmt.Errorf("--tags: %w", err)
 			}
+		}
+	}
+	return nil
+}
+
+// validateTaskOpts runs before building a task payload so unsupported values
+// cannot silently fall back to a default or omit a requested update.
+func validateTaskOpts(opts map[string]string) error {
+	if err := validateIdentifierOpts(opts); err != nil {
+		return err
+	}
+	if v, ok := opts["when"]; ok {
+		switch v {
+		case "today", "anytime", "someday", "inbox":
+		default:
+			return fmt.Errorf("--when: %q is invalid; expected today, anytime, someday, or inbox", v)
+		}
+	}
+	if v, ok := opts["type"]; ok {
+		switch v {
+		case "task", "project", "heading":
+		default:
+			return fmt.Errorf("--type: %q is invalid; expected task, project, or heading", v)
+		}
+	}
+	for _, key := range []string{"deadline", "scheduled"} {
+		if v, ok := opts[key]; ok && parseDate(v) == nil {
+			return fmt.Errorf("--%s: %q is invalid; expected a calendar date in YYYY-MM-DD format", key, v)
 		}
 	}
 	return nil
@@ -172,7 +201,7 @@ func validateBatchOpIdentifiers(op BatchOp) error {
 		}
 	}
 	for _, tag := range op.Tags {
-		if err := thingscloud.ValidateUUID(strings.TrimSpace(tag)); err != nil {
+		if err := thingscloud.ValidateUUID(tag); err != nil {
 			return fmt.Errorf("tags: %w", err)
 		}
 	}
@@ -931,7 +960,7 @@ func cmdCreate(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
-	if err := validateIdentifierOpts(opts); err != nil {
+	if err := validateTaskOpts(opts); err != nil {
 		fatal("create task", err)
 	}
 
@@ -974,7 +1003,7 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
 		fatal("edit", err)
 	}
-	if err := validateIdentifierOpts(opts); err != nil {
+	if err := validateTaskOpts(opts); err != nil {
 		fatal("edit", err)
 	}
 
@@ -1073,6 +1102,9 @@ func cmdTrash(history *thingscloud.History, taskUUID string) {
 }
 
 func cmdPurge(history *thingscloud.History, taskUUID string) {
+	if err := thingscloud.ValidateUUID(taskUUID); err != nil {
+		fatal("purge uuid", err)
+	}
 	tombstoneUUID := generateUUID()
 	payload := map[string]any{
 		"dloid": taskUUID,
@@ -1103,6 +1135,9 @@ func cmdCreateArea(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("create area", err)
+	}
 
 	areaUUID := opts["uuid"]
 	if areaUUID == "" {
@@ -1134,6 +1169,9 @@ func cmdCreateTag(history *thingscloud.History, args []string) {
 
 	title := args[0]
 	opts := parseArgs(args[1:])
+	if err := validateIdentifierOpts(opts); err != nil {
+		fatal("create tag", err)
+	}
 
 	tagUUID := opts["uuid"]
 	if tagUUID == "" {
@@ -1184,14 +1222,20 @@ type BatchOp struct {
 	Heading  string            `json:"heading,omitempty"`
 	Tags     []string          `json:"tags,omitempty"`
 	Type     string            `json:"type,omitempty"`
-	Extra    map[string]string `json:"extra,omitempty"` // for any additional opts
+	Extra    map[string]string `json:"extra,omitempty"` // supported create options; overrides top-level values
 }
 
 func cmdBatch(history *thingscloud.History) {
 	// Read JSON from stdin
 	var ops []BatchOp
-	if err := json.NewDecoder(os.Stdin).Decode(&ops); err != nil {
+	decoder := json.NewDecoder(os.Stdin)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&ops); err != nil {
 		fatalf("parsing batch JSON: %v", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		fatalf("parsing batch JSON: expected a single array with no trailing input")
 	}
 
 	if len(ops) == 0 {
@@ -1224,6 +1268,9 @@ func cmdBatch(history *thingscloud.History) {
 }
 
 func buildBatchEnvelope(op BatchOp) (thingscloud.Identifiable, map[string]string, error) {
+	if op.Cmd != "create" && op.Extra != nil {
+		return nil, nil, fmt.Errorf("extra options are only supported for create")
+	}
 	switch op.Cmd {
 	case "create":
 		return buildBatchCreate(op)
@@ -1286,7 +1333,15 @@ func buildBatchCreate(op BatchOp) (thingscloud.Identifiable, map[string]string, 
 		opts["type"] = op.Type
 	}
 	for k, v := range op.Extra {
-		opts[k] = v
+		switch k {
+		case "note", "when", "deadline", "scheduled", "project", "area", "heading", "tags", "type":
+			opts[k] = v
+		default:
+			return nil, nil, fmt.Errorf("unsupported create extra option: %s", k)
+		}
+	}
+	if err := validateTaskOpts(opts); err != nil {
+		return nil, nil, err
 	}
 
 	payload := newTaskCreatePayload(op.Title, opts)
@@ -1321,6 +1376,9 @@ func buildBatchTrash(op BatchOp) (thingscloud.Identifiable, map[string]string, e
 func buildBatchPurge(op BatchOp) (thingscloud.Identifiable, map[string]string, error) {
 	if op.UUID == "" {
 		return nil, nil, fmt.Errorf("purge requires uuid")
+	}
+	if err := thingscloud.ValidateUUID(op.UUID); err != nil {
+		return nil, nil, fmt.Errorf("uuid: %w", err)
 	}
 
 	tombstoneUUID := generateUUID()
@@ -1383,6 +1441,16 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 		return nil, nil, fmt.Errorf("edit requires uuid")
 	}
 	if err := validateBatchOpIdentifiers(op); err != nil {
+		return nil, nil, err
+	}
+	opts := make(map[string]string)
+	if op.When != "" {
+		opts["when"] = op.When
+	}
+	if op.Deadline != "" {
+		opts["deadline"] = op.Deadline
+	}
+	if err := validateTaskOpts(opts); err != nil {
 		return nil, nil, err
 	}
 
@@ -1481,7 +1549,7 @@ Write commands (fast — skip state loading):
 Batch command (reads JSON from stdin, sends all ops in one HTTP request):
   batch
 
-  Example: echo '[{"cmd":"complete","uuid":"abc"},{"cmd":"trash","uuid":"def"}]' | things-cli batch
+  Example: echo '[{"cmd":"complete","uuid":"BXmAcvS6yK1eDhW31MuZrL"},{"cmd":"trash","uuid":"VJ1edXTP9q3PmFDUuy8EQh"}]' | things-cli batch
 
   Supported operations:
     {"cmd": "create", "title": "...", "note": "...", "when": "today|anytime|someday|inbox",

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -217,6 +217,13 @@ func todayMidnightUTC() int64 {
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).Unix()
 }
 
+func taskScheduleForDate(scheduledDate, today int64) int {
+	if scheduledDate > today {
+		return 2
+	}
+	return 1
+}
+
 func parseDate(s string) *time.Time {
 	t, err := time.Parse("2006-01-02", s)
 	if err != nil {
@@ -344,14 +351,15 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 		}
 	}
 
-	// --scheduled (overrides sr/tir; sets st=1 with dates if not already set by --when)
+	// --scheduled overrides sr/tir. Without --when, future dates are Upcoming
+	// (st=2), while today and past dates use Today/Anytime (st=1).
 	if v, ok := opts["scheduled"]; ok {
 		if t := parseDate(v); t != nil {
 			ts := t.Unix()
 			sr = &ts
 			tir = &ts
 			if _, hasWhen := opts["when"]; !hasWhen {
-				st = 1 // default to anytime+date
+				st = taskScheduleForDate(ts, todayMidnightUTC())
 			}
 		}
 	}
@@ -359,8 +367,9 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 	// --project
 	if v, ok := opts["project"]; ok && v != "" {
 		pr = []string{v}
-		// Tasks in projects are already triaged — auto-set anytime (st=1) unless --when was explicit
-		if _, hasWhen := opts["when"]; !hasWhen {
+		// Tasks in projects are already triaged — auto-set anytime (st=1)
+		// unless the caller supplied a schedule.
+		if !hasExplicitSchedule(opts) {
 			st = 1
 		}
 	}
@@ -368,8 +377,9 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 	// --heading
 	if v, ok := opts["heading"]; ok && v != "" {
 		agr = []string{v}
-		// Tasks under headings are structural — auto-set anytime (st=1) unless --when was explicit
-		if _, hasWhen := opts["when"]; !hasWhen {
+		// Tasks under headings are structural — auto-set anytime (st=1)
+		// unless the caller supplied a schedule.
+		if !hasExplicitSchedule(opts) {
 			st = 1
 		}
 	}
@@ -377,8 +387,9 @@ func newTaskCreatePayload(title string, opts map[string]string) TaskCreatePayloa
 	// --area
 	if v, ok := opts["area"]; ok && v != "" {
 		ar = []string{v}
-		// Tasks in areas are already triaged — auto-set anytime (st=1) unless --when was explicit
-		if _, hasWhen := opts["when"]; !hasWhen {
+		// Tasks in areas are already triaged — auto-set anytime (st=1)
+		// unless the caller supplied a schedule.
+		if !hasExplicitSchedule(opts) {
 			st = 1
 		}
 	}
@@ -497,7 +508,7 @@ func (u *taskUpdate) Inbox() *taskUpdate {
 }
 
 func (u *taskUpdate) ScheduleDate(ts int64) *taskUpdate {
-	return u.Schedule(1, ts, ts)
+	return u.Schedule(taskScheduleForDate(ts, todayMidnightUTC()), ts, ts)
 }
 
 func (u *taskUpdate) Deadline(dd int64) *taskUpdate {
@@ -1541,6 +1552,9 @@ Write commands (fast — skip state loading):
   edit <uuid> [--title ...] [--note ...] [--when ...] [--deadline ...]
          [--scheduled ...] [--area UUID] [--project UUID]
          [--heading UUID] [--tags UUID,...]
+
+  --scheduled uses Upcoming for future local dates and Today/Anytime for today
+  or past dates. An explicit --when takes precedence over that classification.
   complete <uuid>
   trash <uuid>
   purge <uuid>
@@ -1553,7 +1567,8 @@ Batch command (reads JSON from stdin, sends all ops in one HTTP request):
 
   Supported operations:
     {"cmd": "create", "title": "...", "note": "...", "when": "today|anytime|someday|inbox",
-     "project": "uuid", "area": "uuid", "heading": "uuid", "tags": ["uuid",...]}
+     "project": "uuid", "area": "uuid", "heading": "uuid", "tags": ["uuid",...],
+     "extra": {"scheduled": "YYYY-MM-DD"}}
     {"cmd": "complete", "uuid": "..."}
     {"cmd": "trash", "uuid": "..."}
     {"cmd": "purge", "uuid": "..."}

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,6 +53,64 @@ func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
 	assertAnytimeSchedule(t, payload)
 	if got := payload["pr"]; got == nil {
 		t.Fatal("project field was not set")
+	}
+}
+
+func TestTaskContainerMoveReplayClearsPreviousContainer(t *testing.T) {
+	tests := []struct {
+		name       string
+		initial    string
+		update     map[string]any
+		wantArea   []string
+		wantParent []string
+	}{
+		{
+			name:       "project and heading to area",
+			initial:    fmt.Sprintf(`{"tt":"child","pr":[%q],"agr":[%q]}`, testProjectID, testHeadingID),
+			update:     newTaskUpdate().Area(testAreaID).build(),
+			wantArea:   []string{testAreaID},
+			wantParent: []string{},
+		},
+		{
+			name:       "area and heading to project",
+			initial:    fmt.Sprintf(`{"tt":"child","ar":[%q],"agr":[%q]}`, testAreaID, testHeadingID),
+			update:     newTaskUpdate().Project(testProjectID).build(),
+			wantArea:   []string{},
+			wantParent: []string{testProjectID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := memory.NewState()
+			if err := state.Update(thingscloud.Item{
+				UUID: testTaskID, Kind: thingscloud.ItemKindTask7, Action: thingscloud.ItemActionCreated,
+				P: json.RawMessage(tt.initial),
+			}); err != nil {
+				t.Fatalf("seed task: %v", err)
+			}
+			payload, err := json.Marshal(tt.update)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := state.Update(thingscloud.Item{
+				UUID: testTaskID, Kind: thingscloud.ItemKindTask7, Action: thingscloud.ItemActionModified,
+				P: payload,
+			}); err != nil {
+				t.Fatalf("replay move: %v", err)
+			}
+
+			task := state.Tasks[testTaskID]
+			if fmt.Sprint(task.AreaIDs) != fmt.Sprint(tt.wantArea) {
+				t.Errorf("AreaIDs = %v, want %v", task.AreaIDs, tt.wantArea)
+			}
+			if fmt.Sprint(task.ParentTaskIDs) != fmt.Sprint(tt.wantParent) {
+				t.Errorf("ParentTaskIDs = %v, want %v", task.ParentTaskIDs, tt.wantParent)
+			}
+			if len(task.ActionGroupIDs) != 0 {
+				t.Errorf("ActionGroupIDs = %v, want cleared", task.ActionGroupIDs)
+			}
+		})
 	}
 }
 
@@ -279,7 +338,7 @@ func TestScheduledOptionValidation(t *testing.T) {
 
 func TestDirectCommandsRejectInvalidScheduledBeforeWrite(t *testing.T) {
 	if command := os.Getenv("THINGS_CLI_INVALID_SCHEDULE_COMMAND"); command != "" {
-		h, commits := newWireRecorder(t)
+		h, commits, _ := newWireRecorder(t)
 		switch command {
 		case "create":
 			cmdCreate(h, []string{"invalid", "--scheduled", "tomorrow", "--project", testProjectID})
@@ -367,6 +426,18 @@ func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
 
 	payload := requirePayloadMap(t, env)
 	assertAnytimeSchedule(t, payload)
+	if got := payload["pr"].([]string); len(got) != 1 || got[0] != testProjectID {
+		t.Fatalf("pr = %v, want [%s]", got, testProjectID)
+	}
+	if got := payload["ar"].([]string); len(got) != 0 {
+		t.Fatalf("ar = %v, want []", got)
+	}
+	if got := payload["agr"].([]string); len(got) != 0 {
+		t.Fatalf("agr = %v, want []", got)
+	}
+	if len(payload) != 7 {
+		t.Fatalf("payload fields = %v, want only md, st, sr, tir, pr, ar, agr", payload)
+	}
 
 	bs, err := json.Marshal(env)
 	if err != nil {
@@ -395,7 +466,20 @@ func TestBatchMoveToAreaUsesNullScheduleDates(t *testing.T) {
 		t.Fatalf("buildBatchMoveToArea failed: %v", err)
 	}
 
-	assertAnytimeSchedule(t, requirePayloadMap(t, env))
+	payload := requirePayloadMap(t, env)
+	assertAnytimeSchedule(t, payload)
+	if got := payload["ar"].([]string); len(got) != 1 || got[0] != testAreaID {
+		t.Fatalf("ar = %v, want [%s]", got, testAreaID)
+	}
+	if got := payload["pr"].([]string); len(got) != 0 {
+		t.Fatalf("pr = %v, want []", got)
+	}
+	if got := payload["agr"].([]string); len(got) != 0 {
+		t.Fatalf("agr = %v, want []", got)
+	}
+	if len(payload) != 7 {
+		t.Fatalf("payload fields = %v, want only md, st, sr, tir, ar, pr, agr", payload)
+	}
 }
 
 func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
@@ -748,6 +832,26 @@ func TestBuildBatchEditRejectsInvalidRef(t *testing.T) {
 	_, _, err = buildBatchEdit(BatchOp{UUID: "bad uuid", Title: "y"})
 	if err == nil {
 		t.Error("buildBatchEdit with invalid target UUID: got nil error, want validation error")
+	}
+}
+
+func TestBuildBatchEditAllowsProjectWithHeading(t *testing.T) {
+	env, _, err := buildBatchEdit(BatchOp{
+		UUID: testTaskID, Project: testProjectID, Heading: testHeadingID,
+	})
+	if err != nil {
+		t.Fatalf("project with heading: %v", err)
+	}
+
+	payload := requirePayloadMap(t, env)
+	if got := payload["pr"].([]string); len(got) != 1 || got[0] != testProjectID {
+		t.Fatalf("pr = %v, want [%s]", got, testProjectID)
+	}
+	if got := payload["agr"].([]string); len(got) != 1 || got[0] != testHeadingID {
+		t.Fatalf("agr = %v, want [%s]", got, testHeadingID)
+	}
+	if got := payload["ar"].([]string); len(got) != 0 {
+		t.Fatalf("ar = %v, want []", got)
 	}
 }
 

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -53,6 +55,173 @@ func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
 	}
 }
 
+func TestTaskScheduleForDate(t *testing.T) {
+	today := time.Date(2026, time.September, 5, 0, 0, 0, 0, time.UTC).Unix()
+	tests := []struct {
+		name string
+		date int64
+		want int
+	}{
+		{name: "past", date: today - 86400, want: 1},
+		{name: "today", date: today, want: 1},
+		{name: "future", date: today + 86400, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := taskScheduleForDate(tt.date, today); got != tt.want {
+				t.Fatalf("taskScheduleForDate() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewTaskCreatePayloadScheduledDateClassification(t *testing.T) {
+	today := time.Now()
+	tests := []struct {
+		name string
+		date time.Time
+		want int
+	}{
+		{name: "past", date: today.AddDate(0, 0, -1), want: 1},
+		{name: "today", date: today, want: 1},
+		{name: "future", date: today.AddDate(0, 0, 1), want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date := tt.date.Format("2006-01-02")
+			wantDate := parseDate(date).Unix()
+			payload := newTaskCreatePayload("scheduled", map[string]string{"scheduled": date})
+			if payload.St != tt.want {
+				t.Fatalf("st = %d, want %d", payload.St, tt.want)
+			}
+			if payload.Sr == nil || *payload.Sr != wantDate || payload.Tir == nil || *payload.Tir != wantDate {
+				t.Fatalf("sr/tir = %v/%v, want UTC midnight %d", payload.Sr, payload.Tir, wantDate)
+			}
+		})
+	}
+}
+
+func TestNewTaskCreatePayloadExplicitWhenOverridesScheduledClassification(t *testing.T) {
+	today := time.Now()
+	tests := []struct {
+		name string
+		when string
+		date time.Time
+		want int
+	}{
+		{name: "future anytime", when: "anytime", date: today.AddDate(0, 0, 1), want: 1},
+		{name: "today someday", when: "someday", date: today, want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date := tt.date.Format("2006-01-02")
+			wantDate := parseDate(date).Unix()
+			payload := newTaskCreatePayload("scheduled", map[string]string{
+				"scheduled": date,
+				"when":      tt.when,
+			})
+			if payload.St != tt.want {
+				t.Fatalf("st = %d, want explicit --when status %d", payload.St, tt.want)
+			}
+			if payload.Sr == nil || *payload.Sr != wantDate || payload.Tir == nil || *payload.Tir != wantDate {
+				t.Fatalf("sr/tir = %v/%v, want scheduled date %d", payload.Sr, payload.Tir, wantDate)
+			}
+		})
+	}
+}
+
+func TestNewTaskCreatePayloadRelationshipsPreserveScheduledStatus(t *testing.T) {
+	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	tests := []struct {
+		name string
+		opts map[string]string
+	}{
+		{name: "project", opts: map[string]string{"scheduled": future, "project": testProjectID}},
+		{name: "area", opts: map[string]string{"scheduled": future, "area": testAreaID}},
+		{name: "heading", opts: map[string]string{"scheduled": future, "heading": testHeadingID}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := newTaskCreatePayload("scheduled", tt.opts)
+			if payload.St != 2 {
+				t.Fatalf("st = %d, want 2", payload.St)
+			}
+			if payload.Sr == nil || payload.Tir == nil {
+				t.Fatalf("sr/tir = %v/%v, want scheduled date", payload.Sr, payload.Tir)
+			}
+		})
+	}
+}
+
+func TestTaskUpdateScheduleDateClassification(t *testing.T) {
+	today := todayMidnightUTC()
+	for _, tt := range []struct {
+		name string
+		date int64
+		want int
+	}{
+		{name: "past", date: today - 86400, want: 1},
+		{name: "today", date: today, want: 1},
+		{name: "future", date: today + 86400, want: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := newTaskUpdate().ScheduleDate(tt.date).build()
+			if payload["st"] != tt.want || payload["sr"] != tt.date || payload["tir"] != tt.date {
+				t.Fatalf("schedule = st:%v sr:%v tir:%v, want %d/%d/%d", payload["st"], payload["sr"], payload["tir"], tt.want, tt.date, tt.date)
+			}
+		})
+	}
+}
+
+func TestBatchCreateScheduledDateMatchesCreate(t *testing.T) {
+	today := time.Now()
+	tests := []struct {
+		name string
+		date time.Time
+		when string
+	}{
+		{name: "past", date: today.AddDate(0, 0, -1)},
+		{name: "today", date: today},
+		{name: "future", date: today.AddDate(0, 0, 1)},
+		{name: "explicit someday", date: today, when: "someday"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			date := tt.date.Format("2006-01-02")
+			opts := map[string]string{"scheduled": date, "project": testProjectID}
+			if tt.when != "" {
+				opts["when"] = tt.when
+			}
+			want := newTaskCreatePayload("scheduled", opts)
+
+			env, _, err := buildBatchCreate(BatchOp{
+				Title:   "scheduled",
+				When:    tt.when,
+				Project: testProjectID,
+				Extra:   map[string]string{"scheduled": date},
+			})
+			if err != nil {
+				t.Fatalf("buildBatchCreate failed: %v", err)
+			}
+			payload, ok := env.(writeEnvelope).payload.(TaskCreatePayload)
+			if !ok {
+				t.Fatalf("batch payload = %T, want TaskCreatePayload", env.(writeEnvelope).payload)
+			}
+			if payload.St != want.St || payload.Sr == nil || want.Sr == nil || *payload.Sr != *want.Sr || payload.Tir == nil || want.Tir == nil || *payload.Tir != *want.Tir {
+				t.Fatalf("batch schedule = st:%d sr:%v tir:%v, want create schedule st:%d sr:%v tir:%v", payload.St, payload.Sr, payload.Tir, want.St, want.Sr, want.Tir)
+			}
+			if len(payload.Pr) != 1 || payload.Pr[0] != testProjectID {
+				t.Fatalf("batch project = %v, want [%s]", payload.Pr, testProjectID)
+			}
+		})
+	}
+}
+
 func TestHasExplicitSchedule(t *testing.T) {
 	tests := []struct {
 		name string
@@ -80,6 +249,82 @@ func TestHasExplicitSchedule(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := hasExplicitSchedule(tt.opts); got != tt.want {
 				t.Fatalf("hasExplicitSchedule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduledOptionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		wantErr bool
+	}{
+		{name: "absent", opts: map[string]string{}},
+		{name: "valid", opts: map[string]string{"scheduled": "2026-09-06"}},
+		{name: "missing value", opts: map[string]string{"scheduled": "true"}, wantErr: true},
+		{name: "empty", opts: map[string]string{"scheduled": ""}, wantErr: true},
+		{name: "malformed", opts: map[string]string{"scheduled": "tomorrow"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTaskOpts(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateTaskOpts(%v) error = %v, wantErr %v", tt.opts, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDirectCommandsRejectInvalidScheduledBeforeWrite(t *testing.T) {
+	if command := os.Getenv("THINGS_CLI_INVALID_SCHEDULE_COMMAND"); command != "" {
+		h, commits := newWireRecorder(t)
+		switch command {
+		case "create":
+			cmdCreate(h, []string{"invalid", "--scheduled", "tomorrow", "--project", testProjectID})
+		case "edit":
+			cmdEdit(h, testTaskID, []string{"--scheduled", "--area", testAreaID})
+		default:
+			t.Fatalf("unknown helper command %q", command)
+		}
+		if len(*commits) != 0 {
+			t.Fatalf("invalid schedule wrote %d commits, want zero", len(*commits))
+		}
+		return
+	}
+
+	for _, command := range []string{"create", "edit"} {
+		t.Run(command, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestDirectCommandsRejectInvalidScheduledBeforeWrite$")
+			cmd.Env = append(os.Environ(), "THINGS_CLI_INVALID_SCHEDULE_COMMAND="+command)
+			output, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("%s with invalid --scheduled succeeded; output: %s", command, output)
+			}
+			if !strings.Contains(string(output), "--scheduled") {
+				t.Fatalf("%s error = %s, want scheduled-date validation error", command, output)
+			}
+		})
+	}
+}
+
+func TestBuildBatchCreateRejectsInvalidScheduled(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		scheduled string
+	}{
+		{name: "missing value", scheduled: ""},
+		{name: "malformed", scheduled: "tomorrow"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := buildBatchCreate(BatchOp{
+				Title:   "invalid",
+				Project: testProjectID,
+				Extra:   map[string]string{"scheduled": tt.scheduled},
+			})
+			if err == nil || !strings.Contains(err.Error(), "--scheduled") {
+				t.Fatalf("buildBatchCreate error = %v, want scheduled-date validation error", err)
 			}
 		})
 	}

--- a/cmd/things-cli/validation_test.go
+++ b/cmd/things-cli/validation_test.go
@@ -35,12 +35,13 @@ func TestCLIValidationHelper(t *testing.T) {
 }
 
 type cliValidationCloud struct {
-	server *httptest.Server
-	mu     sync.Mutex
-	bodies [][]byte
+	server       *httptest.Server
+	mu           sync.Mutex
+	bodies       [][]byte
+	historyReads int
 }
 
-func newCLIValidationCloud(t *testing.T) *cliValidationCloud {
+func newCLIValidationCloud(t *testing.T, ordinaryTaskIDs ...string) *cliValidationCloud {
 	t.Helper()
 	c := &cliValidationCloud{}
 	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +57,36 @@ func newCLIValidationCloud(t *testing.T) *cliValidationCloud {
 			c.mu.Unlock()
 			_, _ = io.WriteString(w, `{"server-head-index":2}`)
 		case strings.HasSuffix(r.URL.Path, "/items"):
-			_, _ = io.WriteString(w, `{"items":[],"current-item-index":1,"schema":301}`)
+			c.mu.Lock()
+			c.historyReads++
+			c.mu.Unlock()
+			items := []map[string]any{}
+			if len(ordinaryTaskIDs) > 0 {
+				created := make(map[string]any, len(ordinaryTaskIDs))
+				for _, id := range ordinaryTaskIDs {
+					created[id] = map[string]any{
+						"e": "Task7",
+						"t": 0,
+						"p": map[string]any{
+							"tt": "seeded ordinary task",
+							"tp": 0,
+							"st": 1,
+							"ss": 0,
+							"rr": nil,
+							"rp": nil,
+							"rt": []string{},
+						},
+					}
+				}
+				items = append(items, created)
+			}
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items":              items,
+				"current-item-index": 1,
+				"schema":             301,
+			}); err != nil {
+				t.Errorf("encode history fixture: %v", err)
+			}
 		case strings.Contains(r.URL.Path, "/account/"):
 			_, _ = io.WriteString(w, `{"email":"validation@example.com","status":"SYAccountStatusActive","history-key":"validation-history"}`)
 		default:
@@ -71,6 +101,12 @@ func (c *cliValidationCloud) commits() [][]byte {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([][]byte(nil), c.bodies...)
+}
+
+func (c *cliValidationCloud) historyReadCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.historyReads
 }
 
 func runValidationCLI(t *testing.T, cloud *cliValidationCloud, stdin string, args ...string) (int, string) {
@@ -128,6 +164,8 @@ func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
 		{"create padded tag", []string{"create", "Task", "--tags", " " + id + " "}, "", "tags"},
 		{"edit padded tag", []string{"edit", id, "--tags", " " + otherID + " "}, "", "tags"},
 		{"edit empty tags value", []string{"edit", id, "--tags", ""}, "", "tags"},
+		{"edit area with project", []string{"edit", id, "--area", id, "--project", otherID}, "", "area"},
+		{"edit area with heading", []string{"edit", id, "--area", id, "--heading", otherID}, "", "area"},
 		{"create invalid when", []string{"create", "Task", "--when", "tomorrow"}, "", "when"},
 		{"create empty when", []string{"create", "Task", "--when", ""}, "", "when"},
 		{"create missing when value", []string{"create", "Task", "--when"}, "", "when"},
@@ -158,6 +196,8 @@ func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
 		{"batch edit invalid when", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"when":"tomorrow"}]`, id), "when"},
 		{"batch edit invalid deadline", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"deadline":"bad-date"}]`, id), "deadline"},
 		{"batch edit padded tag", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"tags":[%q]}]`, id, " "+otherID+" "), "tags"},
+		{"batch edit area with project", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"area":%q,"project":%q}]`, id, id, otherID), "area"},
+		{"batch edit area with heading", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"area":%q,"heading":%q}]`, id, id, otherID), "area"},
 		{"batch extra project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":"bad-project"}}]`, id), "project"},
 		{"batch extra empty project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":""}}]`, id), "project"},
 		{"batch extra tags overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q],"extra":{"tags":"bad-tag"}}]`, id), "tags"},
@@ -187,6 +227,9 @@ func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
 			}
 			if got := len(cloud.commits()); got != 0 {
 				t.Errorf("commit requests = %d, want 0", got)
+			}
+			if got := cloud.historyReadCount(); got != 1 {
+				t.Errorf("history reads = %d, want only the initial head sync and no write preflight", got)
 			}
 		})
 	}
@@ -236,7 +279,7 @@ func TestCLIWriteValidationAcceptsBatchDatesAndScheduledExtra(t *testing.T) {
 		{"cmd":"create","title":"dated","uuid":%q,"when":"someday","deadline":"2026-10-14","project":%q,"tags":[%q],"extra":{"when":"anytime","deadline":"2026-10-15","scheduled":"2026-10-12"}},
 		{"cmd":"edit","uuid":%q,"when":"someday","deadline":"2026-10-20"}
 	]`, createID, projectID, tagID, editID)
-	cloud := newCLIValidationCloud(t)
+	cloud := newCLIValidationCloud(t, editID)
 	exitCode, output := runValidationCLI(t, cloud, input, "batch")
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d: %s", exitCode, output)
@@ -259,21 +302,23 @@ func TestCLIWriteValidationAcceptsBatchDatesAndScheduledExtra(t *testing.T) {
 func TestCLIWriteValidationAcceptsUnsetBatchOptionals(t *testing.T) {
 	id := thingscloud.NewUUID()
 	tests := []struct {
-		name  string
-		input string
+		name            string
+		input           string
+		ordinaryTaskIDs []string
 	}{
 		{
-			"empty top-level strings without extra",
-			`[{"cmd":"create","title":"empty optionals","uuid":"","note":"","when":"","deadline":"","project":"","area":"","heading":"","tags":[],"type":""}]`,
+			name:  "empty top-level strings without extra",
+			input: `[{"cmd":"create","title":"empty optionals","uuid":"","note":"","when":"","deadline":"","project":"","area":"","heading":"","tags":[],"type":""}]`,
 		},
 		{
-			"null extra",
-			fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"title":"updated","extra":null}]`, id),
+			name:            "null extra",
+			input:           fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"title":"updated","extra":null}]`, id),
+			ordinaryTaskIDs: []string{id},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cloud := newCLIValidationCloud(t)
+			cloud := newCLIValidationCloud(t, tc.ordinaryTaskIDs...)
 			exitCode, output := runValidationCLI(t, cloud, tc.input, "batch")
 			if exitCode != 0 {
 				t.Fatalf("exit code = %d: %s", exitCode, output)

--- a/cmd/things-cli/validation_test.go
+++ b/cmd/things-cli/validation_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	thingscloud "github.com/arthursoares/things-cloud-sdk"
+)
+
+const cliValidationHelper = "THINGS_CLI_VALIDATION_HELPER"
+
+// TestCLIValidationHelper runs the real main function in a subprocess so its
+// os.Exit paths can be asserted without changing production error handling.
+func TestCLIValidationHelper(t *testing.T) {
+	if os.Getenv(cliValidationHelper) == "" {
+		return
+	}
+	var args []string
+	if err := json.Unmarshal([]byte(os.Getenv("THINGS_CLI_VALIDATION_ARGS")), &args); err != nil {
+		t.Fatal(err)
+	}
+	os.Args = append([]string{"things-cli"}, args...)
+	main()
+}
+
+type cliValidationCloud struct {
+	server *httptest.Server
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func newCLIValidationCloud(t *testing.T) *cliValidationCloud {
+	t.Helper()
+	c := &cliValidationCloud{}
+	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/commit"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read commit: %v", err)
+			}
+			c.mu.Lock()
+			c.bodies = append(c.bodies, body)
+			c.mu.Unlock()
+			_, _ = io.WriteString(w, `{"server-head-index":2}`)
+		case strings.HasSuffix(r.URL.Path, "/items"):
+			_, _ = io.WriteString(w, `{"items":[],"current-item-index":1,"schema":301}`)
+		case strings.Contains(r.URL.Path, "/account/"):
+			_, _ = io.WriteString(w, `{"email":"validation@example.com","status":"SYAccountStatusActive","history-key":"validation-history"}`)
+		default:
+			_, _ = io.WriteString(w, `{}`)
+		}
+	}))
+	t.Cleanup(c.server.Close)
+	return c
+}
+
+func (c *cliValidationCloud) commits() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]byte(nil), c.bodies...)
+}
+
+func runValidationCLI(t *testing.T, cloud *cliValidationCloud, stdin string, args ...string) (int, string) {
+	t.Helper()
+	encodedArgs, err := json.Marshal(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestCLIValidationHelper$")
+	cmd.Env = append(os.Environ(),
+		cliValidationHelper+"=1",
+		"THINGS_CLI_VALIDATION_ARGS="+string(encodedArgs),
+		"THINGS_ENDPOINT="+cloud.server.URL,
+		"THINGS_USERNAME=validation@example.com",
+		"THINGS_PASSWORD=test-password",
+	)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("CLI subprocess timed out: %v\n%s", ctx.Err(), out)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), string(out)
+	}
+	t.Fatalf("run CLI: %v", err)
+	return -1, ""
+}
+
+func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
+	id := thingscloud.NewUUID()
+	otherID := thingscloud.NewUUID()
+	validCreate := fmt.Sprintf(`{"cmd":"create","title":"valid","uuid":%q}`, otherID)
+
+	tests := []struct {
+		name  string
+		args  []string
+		stdin string
+		field string
+	}{
+		{"area malformed tag", []string{"create-area", "Area", "--tags", "bad-tag"}, "", "tags"},
+		{"area padded tag", []string{"create-area", "Area", "--tags", " " + id + " "}, "", "tags"},
+		{"area empty tag component", []string{"create-area", "Area", "--tags", id + ",," + otherID}, "", "tags"},
+		{"area empty tags value", []string{"create-area", "Area", "--tags", ""}, "", "tags"},
+		{"tag malformed parent", []string{"create-tag", "Tag", "--parent", "bad-parent"}, "", "parent"},
+		{"tag padded parent", []string{"create-tag", "Tag", "--parent", " " + id + " "}, "", "parent"},
+		{"tag empty parent value", []string{"create-tag", "Tag", "--parent", ""}, "", "parent"},
+		{"create empty project value", []string{"create", "Task", "--project", ""}, "", "project"},
+		{"create empty uuid value", []string{"create", "Task", "--uuid", ""}, "", "uuid"},
+		{"create padded tag", []string{"create", "Task", "--tags", " " + id + " "}, "", "tags"},
+		{"edit padded tag", []string{"edit", id, "--tags", " " + otherID + " "}, "", "tags"},
+		{"edit empty tags value", []string{"edit", id, "--tags", ""}, "", "tags"},
+		{"create invalid when", []string{"create", "Task", "--when", "tomorrow"}, "", "when"},
+		{"create empty when", []string{"create", "Task", "--when", ""}, "", "when"},
+		{"create missing when value", []string{"create", "Task", "--when"}, "", "when"},
+		{"edit invalid when", []string{"edit", id, "--when", "tomorrow"}, "", "when"},
+		{"edit empty when", []string{"edit", id, "--when", ""}, "", "when"},
+		{"edit missing when value", []string{"edit", id, "--when"}, "", "when"},
+		{"create impossible deadline", []string{"create", "Task", "--deadline", "2026-02-30"}, "", "deadline"},
+		{"create malformed deadline", []string{"create", "Task", "--deadline", "02/28/2026"}, "", "deadline"},
+		{"create empty deadline", []string{"create", "Task", "--deadline", ""}, "", "deadline"},
+		{"create missing deadline value", []string{"create", "Task", "--deadline"}, "", "deadline"},
+		{"edit impossible deadline", []string{"edit", id, "--deadline", "2026-02-30"}, "", "deadline"},
+		{"edit malformed deadline", []string{"edit", id, "--deadline", "02/28/2026"}, "", "deadline"},
+		{"edit empty deadline", []string{"edit", id, "--deadline", ""}, "", "deadline"},
+		{"edit missing deadline value", []string{"edit", id, "--deadline"}, "", "deadline"},
+		{"create impossible scheduled", []string{"create", "Task", "--scheduled", "2026-02-30"}, "", "scheduled"},
+		{"create malformed scheduled", []string{"create", "Task", "--scheduled", "next-week"}, "", "scheduled"},
+		{"create empty scheduled", []string{"create", "Task", "--scheduled", ""}, "", "scheduled"},
+		{"create missing scheduled value", []string{"create", "Task", "--scheduled"}, "", "scheduled"},
+		{"edit impossible scheduled", []string{"edit", id, "--scheduled", "2026-02-30"}, "", "scheduled"},
+		{"edit malformed scheduled", []string{"edit", id, "--scheduled", "next-week"}, "", "scheduled"},
+		{"edit empty scheduled", []string{"edit", id, "--scheduled", ""}, "", "scheduled"},
+		{"edit missing scheduled value", []string{"edit", id, "--scheduled"}, "", "scheduled"},
+		{"create invalid type", []string{"create", "Task", "--type", "area"}, "", "type"},
+		{"purge invalid target", []string{"purge", "bad-target"}, "", "uuid"},
+		{"batch create invalid when", []string{"batch"}, `[{"cmd":"create","title":"x","when":"tomorrow"}]`, "when"},
+		{"batch create invalid deadline", []string{"batch"}, `[{"cmd":"create","title":"x","deadline":"2026-02-30"}]`, "deadline"},
+		{"batch create padded tag", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q]}]`, " "+id+" "), "tags"},
+		{"batch edit invalid when", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"when":"tomorrow"}]`, id), "when"},
+		{"batch edit invalid deadline", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"deadline":"bad-date"}]`, id), "deadline"},
+		{"batch edit padded tag", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"tags":[%q]}]`, id, " "+otherID+" "), "tags"},
+		{"batch extra project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":"bad-project"}}]`, id), "project"},
+		{"batch extra empty project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":""}}]`, id), "project"},
+		{"batch extra tags overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q],"extra":{"tags":"bad-tag"}}]`, id), "tags"},
+		{"batch extra empty tags overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q],"extra":{"tags":""}}]`, id), "tags"},
+		{"batch extra invalid when", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"when":"tomorrow"}}]`, "when"},
+		{"batch extra invalid deadline", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"deadline":"bad-date"}}]`, "deadline"},
+		{"batch extra invalid scheduled", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"scheduled":"bad-date"}}]`, "scheduled"},
+		{"batch extra invalid type", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"type":"area"}}]`, "type"},
+		{"batch create rejects unknown extra", []string{"batch"}, `[{"cmd":"create","title":"x","extra":{"checklist":"ignored"}}]`, "checklist"},
+		{"batch purge invalid target", []string{"batch"}, `[{"cmd":"purge","uuid":"bad-target"}]`, "uuid"},
+		{"batch unknown scheduled field", []string{"batch"}, `[{"cmd":"create","title":"x","scheduled":"2026-10-12"}]`, "scheduled"},
+		{"batch edit rejects extra", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"extra":{"scheduled":"2026-10-12"}}]`, id), "extra"},
+		{"batch edit rejects empty extra object", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"extra":{}}]`, id), "extra"},
+		{"batch rejects trailing JSON", []string{"batch"}, fmt.Sprintf(`[%s] {"extra":"value"}`, validCreate), "json"},
+		{"batch validates all operations atomically", []string{"batch"}, fmt.Sprintf(`[%s,{"cmd":"edit","uuid":%q,"deadline":"bad-date"}]`, validCreate, id), "deadline"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newCLIValidationCloud(t)
+			exitCode, output := runValidationCLI(t, cloud, tc.stdin, tc.args...)
+			if exitCode == 0 {
+				t.Errorf("exit code = 0, want nonzero; output:\n%s", output)
+			}
+			if !strings.Contains(strings.ToLower(output), tc.field) {
+				t.Errorf("output does not identify %q: %s", tc.field, output)
+			}
+			if got := len(cloud.commits()); got != 0 {
+				t.Errorf("commit requests = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestCLIWriteValidationAcceptsCanonicalReferencesExactly(t *testing.T) {
+	t.Run("area tags", func(t *testing.T) {
+		areaID, tag1, tag2 := thingscloud.NewUUID(), thingscloud.NewUUID(), thingscloud.NewUUID()
+		cloud := newCLIValidationCloud(t)
+		exitCode, output := runValidationCLI(t, cloud, "", "create-area", "Area", "--uuid", areaID, "--tags", tag1+","+tag2)
+		if exitCode != 0 {
+			t.Fatalf("exit code = %d: %s", exitCode, output)
+		}
+		payload := validationCommitPayload(t, cloud, areaID)
+		want := []string{tag1, tag2}
+		var got []string
+		if err := json.Unmarshal(payload["tg"], &got); err != nil {
+			t.Fatal(err)
+		}
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("tg = %q, want exact refs %q", got, want)
+		}
+	})
+
+	t.Run("tag parent", func(t *testing.T) {
+		tagID, parentID := thingscloud.NewUUID(), thingscloud.NewUUID()
+		cloud := newCLIValidationCloud(t)
+		exitCode, output := runValidationCLI(t, cloud, "", "create-tag", "Tag", "--uuid", tagID, "--parent", parentID)
+		if exitCode != 0 {
+			t.Fatalf("exit code = %d: %s", exitCode, output)
+		}
+		payload := validationCommitPayload(t, cloud, tagID)
+		var got []string
+		if err := json.Unmarshal(payload["pn"], &got); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0] != parentID {
+			t.Errorf("pn = %q, want exact ref [%q]", got, parentID)
+		}
+	})
+}
+
+func TestCLIWriteValidationAcceptsBatchDatesAndScheduledExtra(t *testing.T) {
+	createID, editID := thingscloud.NewUUID(), thingscloud.NewUUID()
+	projectID, tagID := thingscloud.NewUUID(), thingscloud.NewUUID()
+	input := fmt.Sprintf(`[
+		{"cmd":"create","title":"dated","uuid":%q,"when":"someday","deadline":"2026-10-14","project":%q,"tags":[%q],"extra":{"when":"anytime","deadline":"2026-10-15","scheduled":"2026-10-12"}},
+		{"cmd":"edit","uuid":%q,"when":"someday","deadline":"2026-10-20"}
+	]`, createID, projectID, tagID, editID)
+	cloud := newCLIValidationCloud(t)
+	exitCode, output := runValidationCLI(t, cloud, input, "batch")
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d: %s", exitCode, output)
+	}
+
+	create := validationCommitPayload(t, cloud, createID)
+	edit := validationCommitPayload(t, cloud, editID)
+	requireWireUnixDate(t, create, "dd", "2026-10-15")
+	requireWireUnixDate(t, create, "sr", "2026-10-12")
+	requireWireUnixDate(t, create, "tir", "2026-10-12")
+	requireWireUnixDate(t, edit, "dd", "2026-10-20")
+	if string(create["st"]) != "1" || string(edit["st"]) != "2" {
+		t.Errorf("schedules create/edit = %s/%s, want 1/2", create["st"], edit["st"])
+	}
+	if string(create["pr"]) != fmt.Sprintf(`[%q]`, projectID) || string(create["tg"]) != fmt.Sprintf(`[%q]`, tagID) {
+		t.Errorf("create refs changed: pr=%s tg=%s", create["pr"], create["tg"])
+	}
+}
+
+func TestCLIWriteValidationAcceptsUnsetBatchOptionals(t *testing.T) {
+	id := thingscloud.NewUUID()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			"empty top-level strings without extra",
+			`[{"cmd":"create","title":"empty optionals","uuid":"","note":"","when":"","deadline":"","project":"","area":"","heading":"","tags":[],"type":""}]`,
+		},
+		{
+			"null extra",
+			fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"title":"updated","extra":null}]`, id),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloud := newCLIValidationCloud(t)
+			exitCode, output := runValidationCLI(t, cloud, tc.input, "batch")
+			if exitCode != 0 {
+				t.Fatalf("exit code = %d: %s", exitCode, output)
+			}
+			if got := len(cloud.commits()); got != 1 {
+				t.Errorf("commit requests = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func validationCommitPayload(t *testing.T, cloud *cliValidationCloud, id string) map[string]json.RawMessage {
+	t.Helper()
+	bodies := cloud.commits()
+	if len(bodies) != 1 {
+		t.Fatalf("commit requests = %d, want 1", len(bodies))
+	}
+	var envelope map[string]struct {
+		Payload map[string]json.RawMessage `json:"p"`
+	}
+	if err := json.Unmarshal(bodies[0], &envelope); err != nil {
+		t.Fatalf("decode commit: %v", err)
+	}
+	item, ok := envelope[id]
+	if !ok {
+		t.Fatalf("commit has no item %q: %s", id, bodies[0])
+	}
+	return item.Payload
+}
+
+func requireWireUnixDate(t *testing.T, payload map[string]json.RawMessage, field, date string) {
+	t.Helper()
+	want, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int64
+	if err := json.Unmarshal(payload[field], &got); err != nil {
+		t.Fatalf("decode %s: %v", field, err)
+	}
+	if got != want.Unix() {
+		t.Errorf("%s = %d, want %d for %s", field, got, want.Unix(), date)
+	}
+}

--- a/cmd/things-cli/wire_test.go
+++ b/cmd/things-cli/wire_test.go
@@ -49,6 +49,10 @@ func TestTaskUpdateBuilderFields(t *testing.T) {
 			map[string]any{"dd": int64(1770000000)}},
 		{"Scheduled", func() map[string]any { return newTaskUpdate().Scheduled(100, 200).build() },
 			map[string]any{"sr": int64(100), "tir": int64(200)}},
+		{"Area", func() map[string]any { return newTaskUpdate().Area("area").build() },
+			map[string]any{"ar": []string{"area"}, "pr": []string{}, "agr": []string{}}},
+		{"Project", func() map[string]any { return newTaskUpdate().Project("project").build() },
+			map[string]any{"pr": []string{"project"}, "ar": []string{}, "agr": []string{}}},
 		{"Tags", func() map[string]any { return newTaskUpdate().Tags([]string{"a1", "b2"}).build() },
 			map[string]any{"tg": []string{"a1", "b2"}}},
 	}
@@ -233,14 +237,16 @@ type capturedCommit struct {
 	}
 }
 
-// newWireRecorder returns a History wired to a fake server plus a slice
-// collecting every commit POSTed through it.
-func newWireRecorder(t *testing.T) (*thingscloud.History, *[]capturedCommit) {
+// newWireRecorder returns a History wired to a fake server plus slices
+// collecting history preflight GETs and every commit POSTed through it.
+func newWireRecorder(t *testing.T, ordinaryTaskIDs ...string) (*thingscloud.History, *[]capturedCommit, *[]string) {
 	t.Helper()
 	var commits []capturedCommit
+	var historyRequests []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.Method == "POST" && strings.Contains(r.URL.Path, "/commit") {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/commit"):
 			var cc capturedCommit
 			cc.ancestorIndex = r.URL.Query().Get("ancestor-index")
 			if err := json.NewDecoder(r.Body).Decode(&cc.body); err != nil {
@@ -248,15 +254,59 @@ func newWireRecorder(t *testing.T) (*thingscloud.History, *[]capturedCommit) {
 			}
 			commits = append(commits, cc)
 			fmt.Fprint(w, `{"server-head-index":42}`)
-			return
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/items"):
+			historyRequests = append(historyRequests, r.URL.RequestURI())
+			if got := r.URL.Query().Get("start-index"); got != "0" {
+				t.Errorf("preflight start-index = %q, want 0", got)
+			}
+			created := make(map[string]any, len(ordinaryTaskIDs))
+			for _, id := range ordinaryTaskIDs {
+				created[id] = map[string]any{
+					"e": "Task7",
+					"t": 0,
+					"p": map[string]any{
+						"tt": "seeded ordinary task",
+						"tp": 0,
+						"st": 1,
+						"ss": 0,
+						"rr": nil,
+						"rp": nil,
+						"rt": []string{},
+					},
+				}
+			}
+			items := make([]map[string]any, 7)
+			items[0] = created
+			for i := 1; i < len(items); i++ {
+				items[i] = map[string]any{}
+			}
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items":              items,
+				"current-item-index": 7,
+				"schema":             301,
+			}); err != nil {
+				t.Errorf("encode history fixture: %v", err)
+			}
+		default:
+			fmt.Fprint(w, `{}`)
 		}
-		fmt.Fprint(w, `{}`)
 	}))
 	t.Cleanup(server.Close)
 
 	c := thingscloud.New(server.URL, "test@example.com", "pw")
 	h := &thingscloud.History{Client: c, ID: "wire-test-history", LatestServerIndex: 7}
-	return h, &commits
+	return h, &commits, &historyRequests
+}
+
+func assertTaskPreflight(t *testing.T, historyRequests []string, commit capturedCommit) {
+	t.Helper()
+	want := "/version/1/history/wire-test-history/items?start-index=0"
+	if len(historyRequests) != 1 || historyRequests[0] != want {
+		t.Fatalf("history preflight requests = %q, want [%q]", historyRequests, want)
+	}
+	if commit.ancestorIndex != "7" {
+		t.Errorf("ancestor-index = %q, want preflight head 7", commit.ancestorIndex)
+	}
 }
 
 func singleItem(t *testing.T, cc capturedCommit) (uuid string, action int, kind string, payload map[string]any) {
@@ -275,7 +325,7 @@ func singleItem(t *testing.T, cc capturedCommit) (uuid string, action int, kind 
 }
 
 func TestCmdCreateWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, historyRequests := newWireRecorder(t)
 	id := thingscloud.NewUUID()
 
 	cmdCreate(h, []string{"Wire task", "--uuid", id, "--when", "today", "--note", "body"})
@@ -283,13 +333,16 @@ func TestCmdCreateWire(t *testing.T) {
 	if len(*commits) != 1 {
 		t.Fatalf("%d commits, want 1", len(*commits))
 	}
+	if len(*historyRequests) != 0 {
+		t.Fatalf("Task7 create made history preflight requests: %q", *historyRequests)
+	}
 	cc := (*commits)[0]
 	if cc.ancestorIndex != "7" {
 		t.Errorf("ancestor-index = %q, want 7 (the synced head)", cc.ancestorIndex)
 	}
 	gotID, action, kind, p := singleItem(t, cc)
-	if gotID != id || action != 0 || kind != "Task6" {
-		t.Errorf("envelope = (%s, %d, %s), want (%s, 0, Task6)", gotID, action, kind, id)
+	if gotID != id || action != 0 || kind != "Task7" {
+		t.Errorf("envelope = (%s, %d, %s), want (%s, 0, Task7)", gotID, action, kind, id)
 	}
 	if p["md"] != nil {
 		t.Errorf("create sent md = %v, must be null on creates", p["md"])
@@ -304,14 +357,15 @@ func TestCmdCreateWire(t *testing.T) {
 }
 
 func TestCmdCompleteWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 
 	cmdComplete(h, id)
 
 	_, action, kind, p := singleItem(t, (*commits)[0])
-	if action != 1 || kind != "Task6" {
-		t.Errorf("envelope action/kind = %d/%s, want 1/Task6", action, kind)
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if action != 1 || kind != "Task7" {
+		t.Errorf("envelope action/kind = %d/%s, want 1/Task7", action, kind)
 	}
 	if p["ss"] != float64(3) {
 		t.Errorf("ss = %v, want 3 (completed)", p["ss"])
@@ -325,19 +379,20 @@ func TestCmdCompleteWire(t *testing.T) {
 }
 
 func TestCmdTrashWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 
 	cmdTrash(h, id)
 
 	_, action, kind, p := singleItem(t, (*commits)[0])
-	if action != 1 || kind != "Task6" || p["tr"] != true {
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if action != 1 || kind != "Task7" || p["tr"] != true {
 		t.Errorf("trash wire = action %d kind %s tr %v", action, kind, p["tr"])
 	}
 }
 
 func TestCmdPurgeWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	target := thingscloud.NewUUID()
 
 	cmdPurge(h, target)
@@ -358,11 +413,13 @@ func TestCmdPurgeWire(t *testing.T) {
 }
 
 func TestCmdMoveToTodayWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 
-	cmdMoveToToday(h, thingscloud.NewUUID())
+	cmdMoveToToday(h, id)
 
 	_, _, _, p := singleItem(t, (*commits)[0])
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
 	if p["st"] != float64(1) {
 		t.Errorf("st = %v, want 1", p["st"])
 	}
@@ -372,7 +429,7 @@ func TestCmdMoveToTodayWire(t *testing.T) {
 }
 
 func TestCmdCreateAreaWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	id := thingscloud.NewUUID()
 
 	cmdCreateArea(h, []string{"Wire Area", "--uuid", id})
@@ -388,7 +445,7 @@ func TestCmdCreateAreaWire(t *testing.T) {
 }
 
 func TestCmdCreateTagWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	id := thingscloud.NewUUID()
 
 	cmdCreateTag(h, []string{"Wire Tag", "--uuid", id})
@@ -403,7 +460,7 @@ func TestCmdCreateTagWire(t *testing.T) {
 }
 
 func TestCmdAddChecklistWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	task := thingscloud.NewUUID()
 
 	cmdAddChecklist(h, task, []string{"one,two"})
@@ -433,14 +490,15 @@ func TestCmdAddChecklistWire(t *testing.T) {
 }
 
 func TestCmdEditWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 	proj := thingscloud.NewUUID()
 
 	cmdEdit(h, id, []string{"--title", "renamed", "--project", proj})
 
 	gotID, action, kind, p := singleItem(t, (*commits)[0])
-	if gotID != id || action != 1 || kind != "Task6" {
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task7" {
 		t.Errorf("edit envelope = (%s, %d, %s)", gotID, action, kind)
 	}
 	if p["tt"] != "renamed" {
@@ -450,6 +508,12 @@ func TestCmdEditWire(t *testing.T) {
 	if len(pr) != 1 || pr[0] != proj {
 		t.Errorf("pr = %v, want [%s]", p["pr"], proj)
 	}
+	if ar, ok := p["ar"].([]any); !ok || len(ar) != 0 {
+		t.Errorf("ar = %v, want [] when moving to a project", p["ar"])
+	}
+	if agr, ok := p["agr"].([]any); !ok || len(agr) != 0 {
+		t.Errorf("agr = %v, want [] when moving to a project", p["agr"])
+	}
 	// Assigning a project without an explicit schedule must move the task
 	// out of inbox with null dates (Bug 8 + PR #9 semantics).
 	if p["st"] != float64(1) || p["sr"] != nil || p["tir"] != nil {
@@ -458,8 +522,8 @@ func TestCmdEditWire(t *testing.T) {
 }
 
 func TestCmdEditFutureScheduledWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 	proj := thingscloud.NewUUID()
 	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 	wantDate := float64(parseDate(future).Unix())
@@ -467,8 +531,9 @@ func TestCmdEditFutureScheduledWire(t *testing.T) {
 	cmdEdit(h, id, []string{"--scheduled", future, "--project", proj})
 
 	gotID, action, kind, p := singleItem(t, (*commits)[0])
-	if gotID != id || action != 1 || kind != "Task6" {
-		t.Fatalf("edit envelope = (%s, %d, %s), want (%s, 1, Task6)", gotID, action, kind, id)
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task7" {
+		t.Fatalf("edit envelope = (%s, %d, %s), want (%s, 1, Task7)", gotID, action, kind, id)
 	}
 	if p["st"] != float64(2) || p["sr"] != wantDate || p["tir"] != wantDate {
 		t.Fatalf("future schedule = st:%v sr:%v tir:%v, want 2/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
@@ -477,14 +542,14 @@ func TestCmdEditFutureScheduledWire(t *testing.T) {
 	if !ok || len(pr) != 1 || pr[0] != proj {
 		t.Fatalf("pr = %v, want [%s]", p["pr"], proj)
 	}
-	if len(p) != 5 {
-		t.Fatalf("edit payload fields = %v, want only md, st, sr, tir, pr", p)
+	if len(p) != 7 {
+		t.Fatalf("edit payload fields = %v, want only md, st, sr, tir, pr, ar, agr", p)
 	}
 }
 
 func TestCmdEditExplicitWhenOverridesScheduledClassification(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 	area := thingscloud.NewUUID()
 	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 	wantDate := float64(parseDate(future).Unix())
@@ -492,12 +557,19 @@ func TestCmdEditExplicitWhenOverridesScheduledClassification(t *testing.T) {
 	cmdEdit(h, id, []string{"--scheduled", future, "--when", "anytime", "--area", area})
 
 	_, _, _, p := singleItem(t, (*commits)[0])
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
 	if p["st"] != float64(1) || p["sr"] != wantDate || p["tir"] != wantDate {
 		t.Fatalf("explicit anytime schedule = st:%v sr:%v tir:%v, want 1/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
 	}
 	areas, ok := p["ar"].([]any)
 	if !ok || len(areas) != 1 || areas[0] != area {
 		t.Fatalf("ar = %v, want [%s]", p["ar"], area)
+	}
+	if pr, ok := p["pr"].([]any); !ok || len(pr) != 0 {
+		t.Errorf("pr = %v, want [] when moving to an area", p["pr"])
+	}
+	if agr, ok := p["agr"].([]any); !ok || len(agr) != 0 {
+		t.Errorf("agr = %v, want [] when moving to an area", p["agr"])
 	}
 }
 
@@ -573,8 +645,8 @@ func TestLoadStateBuildsAndCachesState(t *testing.T) {
 }
 
 func TestCmdBatchWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id1, id2 := thingscloud.NewUUID(), thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id2)
 
 	// cmdBatch reads ops from stdin.
 	ops := fmt.Sprintf(`[
@@ -592,16 +664,17 @@ func TestCmdBatchWire(t *testing.T) {
 	if len(*commits) != 1 {
 		t.Fatalf("%d commits, want 1 — batch must send all ops in a single HTTP request", len(*commits))
 	}
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
 	body := (*commits)[0].body
 	if len(body) != 2 {
 		t.Fatalf("commit has %d items, want 2", len(body))
 	}
 	create, complete := body[id1], body[id2]
-	if create.E != "Task6" || create.T != 0 {
-		t.Errorf("create envelope = %s/%d, want Task6/0", create.E, create.T)
+	if create.E != "Task7" || create.T != 0 {
+		t.Errorf("create envelope = %s/%d, want Task7/0", create.E, create.T)
 	}
-	if complete.T != 1 {
-		t.Errorf("complete envelope action = %d, want 1", complete.T)
+	if complete.E != "Task7" || complete.T != 1 {
+		t.Errorf("complete envelope = %s/%d, want Task7/1", complete.E, complete.T)
 	}
 	var p map[string]any
 	if err := json.Unmarshal(complete.P, &p); err != nil || p["ss"] != float64(3) {

--- a/cmd/things-cli/wire_test.go
+++ b/cmd/things-cli/wire_test.go
@@ -457,6 +457,50 @@ func TestCmdEditWire(t *testing.T) {
 	}
 }
 
+func TestCmdEditFutureScheduledWire(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	proj := thingscloud.NewUUID()
+	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	wantDate := float64(parseDate(future).Unix())
+
+	cmdEdit(h, id, []string{"--scheduled", future, "--project", proj})
+
+	gotID, action, kind, p := singleItem(t, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task6" {
+		t.Fatalf("edit envelope = (%s, %d, %s), want (%s, 1, Task6)", gotID, action, kind, id)
+	}
+	if p["st"] != float64(2) || p["sr"] != wantDate || p["tir"] != wantDate {
+		t.Fatalf("future schedule = st:%v sr:%v tir:%v, want 2/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
+	}
+	pr, ok := p["pr"].([]any)
+	if !ok || len(pr) != 1 || pr[0] != proj {
+		t.Fatalf("pr = %v, want [%s]", p["pr"], proj)
+	}
+	if len(p) != 5 {
+		t.Fatalf("edit payload fields = %v, want only md, st, sr, tir, pr", p)
+	}
+}
+
+func TestCmdEditExplicitWhenOverridesScheduledClassification(t *testing.T) {
+	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	area := thingscloud.NewUUID()
+	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+	wantDate := float64(parseDate(future).Unix())
+
+	cmdEdit(h, id, []string{"--scheduled", future, "--when", "anytime", "--area", area})
+
+	_, _, _, p := singleItem(t, (*commits)[0])
+	if p["st"] != float64(1) || p["sr"] != wantDate || p["tir"] != wantDate {
+		t.Fatalf("explicit anytime schedule = st:%v sr:%v tir:%v, want 1/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
+	}
+	areas, ok := p["ar"].([]any)
+	if !ok || len(areas) != 1 || areas[0] != area {
+		t.Fatalf("ar = %v, want [%s]", p["ar"], area)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // initCLI / loadState / cmdBatch — full command plumbing against a fake server
 // ---------------------------------------------------------------------------

--- a/docs/plans/2026-09-05-cli-write-validation.md
+++ b/docs/plans/2026-09-05-cli-write-validation.md
@@ -1,0 +1,20 @@
+# CLI write validation
+
+Based on the v0.5.0 `develop` branch. The request-handling cleanup remains a separate draft PR.
+
+## Plan before implementation
+
+1. Add subprocess tests against a fake Things Cloud endpoint. Invalid inputs must exit with an actionable error and send no commit. Include a batch with a valid operation followed by an invalid one to protect all-or-nothing submission.
+2. Reuse the existing identifier validator for area tags and parent tags, and validate purge target IDs before constructing tombstones. Check tag IDs exactly as written; do not validate trimmed text and then send the untrimmed value.
+3. Add one shared validator for the supported task schedule names, task types, and calendar dates. Apply it before task create/edit payload construction and in batch create/edit handling. Preserve existing schedule precedence and date encoding for valid inputs.
+4. Validate batch create options after merging `extra`, so overrides cannot bypass validation. Validate purge IDs as well. Reject ignored `extra` options on non-create operations and unsupported keys inside create `extra`. Reject unknown batch JSON fields and trailing input to catch unsupported or misspelled fields and incomplete submissions.
+5. Document the stricter validation and existing batch `extra.scheduled` support. Keep CLI parsing, payload builders, the SDK API, and date/time-zone semantics otherwise intact; no new dependencies.
+6. Run new regressions before production edits, then focused wire tests, build, race tests, lint, and independent review. Open a separate draft PR against `develop`.
+
+## Compatibility
+
+Previously accepted malformed dates, unrecognized schedule/type names, whitespace-padded tag IDs, and invalid relationship references now fail before a commit is sent. Absent options and empty optional top-level batch strings retain their existing defaults; explicitly empty identifiers in CLI options or `extra` fail validation. Batch create retains its existing `extra` override precedence, but final values must pass validation. Non-create operations reject even an empty `extra` object, while JSON null is treated as absent. Batch scheduling uses `extra.scheduled`; this patch does not add a top-level `scheduled` field or new edit scheduling features.
+
+## Verification
+
+Before production edits, subprocess regressions demonstrated rejected-input cases exiting successfully and sending commits; valid cases passed on the baseline. After implementation, the CLI subprocess/wire tests, `go build ./...`, `go test -race ./...`, `make lint` (zero issues), and `git diff --check` pass. The tests use a fake cloud endpoint; no live-account writes or soak test were run.

--- a/docs/plans/2026-09-05-code-cleanup.md
+++ b/docs/plans/2026-09-05-code-cleanup.md
@@ -1,0 +1,51 @@
+# Code cleanup after v0.5.0
+
+Baseline: `0c748970026507bbbf75936e38ffbc8ce5ed23dd`. `develop` has been rebased onto the released `main` commit.
+
+## First change: request construction and redundant code
+
+1. Add regression tests for invalid account/history identifiers in `Client.Verify`, `History.Items`, and `History.Write`. Require errors instead of panics, no HTTP requests, and unchanged history cursors.
+2. Lock the valid commit request headers and query parameters with a regression test before removing duplicate assignments.
+3. Move request-construction error checks before any request access. Keep existing payloads, response handling, status errors, and authentication behavior.
+4. Remove write headers already supplied by `Client.do`. Replace the test-only `asHTTPError` wrapper with direct `errors.As` calls.
+5. Delete the duplicate task-title assignment and commented-out import in memory replay, covered by the existing title-update and replay tests. Delete the unused `bufio` import and placeholder reference in the soak tool; these have no runtime behavior.
+6. Run focused tests, then build, race-enabled tests, lint, and diff checks. Get an independent review before opening a draft PR against `develop`.
+
+No dependencies or new production abstractions are needed. Changes to the persistent sync schema, CLI architecture, public error types, or debug logging policy belong in separate work.
+
+## Audit findings and follow-up
+
+The following findings are based on code inspection, not live-account testing. They remain outside this first patch. Address correctness before larger structural refactors.
+
+### Next priority: CLI write validation
+
+- `cmd/things-cli/main.go`, `cmdCreateArea` and `cmdCreateTag`: area tag references and parent-tag identifiers bypass `validateIdentifierOpts`. `History.Write` validates only envelope identifiers. Reuse and extend the existing validator, test invalid relationship IDs with a fake server, and assert no commit is sent. Also check that tag whitespace handling produces the same values that validation accepts.
+- `parseDate`, task create/edit, and batch handling silently omit invalid dates or ignore unknown schedule names. Reject invalid options before a write, with tests covering both individual and batch commands. This changes previously permissive CLI behavior and should be documented.
+
+### Sync correctness
+
+- `sync/detect.go`, `detectTaskChanges`: project/area assignment changes are never compared, even though `TaskAssignedToProject` and `TaskAssignedToArea` are public types consumed by `thingsync`. Define assignment, reassignment, and removal event payloads before implementation; test all three.
+- `sync/store.go`, `logChange`, and `sync/sync.go`, `ChangesSince`: storage and query cursors use integer Unix seconds with a strict greater-than comparison. A later event in the same second as a cursor is omitted. Choose a precise cursor/storage contract and a migration strategy; test a cursor between two same-second changes.
+- `sync/process.go`, `processTombstone`: all four entity lookups discard errors. A lookup failure can be treated as absence, letting a batch advance past an unapplied deletion. Propagate failures and verify transaction rollback and unchanged sync position under an injected lookup error.
+- `state/memory/memory.go`, `hasArea`: recursive parent traversal has no cycle detection. Add a visited set and tests for self-cycles, multi-node cycles, and a cycle with another parent reaching an area.
+
+### Decisions needed before broader refactoring
+
+- Memory replay deliberately skips malformed payloads despite returning `error`. Decide whether replay remains best-effort with diagnostics or becomes strict, including partial-state semantics. Do not simply change `continue` to `return` without defining what happens to already-applied items.
+- CLI date writes encode a local calendar date at UTC midnight, but `listTasks` compares against the current UTC day. Around local midnight this can disagree with `--when today`. Specify date-only wire semantics, then test positive and negative time zones with a fixed clock; do not apply a blanket UTC-to-local conversion.
+- SQLite legacy identifier remapping still needs a database migration/rebuild decision, as documented in v0.5.0.
+- Checklist modification dates are applied in memory by the sync processor but are absent from the persistence schema. Area tags and area/tag ordering are also only partially modeled. Group schema changes into a separately tested migration.
+- `thingsync` discards query errors in multiple output builders, which can report incomplete data as a successful result. Refactor those functions to return errors, with closed-database tests, as a separate CLI change.
+
+### Lower-priority simplification candidates
+
+- `cmd/soak`, `runCLI`: every caller ignores its JSON result, and JSON decoding errors are already discarded. Remove the unused return and decoding after locking subprocess success/failure reporting with an offline test.
+- Several debug commands have personal hardcoded task IDs. Confirm continued maintainer use before deleting these entry points; avoid turning them into a new CLI framework merely to retain them.
+- Consolidate or synchronize CLI command documentation, and define deterministic ordering for map-backed area/tag listings if callers need stable output.
+- SDK HTTP status errors mix strings and `HTTPError`; debug output also dumps full requests/responses. Handle error compatibility and logging/redaction policy in a separate patch.
+
+## Verification of the first patch
+
+Before editing production code, the new regression test reproduced nil-request panics in all three affected methods. The valid commit metadata test passed on the baseline. Existing memory replay/title tests passed before removing the duplicate assignment.
+
+After cleanup, `go build ./...`, `go test -race ./...`, `make lint` (zero issues), and `git diff --check` all pass. No live-account or soak test was run.

--- a/docs/plans/2026-09-05-future-scheduling.md
+++ b/docs/plans/2026-09-05-future-scheduling.md
@@ -1,0 +1,32 @@
+# Future scheduled task fix
+
+## Scope
+
+Correct CLI Task6 payloads so a scheduled local calendar date in the future is
+classified as Upcoming (`st=2`), while today and past dates remain
+Today/Anytime (`st=1`). Keep `--when` authoritative when it is supplied and
+preserve the existing UTC-midnight encoding for `sr` and `tir`.
+
+This change is stacked on PR #30 and reuses its shared task-option validation.
+
+## Implementation plan
+
+1. Add deterministic regression coverage for future, today, and past scheduled
+   dates using a fixed-day helper, including explicit `--when` precedence.
+2. Cover create, edit, and batch-create payloads, plus project, heading, and
+   area relationships, while asserting the existing Task6 fields stay intact.
+3. Centralize the date-to-schedule classification and use it from create and
+   update payload builders. Prevent relationship auto-Anytime behavior from
+   replacing either an explicit `--when` or an explicit scheduled date.
+4. Retain PR #30's rejection of malformed or valueless scheduled options at
+   direct create, edit, and batch-create boundaries. Reuse the shared validator
+   instead of adding a second validation implementation.
+5. Document the interaction between `--scheduled` and `--when`, then run the
+   focused CLI tests followed by the repository's normal build and lint checks.
+
+## Constraints
+
+- No new dependencies or cloud writes.
+- Do not change the 34-field create payload or the UTC-midnight civil-date
+  representation.
+- Preserve the safety rule that projects and headings cannot be Inbox items.

--- a/docs/plans/2026-09-05-task7-read-recovery.md
+++ b/docs/plans/2026-09-05-task7-read-recovery.md
@@ -1,0 +1,31 @@
+# Task7 read support and recovery
+
+## Scope and decisions
+
+Implement issue #29 from the v0.5.0 develop baseline. The user approved the proposed approach: retain the active SQLite audit log and rebuild derived state through staged replay. Issue #26's write scheduling is a separate branch/PR. Existing Task6 writes remain unchanged.
+
+Protocol evidence comes from Things 3.23.3 (build 32303501), read-only cloud inspection, and a consistent local database snapshot. The app normalizes Task6 to Task7 without modifying the operation's property dictionary. `sr` is startDate; `tir` is a distinct todayIndexReferenceDate. Modern repeater fields remain incompletely verified and are not a new write contract.
+
+## Plan before production edits
+
+1. Add failing fixtures for Task7 create/partial update, mixed Task6/Task7 identity, notes, relationships, nullable fields, deletion, and future unsupported task kinds.
+2. Add an explicit Task7 read kind and a shared read-only payload helper for null-versus-omitted fields. Preflight unsupported task kinds before a memory batch mutates. SQLite must roll back rejected batches.
+   Add a serialized-envelope guard in `History.Write` so the new Task7 read kind and future task kinds cannot reach the network, including through custom envelope implementations. Retain the existing write kinds and full Task6 wire regression coverage.
+3. Remove SQLite's incorrect `tir` override of `sr`, with a regression distinguishing the two dates.
+4. Introduce a persisted replay generation independent of structural schema. Check it before caught-up returns. Fresh databases use the current generation; old populated state requires recovery.
+5. Take a consistent, permission-restricted SQLite backup. Replay cloud history from zero into empty staging state. Preserve old change-log rows/IDs/timestamps; suppress historical replay events below the original next-batch cursor. Install rebuilt entities, junctions, cursor, generation, and only genuinely new log entries in one transaction after checking that the original database has not advanced concurrently.
+6. Keep the old database unchanged on backup, fetch, decode, progress, or installation failure. Test successful retry, note-delta single application, old-log retention, cutoff boundaries, idempotence, and concurrent-state protection.
+7. Bump the CLI cache generation, back up obsolete cache bytes, and replace the cache atomically only after successful complete replay. Preserve usable old data on failure and report unsupported task kinds without private payloads.
+8. Run build, focused regressions, race tests, lint, and independent review. Re-run the read-only comparison using the actual implementation with disposable local state, documenting remaining gaps. Publish a draft PR and update issue #29.
+
+No dependencies, cloud mutations, or destructive migration of the user's live Things.app database are needed. Private captures and credentials stay outside the repository. Recovery of the user's installed SDK cache/database is tested on copies first.
+
+## Verification record
+
+- New backend/cache/write-guard regressions reproduced the missing Task7 state, stale caught-up cache, unsafe replacement, and unverified write paths before the fixes.
+- Independent review found malformed-note acceptance and repeated full-backup accumulation. Note values are now checked before mutation; every SQLite attempt makes a fresh validated snapshot and removes only its own full-content duplicate. A restored database with the same cursor but different audit content retains its own backup.
+- Real-capture upgrade using the actual implementation restored seven missing tasks and all three inbox tasks. The 265 scheduled-date mismatches disappeared; all 5,352 existing audit rows remained byte-identical, recovery returned no historical notifications, and the next sync returned no changes.
+- Read-only live CLI validation rebuilt a disposable version-1 cache: old reader inbox 0, new reader inbox 3, Things.app inbox 3. A repeated read stayed at 3 and the original cache had an exact 0600 backup.
+- Three orphan Task6 modification-only records remain separate from the Task7 repair. Modern repeater semantics and actual Task7 project/heading wire variants remain incompletely observed; those variant tests are synthetic.
+- The CLI uses optimistic cache-change detection plus atomic replacement, not a cross-process lock. Concurrent complete snapshots may replace one another and catch up on a later read. Separate cache paths avoid shared-writer contention.
+- No live cloud writes have been made. The separate scheduling PR and combined stack require a controlled disposable-account/Things.app check before treating the write behavior as app-verified. Process-kill/power-loss injection has not been performed.

--- a/docs/task7-write-policy.md
+++ b/docs/task7-write-policy.md
@@ -1,0 +1,106 @@
+# Task7 write support
+
+Task6 and Task7 are versions of history-event payloads. The same task UUID can
+have a Task7 creation followed by a Task6 modification. Migrating a writer
+changes the envelopes it sends; it does not require rewriting an account's
+existing tasks or history.
+
+## Supported scope
+
+The CLI sends Task7 for supported task, project, and heading creation and task
+modification operations. Tag4, Area3, ChecklistItem3, and Tombstone2 operations
+keep their existing formats. The SDK also accepts explicit `ItemKindTask7`
+envelopes within the validated scope.
+
+For compatibility, `ItemKindTask` remains Task6. Existing SDK callers continue
+to emit the kind they requested. The readers retain support for both versions;
+do not change their shared Task6 discriminator to migrate a writer.
+
+- Creation uses the verified complete payload, including null modification
+  date and recurrence configuration, and empty recurrence links.
+- Project and heading creation is limited to Anytime in this first scope;
+  ordinary task creation supports the verified Inbox/Anytime/Someday and
+  corresponding date-based scheduling encodings.
+- Updates are sparse: omitted properties remain omitted. Supported operations
+  include full-note replacement, ordinary scheduling, relationships, tags,
+  completion/reopening, and recoverable trash/restoration.
+- Direct note-delta writes, recurrence configuration, unsupported properties,
+  and Task7 permanent-deletion events are outside this first write contract.
+
+Area and project moves explicitly clear incompatible parent relationships.
+An edit cannot combine area with project or heading; project plus heading is
+supported. This avoids silently choosing between conflicting destinations or
+leaving a task attached to its previous container.
+
+Task7 modifications require an existing, nonrecurring target. Before posting,
+`History.Write` reads raw history from index zero and classifies the targeted
+UUIDs. A single scan covers every Task7 update in the batch. This avoids
+relying on the public `Task` projection, which does not retain every recurrence
+field. Unknown/missing targets and recurring templates or instances fail
+before any operation in that write request is posted.
+
+This also rejects older or sparse histories without explicit values for all
+three recurrence markers (`rr`, `rp`, `rt`), including tasks created by the
+legacy sparse SDK example. Such a task may be ordinary, but the new checker
+does not infer that from incomplete evidence. CLI updates therefore have a
+compatibility limitation for these records; there is no automatic Task6
+fallback. Existing explicit Task6 SDK calls keep their previous behavior.
+
+This preflight adds network reads and work proportional to the history size
+for update requests. It uses a fixed checked history head as the commit
+ancestor; it does not silently retry a failed commit. Existing Task6 writes
+keep their prior behavior and do not gain this recurrence protection.
+
+A controlled stale-ancestor test wrote one title update, then submitted a
+second update to the same UUID and field using the preceding head. The server
+returned HTTP 409 for the second request and history contained only the first
+event. This verifies rejection in that case; broader concurrent/offline
+convergence remains outside the tested scope.
+
+## Explicit SDK update
+
+```go
+update := things.TaskActionItem{
+    Item: things.Item{
+        UUID: taskUUID,
+        Kind: things.ItemKindTask7,
+        Action: things.ItemActionModified,
+    },
+    P: things.TaskActionItemPayload{
+        Title: things.String("Updated title"),
+        ModificationDate: things.Time(time.Now()),
+    },
+}
+if err := history.Write(update); err != nil {
+    return err
+}
+```
+
+Do not serialize a projected task back as a complete replacement: unmodeled
+properties such as modern repeater data cannot be reconstructed from it.
+Use the CLI's complete creation payload or an equivalent validated full
+envelope for Task7 creation; its required nulls differ from the legacy SDK's
+sparse `TaskActionItemPayload` encoding.
+
+## Mixed-version evidence
+
+In the disposable account, the current Task6 CLI performed a title-only edit
+on an ordinary Task7 task and on a native Task7 repeating template. Both writes
+were persisted as Task6 modifications containing only `tt` and `md`, on the
+original UUIDs. Things applied the titles and preserved the checked notes,
+scheduling, status, and recurrence columns. The template's stored recurrence
+rule remained byte-identical.
+
+The native weekly-after-completion control used a non-null `rr` object with
+`rrv=4`, `tp=1`, `fu=256`, and `fa=1`; `rp` was null. The app created a template
+and a separate instance linked through `rt`. Completing the instance in Things
+emitted a Task7 `ss`/`sp`/`md` update on the instance and an `acrd`/`tir` update
+on its template. The app then showed September 13 as the next occurrence.
+
+That confirms title-only mixed-version compatibility for these cases. It
+does not establish recurring lifecycle support: changing an envelope's kind
+does not synthesize the companion template updates. Non-null modern `rp`,
+other recurrence modes, and concurrent/offline convergence remain unverified.
+
+See [the live verification report](task7-write-verification.md) for the tested
+ordinary-operation matrix and its limits.

--- a/docs/task7-write-verification.md
+++ b/docs/task7-write-verification.md
@@ -1,0 +1,90 @@
+# Task7 disposable-account verification — 2026-09-06
+
+## Result and scope
+
+Ten explicit Task7 commits succeeded in an isolated disposable Things Cloud
+account using Things 3.23.3 (32303501), schema 301. Each commit was read back
+with the exact submitted property dictionary. Native app synchronization and
+read-only SQLite queries confirmed the resulting state. SDK reads confirmed
+the tested values, with the Unicode replay correction described below.
+
+This establishes a tested subset, not a complete Task7 write specification.
+The production `History.Write` Task7 guard remains unchanged; normal SDK/CLI
+writes remain Task6. No account credentials or private history captures are
+included in this repository.
+
+## Method
+
+- Confirmed the disposable and original accounts had distinct history IDs.
+  The original account was used only for this read-only separation check.
+- Created a named control task in Things, edited its Unicode note, and set it
+  to Today. Captured those Task7 events from cloud history. These are persisted
+  native events, not an interception of the native outgoing HTTP request.
+- Used a private test-only HTTP writer to submit explicit `e: "Task7"` events
+  for one owned test UUID. It checked account separation and the current head,
+  recorded each write intent, and refused automatic retries or duplicate stages.
+- Reused captured native creation, note, and Today shapes. Future scheduling,
+  date clearing, completion, reopening, and trash/restoration used the existing
+  SDK property conventions with an explicit Task7 envelope.
+- Compared cloud readback, candidate SDK output, and Things' local database
+  opened read-only. Inspected creation/notes in the UI and the restored task
+  after a normal app quit and relaunch. Intermediate lifecycle verification
+  used the local database; it did not independently inspect every view.
+
+## Passed cases
+
+| Operation | Verified fields or behavior |
+| --- | --- |
+| Create ordinary task | Native 34-property shape; empty note; task opens in Things |
+| Initial Unicode note | Captured insertion into empty note |
+| Interior Unicode edit | Captured byte-offset delta after Greek text and emoji |
+| Today | Native `st=1`, `sr`, `tir`, `ix`, `md` shape |
+| Future schedule and deadline | `st=2`; September 10 start; September 11 deadline |
+| Clear dates | Explicit null `sr`, `tir`, `dd`; `st=1` |
+| Complete | `ss=3` and non-null `sp` |
+| Reopen | `ss=0`, null `sp` |
+| Recoverable trash | `tr=true` |
+| Restore | `tr=false`; task remains open with its correct note after restart |
+
+Native creation used the same 34 property names as the current Task6 create
+payload. That observation alone does not establish equal semantics for every
+field or justify changing the production envelope.
+
+## Unicode defect and correction
+
+Starting text: `Native Task7 note α 🚀\nSecond line.`
+
+The native app emitted this delta:
+
+```json
+{"_t":"tx","t":2,"ps":[{"r":"Update","p":26,"l":5,"ch":3672733299}]}
+```
+
+Things produced `Native Task7 note α 🚀\nUpdated line.`. Offset 26 is the UTF-8
+byte position of `Second`; its Unicode scalar position is 22 and its UTF-16
+position is 23. The old rune-index decoder instead produced `SecoUpdatene.`.
+Replaying the identical delta through an explicit Task7 write reproduced the
+correct native result and the incorrect SDK result.
+
+`ApplyPatches` now uses byte offsets and bounds lengths before addition to avoid
+integer overflow. Replay generation 3 invalidates older CLI/SQLite derived
+state. Regression tests cover the native delta, malformed numeric ranges, and
+caught-up version-2 cache/database recovery with preserved SQLite audit rows.
+The actual disposable-account version-2 CLI cache was also repaired by the
+new binary and matched the app after restart.
+
+## Remaining verification gaps
+
+- Non-null `rp`/`rr`, modern recurrence and repeat-instance operations.
+- Direct Task7 project/heading creation, relationship moves, tags, checklists,
+  reminders, ordering under concurrency, and bulk writes.
+- Permanent deletion and wire action `t=2` were not exercised in this write test.
+- Conflict/retry behavior, offline concurrent edits, and multi-device convergence.
+- Raw native HTTP headers/body equivalence; server persistence may normalize
+  requests. No TLS interception or certificate changes were used.
+- The general malformed-patch/checksum contract is not established by this
+  successful Unicode example. A malformed byte range splitting a multibyte
+  character can still yield invalid UTF-8; checked replay with transactional
+  error propagation would require a separate change.
+
+These limits must stay explicit in any proposal to enable Task7 writes.

--- a/docs/task7-write-verification.md
+++ b/docs/task7-write-verification.md
@@ -9,9 +9,10 @@ read-only SQLite queries confirmed the resulting state. SDK reads confirmed
 the tested values, with the Unicode replay correction described below.
 
 This establishes a tested subset, not a complete Task7 write specification.
-The production `History.Write` Task7 guard remains unchanged; normal SDK/CLI
-writes remain Task6. No account credentials or private history captures are
-included in this repository.
+The initial tests used a private writer while production writes remained
+Task6. The subsequent [Task7 write policy](task7-write-policy.md) uses this
+evidence to scope supported writes and reject recurrence updates. No account
+credentials or private history captures are included in this repository.
 
 ## Method
 
@@ -95,11 +96,49 @@ project view showed the second child under the heading.
 
 This verifies those particular batch and relationship shapes. It does not
 test concurrent reordering, every checklist operation, or repeat-instance
-relationships. The default SDK/CLI write envelope remains Task6.
+relationships.
+
+## Follow-up: mixed-version edits and native recurrence
+
+A normal Task6 CLI title edit was applied to both an existing ordinary Task7
+task and a native Task7 recurrence template. Both events used the same UUIDs
+and contained only `tt`/`md`. App and SDK readback passed; checked non-title
+fields were unchanged, including the exact stored recurrence-rule bytes.
+
+The native weekly-after-completion example used `rr` version 4, not a non-null
+`rp`. It created a template plus an `rt`-linked instance. Native completion
+updated the instance (`ss`/`sp`/`md`) and its template (`acrd`/`tir`), after which
+the app showed September 13 as the next occurrence. This is evidence for that
+particular native lifecycle, not complete SDK recurrence-write support.
+
+## Migrated CLI acceptance
+
+The migrated CLI was exercised through its normal `History.Write` path, rather
+than the private direct writer. Creation with a full Unicode note and future
+start/deadline dates, sparse title/note/date editing, completion, and recoverable
+trash all emitted Task7 and matched both the app database and SDK readback.
+
+An edit of the known recurring template was rejected. A batch combining an
+ordinary edit and recurring-instance completion was also rejected in full.
+The cloud head remained unchanged in both cases.
+
+The real CLI move-to-area probe exposed a pre-existing omission: it set `ar`
+without clearing `pr`/`agr`, leaving the task attached to its old project and
+heading. The corrected command explicitly clears those arrays. Its live retest
+left only the area relationship and removed the task from the old project view.
+The inverse move-to-project cleared `ar`/`agr` and left only the project; app
+database and SDK readback agreed. Ambiguous area-plus-project/heading edits are
+rejected before preflight or POST. Creation and standalone heading behavior
+were not changed by this move correction.
+
+A same-UUID, same-field stale-ancestor test returned HTTP 409 for the second
+write and produced no second history event. This is a bounded conflict result,
+not a complete concurrency or offline-convergence test.
 
 ## Remaining verification gaps
 
-- Non-null `rp`/`rr`, modern recurrence and repeat-instance operations.
+- Non-null modern `rp`, broader `rr` configurations, and SDK-driven recurrence
+  creation and repeat-instance lifecycle operations.
 - Reminders, ordering under concurrency, and broader bulk/checklist operations
   beyond the specific creation and move cases above.
 - Permanent deletion and wire action `t=2` were not exercised in this write test.

--- a/docs/task7-write-verification.md
+++ b/docs/task7-write-verification.md
@@ -73,18 +73,41 @@ caught-up version-2 cache/database recovery with preserved SQLite audit rows.
 The actual disposable-account version-2 CLI cache was also repaired by the
 new binary and matched the app after restart.
 
+## Follow-up: checked replay and relationship tests
+
+Checked note replay now rejects invalid UTF-8 before applying a memory batch
+or committing a SQLite transaction. Existing public `ApplyPatches` behavior
+remains available; the state backends use the checked path. The decoder does
+not infer checksum semantics from this example.
+
+A further seven-object commit created a Task7 project in the disposable area,
+a Task7 heading, two Task7 child tasks, a Tag4 tag, and two ChecklistItem3
+children. One task was created under the heading with the tag and checklist;
+the other was created directly under the project. Exact cloud readback,
+SDK state, and read-only Things database checks passed for all objects and
+relationships. The project, heading, and tasks displayed correctly in Things.
+
+A subsequent two-task commit moved the first child from its heading/project
+to the disposable area, cleared its tag, and moved the second child into the
+heading with that tag. Explicit empty relationship arrays and the submitted
+ordering values matched both the SDK and Things database after sync. The
+project view showed the second child under the heading.
+
+This verifies those particular batch and relationship shapes. It does not
+test concurrent reordering, every checklist operation, or repeat-instance
+relationships. The default SDK/CLI write envelope remains Task6.
+
 ## Remaining verification gaps
 
 - Non-null `rp`/`rr`, modern recurrence and repeat-instance operations.
-- Direct Task7 project/heading creation, relationship moves, tags, checklists,
-  reminders, ordering under concurrency, and bulk writes.
+- Reminders, ordering under concurrency, and broader bulk/checklist operations
+  beyond the specific creation and move cases above.
 - Permanent deletion and wire action `t=2` were not exercised in this write test.
 - Conflict/retry behavior, offline concurrent edits, and multi-device convergence.
 - Raw native HTTP headers/body equivalence; server persistence may normalize
   requests. No TLS interception or certificate changes were used.
 - The general malformed-patch/checksum contract is not established by this
-  successful Unicode example. A malformed byte range splitting a multibyte
-  character can still yield invalid UTF-8; checked replay with transactional
-  error propagation would require a separate change.
+  successful Unicode example. Checked replay rejects invalid UTF-8 results;
+  it does not detect every semantically wrong patch that still yields valid text.
 
 These limits must stay explicit in any proposal to enable Task7 writes.

--- a/histories.go
+++ b/histories.go
@@ -243,21 +243,18 @@ func (h *History) Write(items ...Identifiable) error {
 		return err
 	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("/version/1/history/%s/commit", h.ID), bytes.NewReader(bs))
+	if err != nil {
+		return err
+	}
 	req.Header.Add("Schema", "301")
 	req.Header.Add("Push-Priority", "5")
 	// Full App-Instance-Id matching Things format: {hash}-{bundleId}-{hash}
 	req.Header.Add("App-Instance-Id", "000000000000000000000000000000000000000000000000000000000000000-com.culturedcode.ThingsMac-000000000000000000000000000000000000000000000000000000000000000")
 	req.Header.Add("App-Id", "com.culturedcode.ThingsMac")
-	req.Header.Add("Content-Encoding", "UTF-8")
-	req.Header.Add("Host", "cloud.culturedcode.com")
-	req.Header.Add("Accept", "application/json")
 	query := req.URL.Query()
 	query.Add("ancestor-index", strconv.Itoa(h.LatestServerIndex))
 	query.Add("_cnt", "1")
 	req.URL.RawQuery = query.Encode()
-	if err != nil {
-		return err
-	}
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return err

--- a/histories.go
+++ b/histories.go
@@ -242,6 +242,9 @@ func (h *History) Write(items ...Identifiable) error {
 	if err != nil {
 		return err
 	}
+	if err := validateTaskWriteKinds(bs); err != nil {
+		return err
+	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("/version/1/history/%s/commit", h.ID), bytes.NewReader(bs))
 	req.Header.Add("Schema", "301")
 	req.Header.Add("Push-Priority", "5")

--- a/histories.go
+++ b/histories.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strconv"
+	"strings"
+	"unicode/utf8"
 )
 
 // History represents a synchronization stream. It's identified with a uuid v4
@@ -242,8 +244,20 @@ func (h *History) Write(items ...Identifiable) error {
 	if err != nil {
 		return err
 	}
-	if err := validateTaskWriteKinds(bs); err != nil {
+	plan, err := validateTaskWrites(bs)
+	if err != nil {
 		return err
+	}
+	ancestorIndex := h.LatestServerIndex
+	if plan.needsPreflight() {
+		checkedHead, err := h.preflightTask7Modifications(plan.modificationTargets)
+		if err != nil {
+			return err
+		}
+		// Use the fixed raw-history snapshot head as the commit ancestor. The
+		// method deliberately does not retry if the server rejects the write.
+		h.LatestServerIndex = checkedHead
+		ancestorIndex = checkedHead
 	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("/version/1/history/%s/commit", h.ID), bytes.NewReader(bs))
 	if err != nil {
@@ -255,7 +269,7 @@ func (h *History) Write(items ...Identifiable) error {
 	req.Header.Add("App-Instance-Id", "000000000000000000000000000000000000000000000000000000000000000-com.culturedcode.ThingsMac-000000000000000000000000000000000000000000000000000000000000000")
 	req.Header.Add("App-Id", "com.culturedcode.ThingsMac")
 	query := req.URL.Query()
-	query.Add("ancestor-index", strconv.Itoa(h.LatestServerIndex))
+	query.Add("ancestor-index", strconv.Itoa(ancestorIndex))
 	query.Add("_cnt", "1")
 	req.URL.RawQuery = query.Encode()
 	resp, err := h.Client.do(req)
@@ -278,4 +292,208 @@ func (h *History) Write(items ...Identifiable) error {
 	}
 	h.LatestServerIndex = w.ServerHeadIndex
 	return nil
+}
+
+type task7TargetState struct {
+	exists             bool
+	ambiguous          bool
+	future             bool
+	lastAffectedIndex  int
+	sameIndexAmbiguous bool
+
+	rrKnown  bool
+	rrActive bool
+	rpKnown  bool
+	rpActive bool
+	rtKnown  bool
+	rtActive bool
+	icsd     bool
+	acrd     bool
+}
+
+func (h *History) preflightTask7Modifications(targets map[string]struct{}) (int, error) {
+	states := make(map[string]*task7TargetState, len(targets))
+	for id := range targets {
+		states[id] = &task7TargetState{lastAffectedIndex: -1}
+	}
+
+	// Items mutates its receiver. Scan through a copy so every failed or
+	// incomplete preflight leaves the caller's History untouched.
+	snapshot := *h
+	snapshot.LatestServerIndex = 0
+	snapshot.LoadedServerIndex = 0
+	start, checkedHead := 0, -1
+	for {
+		items, _, err := snapshot.Items(ItemsOptions{StartIndex: start})
+		if err != nil {
+			return 0, fmt.Errorf("Task7 write preflight: %w", err)
+		}
+		if checkedHead < 0 {
+			checkedHead = snapshot.LatestServerIndex
+			if checkedHead < 0 {
+				return 0, fmt.Errorf("Task7 write preflight: invalid history head")
+			}
+		} else if snapshot.LatestServerIndex < checkedHead {
+			return 0, fmt.Errorf("Task7 write preflight: history head regressed")
+		}
+
+		for _, item := range items {
+			if !item.HasServerIndex || item.ServerIndex >= checkedHead {
+				continue
+			}
+			if err := applyTask7PreflightItem(states, item); err != nil {
+				return 0, err
+			}
+		}
+		if snapshot.LoadedServerIndex >= checkedHead {
+			break
+		}
+		if snapshot.LoadedServerIndex <= start {
+			return 0, fmt.Errorf("Task7 write preflight: history ended before checked head %d", checkedHead)
+		}
+		start = snapshot.LoadedServerIndex
+	}
+
+	for id, state := range states {
+		switch {
+		case state.future:
+			return 0, fmt.Errorf("Task7 write preflight: target %s has an unsupported future task kind", id)
+		case !state.exists || state.ambiguous || state.sameIndexAmbiguous:
+			return 0, fmt.Errorf("Task7 write preflight: target %s is missing or ambiguous", id)
+		case !state.rrKnown || !state.rpKnown || !state.rtKnown:
+			return 0, fmt.Errorf("Task7 write preflight: target %s lacks complete recurrence markers", id)
+		case state.rrActive || state.rpActive || state.rtActive || state.icsd || state.acrd:
+			return 0, fmt.Errorf("Task7 write preflight: target %s is recurring", id)
+		}
+	}
+	return checkedHead, nil
+}
+
+func applyTask7PreflightItem(states map[string]*task7TargetState, item Item) error {
+	if item.Kind == ItemKind("Tombstone2") || item.Kind == ItemKind("Tombstone") {
+		if !utf8.Valid(item.P) || rejectUnpairedJSONSurrogates(item.P) != nil || rejectDuplicateJSONKeys(item.P, true) != nil {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		var payload TombstoneActionItemPayload
+		if err := json.Unmarshal(item.P, &payload); err != nil {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		fields, err := jsonObject(item.P)
+		if err != nil {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		if _, ok := jsonString(fields["dloid"]); !ok || payload.DeletedObjectID == "" {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		target := payload.DeletedObjectID
+		if item.Kind == ItemKind("Tombstone") && ValidateUUID(target) != nil {
+			target = EncodeLegacyIdentifier(target)
+		}
+		if state := states[target]; state != nil {
+			state.markAffected(item.ServerIndex)
+			state.resetSemantic(false)
+		}
+		return nil
+	}
+
+	id := item.UUID
+	if isLegacyTaskKind(item.Kind) && ValidateUUID(id) != nil {
+		id = EncodeLegacyIdentifier(id)
+	}
+	state := states[id]
+	if state == nil {
+		return nil
+	}
+	state.markAffected(item.ServerIndex)
+
+	switch string(item.Kind) {
+	case "Task6", "Task7", "Task4", "Task3", "Task":
+	case "Tombstone2", "Tombstone":
+		return nil
+	default:
+		if strings.HasPrefix(string(item.Kind), "Task") {
+			state.future = true
+		}
+		state.ambiguous = true
+		return nil
+	}
+
+	switch item.Action {
+	case ItemActionCreated:
+		ambiguous := state.ambiguous || state.future || state.exists
+		state.resetSemantic(true)
+		state.ambiguous = ambiguous
+	case ItemActionModified:
+		if !state.exists {
+			state.ambiguous = true
+		}
+	case ItemActionDeleted:
+		state.resetSemantic(false)
+		return nil
+	default:
+		state.ambiguous = true
+		return nil
+	}
+	if !utf8.Valid(item.P) || rejectUnpairedJSONSurrogates(item.P) != nil || rejectDuplicateJSONKeys(item.P, true) != nil {
+		state.ambiguous = true
+		return nil
+	}
+	payload, err := jsonObject(item.P)
+	if err != nil {
+		state.ambiguous = true
+		return nil
+	}
+	applyRawRecurrenceMarker(payload, "rr", &state.rrKnown, &state.rrActive)
+	applyRawRecurrenceMarker(payload, "rp", &state.rpKnown, &state.rpActive)
+	if raw, ok := payload["rt"]; ok {
+		state.rtKnown = true
+		if jsonNull(raw) {
+			state.rtActive = false
+		} else if values, err := jsonStringArray(raw); err == nil {
+			state.rtActive = len(values) != 0
+		} else {
+			state.ambiguous = true
+		}
+	}
+	applyRawPresenceMarker(payload, "icsd", &state.icsd)
+	applyRawPresenceMarker(payload, "acrd", &state.acrd)
+	return nil
+}
+
+func (s *task7TargetState) markAffected(serverIndex int) {
+	if s.lastAffectedIndex == serverIndex {
+		s.sameIndexAmbiguous = true
+	}
+	s.lastAffectedIndex = serverIndex
+}
+
+func (s *task7TargetState) resetSemantic(exists bool) {
+	lastIndex, sameIndexAmbiguous := s.lastAffectedIndex, s.sameIndexAmbiguous
+	*s = task7TargetState{
+		exists:             exists,
+		lastAffectedIndex:  lastIndex,
+		sameIndexAmbiguous: sameIndexAmbiguous,
+	}
+}
+
+func isLegacyTaskKind(kind ItemKind) bool {
+	switch string(kind) {
+	case "Task4", "Task3", "Task":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyRawRecurrenceMarker(payload map[string]json.RawMessage, key string, known, active *bool) {
+	if raw, ok := payload[key]; ok {
+		*known = true
+		*active = !jsonNull(raw)
+	}
+}
+
+func applyRawPresenceMarker(payload map[string]json.RawMessage, key string, active *bool) {
+	if raw, ok := payload[key]; ok {
+		*active = !jsonNull(raw)
+	}
 }

--- a/histories_coverage_test.go
+++ b/histories_coverage_test.go
@@ -6,12 +6,6 @@ import (
 	"testing"
 )
 
-// asHTTPError reports whether err (or a wrapped error) is an *HTTPError, and if
-// so stores it in *target.
-func asHTTPError(err error, target **HTTPError) bool {
-	return errors.As(err, target)
-}
-
 func TestClient_History(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
@@ -58,7 +52,7 @@ func TestClient_History(t *testing.T) {
 		c := New(server.URL, "martin@example.com", "")
 		_, err := c.History("id")
 		var httpErr *HTTPError
-		if !asHTTPError(err, &httpErr) {
+		if !errors.As(err, &httpErr) {
 			t.Fatalf("History err = %v, want *HTTPError", err)
 		}
 		if httpErr.StatusCode != http.StatusInternalServerError {
@@ -142,7 +136,7 @@ func TestHistory_Sync_ErrorStatus(t *testing.T) {
 	h := History{Client: c, ID: "id"}
 	err := h.Sync()
 	var httpErr *HTTPError
-	if !asHTTPError(err, &httpErr) {
+	if !errors.As(err, &httpErr) {
 		t.Fatalf("Sync err = %v, want *HTTPError", err)
 	}
 }

--- a/items.go
+++ b/items.go
@@ -40,14 +40,14 @@ type ItemsOptions struct {
 // Note that if a item was changed multiple times it will be present multiple times in the result too.
 func (h *History) Items(opts ItemsOptions) ([]Item, bool, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("/version/1/history/%s/items", h.ID), nil)
+	if err != nil {
+		return nil, false, err
+	}
 
 	values := req.URL.Query()
 	values.Set("start-index", strconv.Itoa(opts.StartIndex))
 	req.URL.RawQuery = values.Encode()
 
-	if err != nil {
-		return nil, false, err
-	}
 	resp, err := h.Client.do(req)
 	if err != nil {
 		return nil, false, err

--- a/notes.go
+++ b/notes.go
@@ -1,5 +1,10 @@
 package thingscloud
 
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
 // NoteTypeFullText indicates a note with complete text
 const NoteTypeFullText = 1
 
@@ -25,8 +30,24 @@ type Note struct {
 
 // ApplyPatches applies a series of text patches using UTF-8 byte offsets.
 func ApplyPatches(original string, patches []NotePatch) string {
+	result, _ := applyPatches(original, patches, false)
+	return result
+}
+
+// ApplyPatchesChecked applies byte-offset patches and rejects any patch that
+// leaves the note in an invalid UTF-8 state. ApplyPatches remains available for
+// callers that rely on its historical unchecked behavior.
+func ApplyPatchesChecked(original string, patches []NotePatch) (string, error) {
+	return applyPatches(original, patches, true)
+}
+
+func applyPatches(original string, patches []NotePatch, validateUTF8 bool) (string, error) {
+	if validateUTF8 && !utf8.ValidString(original) {
+		return "", fmt.Errorf("original note is not valid UTF-8")
+	}
+
 	text := []byte(original)
-	for _, p := range patches {
+	for i, p := range patches {
 		position := p.Position
 		if position < 0 {
 			position = 0
@@ -48,7 +69,10 @@ func ApplyPatches(original string, patches []NotePatch) string {
 		result := append([]byte(nil), text[:position]...)
 		result = append(result, p.Replacement...)
 		result = append(result, text[end:]...)
+		if validateUTF8 && !utf8.Valid(result) {
+			return "", fmt.Errorf("note patch %d produced invalid UTF-8", i)
+		}
 		text = result
 	}
-	return string(text)
+	return string(text), nil
 }

--- a/notes.go
+++ b/notes.go
@@ -23,36 +23,32 @@ type Note struct {
 	Patches  []NotePatch `json:"ps,omitempty"`
 }
 
-// ApplyPatches applies a series of text patches to an original string
+// ApplyPatches applies a series of text patches using UTF-8 byte offsets.
 func ApplyPatches(original string, patches []NotePatch) string {
-	runes := []rune(original)
+	text := []byte(original)
 	for _, p := range patches {
-		if p.Position < 0 {
-			p.Position = 0
+		position := p.Position
+		if position < 0 {
+			position = 0
 		}
-		if p.Position > len(runes) {
-			p.Position = len(runes)
+		if position > len(text) {
+			position = len(text)
 		}
-		end := p.Position + p.Length
-		if end > len(runes) {
-			end = len(runes)
+
+		length := p.Length
+		if length < 0 {
+			length = 0
 		}
-		if end < p.Position {
-			// Negative length in a corrupt/hostile patch: treat as a
-			// pure insertion instead of slicing out of bounds.
-			end = p.Position
+		remaining := len(text) - position
+		if length > remaining {
+			length = remaining
 		}
-		actualLength := end - p.Position
-		replacementRunes := []rune(p.Replacement)
-		newCap := len(runes) - actualLength + len(replacementRunes)
-		if newCap < 0 {
-			newCap = len(replacementRunes)
-		}
-		result := make([]rune, 0, newCap)
-		result = append(result, runes[:p.Position]...)
-		result = append(result, replacementRunes...)
-		result = append(result, runes[end:]...)
-		runes = result
+		end := position + length
+
+		result := append([]byte(nil), text[:position]...)
+		result = append(result, p.Replacement...)
+		result = append(result, text[end:]...)
+		text = result
 	}
-	return string(runes)
+	return string(text)
 }

--- a/notes_negative_patch_test.go
+++ b/notes_negative_patch_test.go
@@ -2,6 +2,15 @@ package thingscloud
 
 import "testing"
 
+func TestApplyPatches_NegativePositionClampsToStart(t *testing.T) {
+	t.Parallel()
+
+	got := ApplyPatches("hello", []NotePatch{{Replacement: "X", Position: -1, Length: 1}})
+	if got != "Xello" {
+		t.Errorf("ApplyPatches negative position = %q, want %q", got, "Xello")
+	}
+}
+
 func TestApplyPatches_NegativeLengthDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
@@ -15,5 +24,15 @@ func TestApplyPatches_NegativeLengthDoesNotPanic(t *testing.T) {
 	got = ApplyPatches("hello", []NotePatch{{Replacement: "", Position: 3, Length: -1}})
 	if got != "hello" {
 		t.Errorf("ApplyPatches negative length no-op = %q, want %q", got, "hello")
+	}
+}
+
+func TestApplyPatches_LengthOverflowClampsToEnd(t *testing.T) {
+	t.Parallel()
+
+	maxInt := int(^uint(0) >> 1)
+	got := ApplyPatches("AB", []NotePatch{{Replacement: "X", Position: 1, Length: maxInt}})
+	if got != "AX" {
+		t.Errorf("ApplyPatches overflowing length = %q, want %q", got, "AX")
 	}
 }

--- a/notes_test.go
+++ b/notes_test.go
@@ -2,7 +2,9 @@ package thingscloud
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestNote_FullText(t *testing.T) {
@@ -83,5 +85,87 @@ func TestNote_ApplyMultiplePatches(t *testing.T) {
 	result := ApplyPatches(original, patches)
 	if result != "XBCDEF" {
 		t.Errorf("expected 'XBCDEF', got '%s'", result)
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	_, err := ApplyPatchesChecked("α", []NotePatch{{Position: 1, Length: 1}})
+	if err == nil {
+		t.Fatal("ApplyPatchesChecked accepted a patch that split a UTF-8 encoding")
+	}
+	if !strings.Contains(err.Error(), "patch 0") {
+		t.Fatalf("error %q does not identify the invalid patch", err)
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidOriginal(t *testing.T) {
+	t.Parallel()
+
+	invalid := string([]byte{0xff})
+	for _, patches := range [][]NotePatch{
+		nil,
+		{{Position: 0, Length: 1, Replacement: "valid"}},
+	} {
+		if _, err := ApplyPatchesChecked(invalid, patches); err == nil {
+			t.Fatalf("ApplyPatchesChecked accepted invalid original with patches %+v", patches)
+		}
+	}
+}
+
+func TestApplyPatchesCheckedAllowsMidCodePointNoOpWhenResultIsValid(t *testing.T) {
+	t.Parallel()
+
+	got, err := ApplyPatchesChecked("α", []NotePatch{{Position: 1}})
+	if err != nil {
+		t.Fatalf("ApplyPatchesChecked rejected a valid result: %v", err)
+	}
+	if got != "α" {
+		t.Fatalf("ApplyPatchesChecked = %q, want α", got)
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidIntermediateResult(t *testing.T) {
+	t.Parallel()
+
+	patches := []NotePatch{
+		{Position: 1, Length: 1}, // Leaves only the first byte of α.
+		{Position: 0, Length: 1}, // Would make the final result valid again.
+	}
+	if got := ApplyPatches("α", patches); got != "" || !utf8.ValidString(got) {
+		t.Fatalf("test setup produced %q, want a valid empty final result", got)
+	}
+	if _, err := ApplyPatchesChecked("α", patches); err == nil {
+		t.Fatal("ApplyPatchesChecked accepted an invalid intermediate result")
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidLaterPatch(t *testing.T) {
+	t.Parallel()
+
+	patches := []NotePatch{
+		{Position: 0, Length: 0, Replacement: "A"},
+		{Position: 2, Length: 1}, // Splits α after the valid insertion.
+	}
+	if _, err := ApplyPatchesChecked("α", patches); err == nil || !strings.Contains(err.Error(), "patch 1") {
+		t.Fatalf("ApplyPatchesChecked error = %v, want invalid patch 1", err)
+	}
+}
+
+func TestApplyPatchesCheckedValidNativeUnicodeDelta(t *testing.T) {
+	t.Parallel()
+
+	got, err := ApplyPatchesChecked("Native Task7 note α 🚀\nSecond line.", []NotePatch{{
+		Position:    26,
+		Length:      5,
+		Replacement: "Update",
+		Checksum:    3672733299,
+	}})
+	if err != nil {
+		t.Fatalf("ApplyPatchesChecked: %v", err)
+	}
+	if got != "Native Task7 note α 🚀\nUpdated line." {
+		t.Fatalf("ApplyPatchesChecked = %q", got)
 	}
 }

--- a/notes_test.go
+++ b/notes_test.go
@@ -45,6 +45,21 @@ func TestNote_ApplyPatch(t *testing.T) {
 	}
 }
 
+func TestNote_ApplyPatch_UsesUTF8ByteOffsets(t *testing.T) {
+	original := "Native Task7 note α 🚀\nSecond line."
+	patch := NotePatch{
+		Position:    26,
+		Length:      5,
+		Replacement: "Update",
+		Checksum:    3672733299,
+	}
+
+	result := ApplyPatches(original, []NotePatch{patch})
+	if result != "Native Task7 note α 🚀\nUpdated line." {
+		t.Errorf("expected native Task7 note replay, got %q", result)
+	}
+}
+
 func TestNote_ApplyPatch_PositionBeyondLength(t *testing.T) {
 	// Patch position is beyond the string — should not panic
 	result := ApplyPatches("", []NotePatch{{Position: 10, Length: 0, Replacement: "hello"}})

--- a/request_regression_test.go
+++ b/request_regression_test.go
@@ -1,0 +1,103 @@
+package thingscloud
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestInvalidRequestIdentifiersReturnErrors(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"Verify", "Items", "Write"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("%s panicked instead of returning a request error: %v", operation, p)
+				}
+			}()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Error("invalid identifier reached the HTTP server")
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+			c := New(server.URL, "bad\nemail", "password")
+			h := c.HistoryWithID("bad\nhistory")
+			h.LatestServerIndex = 42
+			h.LoadedServerIndex = 21
+
+			var err error
+			switch operation {
+			case "Verify":
+				var response *VerifyResponse
+				response, err = c.Verify()
+				if response != nil {
+					t.Error("Verify returned a response for an invalid request")
+				}
+			case "Items":
+				var items []Item
+				var more bool
+				items, more, err = h.Items(ItemsOptions{StartIndex: 21})
+				if items != nil || more {
+					t.Errorf("Items returned (%v, %v) for an invalid request", items, more)
+				}
+			case "Write":
+				err = h.Write(TaskActionItem{
+					Item: Item{UUID: NewUUID(), Kind: ItemKindTask, Action: ItemActionCreated},
+					P:    TaskActionItemPayload{Title: String("test")},
+				})
+			}
+			var urlErr *url.Error
+			if !errors.As(err, &urlErr) {
+				t.Fatalf("%s error = %v, want request URL error", operation, err)
+			}
+			if h.LatestServerIndex != 42 || h.LoadedServerIndex != 21 {
+				t.Errorf("invalid request changed history cursors: %+v", h)
+			}
+		})
+	}
+}
+
+func TestHistoryWritePreservesRequestMetadata(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/version/1/history/history-id/commit" {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+		}
+		for key, want := range map[string]string{
+			"Schema": "301", "Push-Priority": "5", "App-Id": "com.culturedcode.ThingsMac",
+			"Accept": "application/json", "Content-Encoding": "UTF-8",
+			"Content-Type": "application/json; charset=UTF-8", "User-Agent": ThingsUserAgent,
+		} {
+			if got := r.Header.Get(key); got != want {
+				t.Errorf("%s = %q, want %q", key, got, want)
+			}
+		}
+		if r.Header.Get("App-Instance-Id") == "" || r.Header.Get("Things-Client-Info") == "" {
+			t.Error("missing app instance or client info header")
+		}
+		if got := r.URL.Query().Get("ancestor-index"); got != "42" {
+			t.Errorf("ancestor-index = %q, want 42", got)
+		}
+		if got := r.URL.Query().Get("_cnt"); got != "1" {
+			t.Errorf("_cnt = %q, want 1", got)
+		}
+		_, _ = w.Write([]byte(`{"server-head-index":43}`))
+	}))
+	defer server.Close()
+	c := New(server.URL, "test@example.com", "password")
+	h := c.HistoryWithID("history-id")
+	h.LatestServerIndex = 42
+	if err := h.Write(TaskActionItem{
+		Item: Item{UUID: NewUUID(), Kind: ItemKindTask, Action: ItemActionCreated},
+		P:    TaskActionItemPayload{Title: String("test")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if h.LatestServerIndex != 43 {
+		t.Errorf("LatestServerIndex = %d, want 43", h.LatestServerIndex)
+	}
+}

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -146,22 +146,6 @@ func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 		ids := *item.P.ParentTaskIDs
 		t.ParentTaskIDs = ids
 	}
-	if item.P.Note != nil {
-		var noteStr string
-		if err := json.Unmarshal(item.P.Note, &noteStr); err == nil {
-			t.Note = noteStr
-		} else {
-			var note things.Note
-			if err := json.Unmarshal(item.P.Note, &note); err == nil {
-				switch note.Type {
-				case things.NoteTypeFullText:
-					t.Note = note.Value
-				case things.NoteTypeDelta:
-					t.Note = things.ApplyPatches(t.Note, note.Patches)
-				}
-			}
-		}
-	}
 	if item.P.AlarmTimeOffset != nil {
 		t.AlarmTimeOffset = item.P.AlarmTimeOffset
 	}
@@ -261,9 +245,25 @@ func (s *State) Update(items ...things.Item) error {
 	// especially note deltas that would be applied twice on retry.
 	taskPayloads := make([]things.TaskReadPayload, len(items))
 	decodedTaskPayload := make([]bool, len(items))
+	resolvedTaskNotes := make([]string, len(items))
+	resolvedTaskNote := make([]bool, len(items))
+	type noteState struct {
+		value  string
+		exists bool
+	}
+	notes := make(map[string]noteState)
 	for i, rawItem := range items {
 		switch rawItem.Kind {
 		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+			legacy := isLegacyItemKind(rawItem.Kind)
+			id := rawItem.UUID
+			if legacy && things.ValidateUUID(id) != nil {
+				id = things.EncodeLegacyIdentifier(id)
+			}
+			if rawItem.Action == things.ItemActionDeleted {
+				notes[id] = noteState{}
+				continue
+			}
 			if rawItem.Action != things.ItemActionCreated && rawItem.Action != things.ItemActionModified {
 				continue
 			}
@@ -273,6 +273,33 @@ func (s *State) Update(items ...things.Item) error {
 			}
 			taskPayloads[i] = payload
 			decodedTaskPayload[i] = true
+
+			current := ""
+			if state, ok := notes[id]; ok {
+				if state.exists {
+					current = state.value
+				}
+			} else if task := s.Tasks[id]; task != nil {
+				current = task.Note
+			}
+			resolved, err := payload.ResolveNote(current)
+			if err != nil {
+				return err
+			}
+			resolvedTaskNotes[i] = resolved
+			resolvedTaskNote[i] = true
+			notes[id] = noteState{value: resolved, exists: true}
+
+		case things.ItemKindTombstone, things.ItemKindTombstonePlain:
+			var payload things.TombstoneActionItemPayload
+			if err := json.Unmarshal(rawItem.P, &payload); err != nil {
+				continue
+			}
+			oid := payload.DeletedObjectID
+			if isLegacyItemKind(rawItem.Kind) && things.ValidateUUID(oid) != nil {
+				oid = things.EncodeLegacyIdentifier(oid)
+			}
+			notes[oid] = noteState{}
 		}
 	}
 
@@ -303,6 +330,9 @@ func (s *State) Update(items ...things.Item) error {
 				fallthrough
 			case things.ItemActionModified:
 				task := s.updateTask(item)
+				if resolvedTaskNote[i] {
+					task.Note = resolvedTaskNotes[i]
+				}
 				payload.ApplyNulls(task)
 				s.Tasks[item.UUID()] = task
 			case things.ItemActionDeleted:

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -256,7 +256,31 @@ func (s *State) updateTag(item things.TagActionItem) *things.Tag {
 
 // Update applies all items to update the aggregated state
 func (s *State) Update(items ...things.Item) error {
-	for _, rawItem := range items {
+	if err := things.ValidateTaskReadKinds(items); err != nil {
+		return err
+	}
+
+	// Decode every task create/modify before applying any item. A malformed
+	// task payload late in the batch must not leave earlier mutations behind,
+	// especially note deltas that would be applied twice on retry.
+	taskPayloads := make([]things.TaskReadPayload, len(items))
+	decodedTaskPayload := make([]bool, len(items))
+	for i, rawItem := range items {
+		switch rawItem.Kind {
+		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+			if rawItem.Action != things.ItemActionCreated && rawItem.Action != things.ItemActionModified {
+				continue
+			}
+			payload, err := things.DecodeTaskReadPayload(rawItem.P)
+			if err != nil {
+				return err
+			}
+			taskPayloads[i] = payload
+			decodedTaskPayload[i] = true
+		}
+	}
+
+	for i, rawItem := range items {
 		legacy := isLegacyItemKind(rawItem.Kind)
 		// A legacy-kind item whose key already parses as canonical Base58
 		// carries a current-generation identifier and must not be re-derived
@@ -267,10 +291,12 @@ func (s *State) Update(items ...things.Item) error {
 		}
 
 		switch rawItem.Kind {
-		case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 			item := things.TaskActionItem{Item: rawItem}
-			if err := json.Unmarshal(rawItem.P, &item.P); err != nil {
-				continue // Skip items that can't be parsed
+			var payload things.TaskReadPayload
+			if decodedTaskPayload[i] {
+				payload = taskPayloads[i]
+				item.P = payload.TaskActionItemPayload
 			}
 			if legacy {
 				encodeLegacyTaskReferences(&item.P)
@@ -280,7 +306,9 @@ func (s *State) Update(items ...things.Item) error {
 			case things.ItemActionCreated:
 				fallthrough
 			case things.ItemActionModified:
-				s.Tasks[item.UUID()] = s.updateTask(item)
+				task := s.updateTask(item)
+				payload.ApplyNulls(task)
+				s.Tasks[item.UUID()] = task
 			case things.ItemActionDeleted:
 				delete(s.Tasks, item.UUID())
 			default:

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -2,7 +2,6 @@ package memory
 
 import (
 	"encoding/json"
-	// "fmt"
 	"sort"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -162,9 +161,6 @@ func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 				}
 			}
 		}
-	}
-	if item.P.Title != nil {
-		t.Title = *item.P.Title
 	}
 	if item.P.AlarmTimeOffset != nil {
 		t.AlarmTimeOffset = item.P.AlarmTimeOffset

--- a/state/memory/task7_test.go
+++ b/state/memory/task7_test.go
@@ -1,0 +1,248 @@
+package memory
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+const task7Kind things.ItemKind = "Task7"
+
+func taskReadItem(id string, kind things.ItemKind, action things.ItemAction, payload string) things.Item {
+	return things.Item{UUID: id, Kind: kind, Action: action, P: json.RawMessage(payload)}
+}
+
+func requireTask(t *testing.T, state *State, id string) *things.Task {
+	t.Helper()
+	task := state.Tasks[id]
+	if task == nil {
+		t.Fatalf("task %q not found", id)
+	}
+	return task
+}
+
+func TestStateUpdateTask7CreateAndModify(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("task-7", task7Kind, things.ItemActionCreated, `{"tt":"","st":0,"tp":0}`),
+		taskReadItem("task-7", task7Kind, things.ItemActionModified, `{"tt":"New task"}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(state.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(state.Tasks))
+	}
+	task := requireTask(t, state, "task-7")
+	if task.Title != "New task" || task.Schedule != things.TaskScheduleInbox {
+		t.Fatalf("task = title %q, schedule %v; want New task in Inbox", task.Title, task.Schedule)
+	}
+}
+
+func TestStateUpdateTask6AndTask7ShareIdentity(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("same-task", things.ItemKindTask, things.ItemActionCreated, `{"tt":"Task6 title","ss":0}`),
+		taskReadItem("same-task", task7Kind, things.ItemActionModified, `{"tt":"Task7 title","ss":3}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(state.Tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(state.Tasks))
+	}
+	task := requireTask(t, state, "same-task")
+	if task.Title != "Task7 title" || task.Status != things.TaskStatusCompleted {
+		t.Fatalf("mixed-kind task = title %q, status %v", task.Title, task.Status)
+	}
+}
+
+func TestStateUpdateTask7Notes(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("notes", task7Kind, things.ItemActionCreated, `{"nt":{"_t":"Note","t":1,"v":"hello world"}}`),
+		taskReadItem("notes", task7Kind, things.ItemActionModified, `{"nt":{"_t":"Note","t":2,"ps":[{"p":6,"l":5,"r":"Things","ch":0}]}}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := requireTask(t, state, "notes").Note; got != "hello Things" {
+		t.Fatalf("note = %q, want %q", got, "hello Things")
+	}
+}
+
+func TestStateUpdateTask7TitleEmptyAndOmitted(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("title", task7Kind, things.ItemActionCreated, `{"tt":"original"}`),
+		taskReadItem("title", task7Kind, things.ItemActionModified, `{"ss":3}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := requireTask(t, state, "title").Title; got != "original" {
+		t.Fatalf("title = %q after omitted update, want original", got)
+	}
+	if err := state.Update(
+		taskReadItem("title", task7Kind, things.ItemActionModified, `{"tt":""}`),
+		taskReadItem("title", task7Kind, things.ItemActionModified, `{"ss":0}`),
+	); err != nil {
+		t.Fatalf("empty title update: %v", err)
+	}
+	if got := requireTask(t, state, "title").Title; got != "" {
+		t.Fatalf("title = %q, want explicit empty title preserved across omitted update", got)
+	}
+}
+
+func TestStateUpdateTask7NullableFields(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("nullable", task7Kind, things.ItemActionCreated, `{
+			"md":1700000000,"sr":1700000100,"sp":1700000200,"dd":1700000300,"ato":15,
+			"ar":["area"],"pr":["project"],"agr":["heading"],"tg":["tag"],"rt":["repeat"],"dl":["delegate"]
+		}`),
+		taskReadItem("nullable", task7Kind, things.ItemActionModified, `{
+			"md":null,"sr":null,"sp":null,"dd":null,"ato":null,
+			"ar":null,"pr":[],"agr":null,"tg":[],"rt":null,"dl":[]
+		}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	task := requireTask(t, state, "nullable")
+	if task.ModificationDate != nil || task.ScheduledDate != nil || task.CompletionDate != nil || task.DeadlineDate != nil || task.AlarmTimeOffset != nil {
+		t.Fatalf("explicit null did not clear dates/alarm: %+v", task)
+	}
+	if task.AreaIDs != nil || task.ActionGroupIDs != nil || task.RecurrenceIDs != nil {
+		t.Fatalf("null relationships were not cleared to nil: ar=%v agr=%v rt=%v", task.AreaIDs, task.ActionGroupIDs, task.RecurrenceIDs)
+	}
+	if len(task.ParentTaskIDs) != 0 || len(task.TagIDs) != 0 || len(task.DelegateIDs) != 0 {
+		t.Fatalf("empty relationships were not cleared: pr=%v tg=%v dl=%v", task.ParentTaskIDs, task.TagIDs, task.DelegateIDs)
+	}
+}
+
+func TestStateUpdateTask7ScheduleStatusTrashAndDeletion(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		t.Run(string(payload), func(t *testing.T) {
+			t.Parallel()
+			state := NewState()
+			if err := state.Update(taskReadItem("lifecycle", task7Kind, things.ItemActionCreated, `{"st":2,"ss":2,"tr":true}`)); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			task := requireTask(t, state, "lifecycle")
+			if task.Schedule != things.TaskScheduleSomeday || task.Status != things.TaskStatusCanceled || !task.InTrash {
+				t.Fatalf("lifecycle fields = schedule %v status %v trash %v", task.Schedule, task.Status, task.InTrash)
+			}
+			if err := state.Update(things.Item{UUID: "lifecycle", Kind: task7Kind, Action: things.ItemActionDeleted, P: payload}); err != nil {
+				t.Fatalf("delete: %v", err)
+			}
+			if _, ok := state.Tasks["lifecycle"]; ok {
+				t.Fatal("deleted Task7 remains in state")
+			}
+		})
+	}
+}
+
+func TestStateUpdateTask7SyntheticProjectAndHeading(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	err := state.Update(
+		taskReadItem("project", task7Kind, things.ItemActionCreated, `{"tt":"Project","tp":1}`),
+		taskReadItem("heading", task7Kind, things.ItemActionCreated, `{"tt":"Heading","tp":2,"pr":["project"]}`),
+		taskReadItem("child", task7Kind, things.ItemActionCreated, `{"tt":"Child","tp":0,"pr":["project"],"agr":["heading"]}`),
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := state.Projects(); len(got) != 1 || got[0].UUID != "project" {
+		t.Fatalf("Projects = %+v", got)
+	}
+	if got := state.Headings("project"); len(got) != 1 || got[0].UUID != "heading" {
+		t.Fatalf("Headings = %+v", got)
+	}
+	if got := state.TasksByHeading("heading", ListOption{}); len(got) != 1 || got[0].UUID != "child" {
+		t.Fatalf("TasksByHeading = %+v", got)
+	}
+}
+
+func TestStateUpdateRejectsFutureTaskKindBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	const privateUUID = "PRIVATE-UUID-SHOULD-NOT-LEAK"
+	const privatePayload = "PRIVATE-PAYLOAD-SHOULD-NOT-LEAK"
+	state := NewState()
+	if err := state.Update(taskReadItem("notes", task7Kind, things.ItemActionCreated, `{"nt":"base"}`)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := state.Update(
+		taskReadItem("notes", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":4,"l":0,"r":" once","ch":0}]}}`),
+		taskReadItem(privateUUID, things.ItemKind("Task8"), things.ItemActionCreated, `{"tt":"`+privatePayload+`"}`),
+	)
+	if err == nil {
+		t.Fatal("Update accepted unsupported Task8")
+	}
+	if got := requireTask(t, state, "notes").Note; got != "base" {
+		t.Fatalf("batch mutated before unsupported kind error: note = %q", got)
+	}
+	if strings.Contains(err.Error(), privateUUID) || strings.Contains(err.Error(), privatePayload) {
+		t.Fatalf("error leaked item details: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Task8") {
+		t.Fatalf("error %q does not identify unsupported kind", err)
+	}
+}
+
+func TestStateUpdateRejectsMalformedTaskPayloadBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	const privateUUID = "PRIVATE-MALFORMED-UUID"
+	const privatePayload = "PRIVATE-MALFORMED-PAYLOAD"
+	state := NewState()
+	if err := state.Update(taskReadItem("existing", task7Kind, things.ItemActionCreated, `{"tt":"before"}`)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := state.Update(
+		taskReadItem("existing", task7Kind, things.ItemActionModified, `{"tt":"after"}`),
+		taskReadItem(privateUUID, task7Kind, things.ItemActionCreated, `"`+privatePayload+`"`),
+	)
+	if err == nil {
+		t.Fatal("Update accepted non-object Task7 payload")
+	}
+	if got := requireTask(t, state, "existing").Title; got != "before" {
+		t.Fatalf("batch mutated before malformed payload error: title = %q", got)
+	}
+	if strings.Contains(err.Error(), privateUUID) || strings.Contains(err.Error(), privatePayload) {
+		t.Fatalf("error leaked item details: %v", err)
+	}
+}
+
+func TestStateUpdateTask7DatePrecision(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	if err := state.Update(taskReadItem("date", task7Kind, things.ItemActionCreated, `{"sr":1700000000.25}`)); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	want := time.Unix(1700000000, 250000000).UTC()
+	if got := requireTask(t, state, "date").ScheduledDate; got == nil || !got.Equal(want) {
+		t.Fatalf("scheduled date = %v, want %v", got, want)
+	}
+}

--- a/state/memory/task7_test.go
+++ b/state/memory/task7_test.go
@@ -234,6 +234,121 @@ func TestStateUpdateRejectsMalformedTaskPayloadBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestStateUpdateRejectsInvalidNoteDeltaBeforeBatchMutation(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	if err := state.Update(
+		taskReadItem("first", task7Kind, things.ItemActionCreated, `{"tt":"before","nt":"safe"}`),
+		taskReadItem("unicode", task7Kind, things.ItemActionCreated, `{"nt":"α"}`),
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := state.Update(
+		taskReadItem("first", task7Kind, things.ItemActionModified, `{"tt":"after","nt":"changed"}`),
+		taskReadItem("created", task7Kind, things.ItemActionCreated, `{"tt":"must roll back"}`),
+		taskReadItem("unicode", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+	)
+	if err == nil {
+		t.Fatal("Update accepted a note delta that produced invalid UTF-8")
+	}
+	if got := requireTask(t, state, "first"); got.Title != "before" || got.Note != "safe" {
+		t.Fatalf("earlier task mutated: %+v", got)
+	}
+	if _, ok := state.Tasks["created"]; ok {
+		t.Fatal("earlier task create survived rejected batch")
+	}
+	if got := requireTask(t, state, "unicode").Note; got != "α" {
+		t.Fatalf("invalid delta changed note to %q", got)
+	}
+}
+
+func TestStateUpdateNotePreflightTracksEarlierBatchEvents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create then malformed delta", func(t *testing.T) {
+		state := NewState()
+		err := state.Update(
+			taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`),
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		)
+		if err == nil {
+			t.Fatal("Update accepted malformed delta against an earlier create")
+		}
+		if _, ok := state.Tasks["note"]; ok {
+			t.Fatal("create survived rejected batch")
+		}
+	})
+
+	t.Run("valid edit then malformed delta", func(t *testing.T) {
+		state := NewState()
+		if err := state.Update(taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		err := state.Update(
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"A"}]}}`),
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":2,"l":1,"r":""}]}}`),
+		)
+		if err == nil {
+			t.Fatal("Update accepted malformed delta against an earlier edit")
+		}
+		if got := requireTask(t, state, "note").Note; got != "α" {
+			t.Fatalf("batch changed note to %q", got)
+		}
+	})
+
+	t.Run("delete then delta starts from empty note", func(t *testing.T) {
+		state := NewState()
+		if err := state.Update(taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.Update(
+			taskReadItem("note", task7Kind, things.ItemActionDeleted, `{}`),
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		); err != nil {
+			t.Fatalf("delta after delete should use an empty note: %v", err)
+		}
+		if got := requireTask(t, state, "note").Note; got != "" {
+			t.Fatalf("note after delete and clamped delta = %q", got)
+		}
+	})
+
+	t.Run("tombstone then delta starts from empty note", func(t *testing.T) {
+		state := NewState()
+		if err := state.Update(taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.Update(
+			things.Item{UUID: "tombstone", Kind: things.ItemKindTombstone, P: json.RawMessage(`{"dloid":"note"}`)},
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		); err != nil {
+			t.Fatalf("delta after tombstone should use an empty note: %v", err)
+		}
+		if got := requireTask(t, state, "note").Note; got != "" {
+			t.Fatalf("note after tombstone and clamped delta = %q", got)
+		}
+	})
+
+	t.Run("legacy tombstone and task share normalized identity", func(t *testing.T) {
+		const legacyID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+		currentID := things.EncodeLegacyIdentifier(legacyID)
+		state := NewState()
+		if err := state.Update(taskReadItem(legacyID, things.ItemKindTaskPlain, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.Update(
+			things.Item{UUID: "legacy-tombstone", Kind: things.ItemKindTombstonePlain, P: json.RawMessage(`{"dloid":"` + legacyID + `"}`)},
+			taskReadItem(legacyID, things.ItemKindTaskPlain, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		); err != nil {
+			t.Fatalf("delta after legacy tombstone should use an empty note: %v", err)
+		}
+		if got := requireTask(t, state, currentID).Note; got != "" {
+			t.Fatalf("note after legacy tombstone and clamped delta = %q", got)
+		}
+	})
+}
+
 func TestStateUpdateTask7DatePrecision(t *testing.T) {
 	t.Parallel()
 

--- a/sync/coverage_test.go
+++ b/sync/coverage_test.go
@@ -389,47 +389,10 @@ func TestProcessTagChecklistTombstone(t *testing.T) {
 	})
 }
 
-// TestProcessNotePayloads covers parseNotePayload for plain-string, full-text,
-// and delta note representations.
+// TestProcessNotePayloads covers delivery of a decoded note through the
+// transactional sync path.
 func TestProcessNotePayloads(t *testing.T) {
 	t.Parallel()
-
-	t.Run("plain string note", func(t *testing.T) {
-		t.Parallel()
-		got := parseNotePayload("old", json.RawMessage(`"a plain note"`))
-		if got != "a plain note" {
-			t.Errorf("expected plain string note, got %q", got)
-		}
-	})
-
-	t.Run("full text note", func(t *testing.T) {
-		t.Parallel()
-		raw, _ := json.Marshal(things.Note{Type: things.NoteTypeFullText, Value: "full replacement"})
-		got := parseNotePayload("old", raw)
-		if got != "full replacement" {
-			t.Errorf("expected full-text replacement, got %q", got)
-		}
-	})
-
-	t.Run("delta note applies patches", func(t *testing.T) {
-		t.Parallel()
-		raw, _ := json.Marshal(things.Note{
-			Type:    things.NoteTypeDelta,
-			Patches: []things.NotePatch{{Position: 0, Length: 0, Replacement: "Hi "}},
-		})
-		got := parseNotePayload("there", raw)
-		if got != "Hi there" {
-			t.Errorf("expected patched note 'Hi there', got %q", got)
-		}
-	})
-
-	t.Run("invalid note keeps current value", func(t *testing.T) {
-		t.Parallel()
-		got := parseNotePayload("unchanged", json.RawMessage(`12345`))
-		if got != "unchanged" {
-			t.Errorf("expected current note preserved, got %q", got)
-		}
-	})
 
 	t.Run("note delivered through processItems", func(t *testing.T) {
 		t.Parallel()

--- a/sync/process.go
+++ b/sync/process.go
@@ -20,8 +20,8 @@ var itemKindArea2 = things.ItemKindArea
 // processItems processes a batch of Things Cloud items into semantic changes.
 // The baseIndex is the starting server index for this batch.
 func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, error) {
-	if len(items) == 0 {
-		return nil, nil
+	if err := things.ValidateTaskReadKinds(items); err != nil {
+		return nil, err
 	}
 
 	// Wrap entire batch in a transaction for massive performance improvement
@@ -47,7 +47,12 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 
 		changes, err := s.processItem(item, serverIndex, ts)
 		if err != nil {
-			return nil, fmt.Errorf("processing item %s: %w", item.UUID, err)
+			return nil, fmt.Errorf("processing item at server index %d: %w", serverIndex, err)
+		}
+		// Recovery replays old operations to reconstruct state, but their
+		// audit records and notifications already belong to the live database.
+		if serverIndex < s.replayLogCutoff {
+			continue
 		}
 
 		// Log each change
@@ -80,7 +85,7 @@ func (s *Syncer) processItems(items []things.Item, baseIndex int) ([]Change, err
 // processItem routes an item to the correct handler based on its Kind.
 func (s *Syncer) processItem(item things.Item, serverIndex int, ts time.Time) ([]Change, error) {
 	switch item.Kind {
-	case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+	case things.ItemKindTask7, things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 		return s.processTaskItem(item, serverIndex, ts)
 	case itemKindArea2, things.ItemKindArea3, things.ItemKindAreaPlain:
 		return s.processAreaItem(item, serverIndex, ts)
@@ -109,7 +114,7 @@ func (s *Syncer) processTaskItem(item things.Item, serverIndex int, ts time.Time
 	// Get the old state
 	old, err := s.getTask(item.UUID)
 	if err != nil {
-		return nil, fmt.Errorf("getting task %s: %w", item.UUID, err)
+		return nil, fmt.Errorf("getting task: %w", err)
 	}
 
 	// Handle deletion
@@ -123,13 +128,14 @@ func (s *Syncer) processTaskItem(item things.Item, serverIndex int, ts time.Time
 	}
 
 	// Unmarshal the payload
-	var payload things.TaskActionItemPayload
-	if err := json.Unmarshal(item.P, &payload); err != nil {
+	payload, err := things.DecodeTaskReadPayload(item.P)
+	if err != nil {
 		return nil, fmt.Errorf("unmarshaling task payload: %w", err)
 	}
 
 	// Apply payload to build new state
-	newTask := applyTaskPayload(old, item.UUID, payload)
+	newTask := applyTaskPayload(old, item.UUID, payload.TaskActionItemPayload)
+	payload.ApplyNulls(newTask)
 
 	// Save the new state
 	if err := s.saveTask(newTask); err != nil {
@@ -414,10 +420,6 @@ func applyTaskPayload(old *things.Task, uuid string, p things.TaskActionItemPayl
 	}
 	if p.ScheduledDate != nil {
 		t.ScheduledDate = p.ScheduledDate.Time()
-	}
-	if p.TaskIR != nil {
-		// TaskIR (tir) is an alternative scheduled date field
-		t.ScheduledDate = p.TaskIR.Time()
 	}
 	if p.CompletionDate != nil {
 		t.CompletionDate = p.CompletionDate.Time()

--- a/sync/process.go
+++ b/sync/process.go
@@ -135,6 +135,11 @@ func (s *Syncer) processTaskItem(item things.Item, serverIndex int, ts time.Time
 
 	// Apply payload to build new state
 	newTask := applyTaskPayload(old, item.UUID, payload.TaskActionItemPayload)
+	resolvedNote, err := payload.ResolveNote(newTask.Note)
+	if err != nil {
+		return nil, err
+	}
+	newTask.Note = resolvedNote
 	payload.ApplyNulls(newTask)
 
 	// Save the new state
@@ -467,43 +472,5 @@ func applyTaskPayload(old *things.Task, uuid string, p things.TaskActionItemPayl
 		t.DelegateIDs = *p.DelegateIDs
 	}
 
-	// Handle Note specially: can be string or Note struct with patches
-	if len(p.Note) > 0 {
-		t.Note = parseNotePayload(t.Note, p.Note)
-	}
-
 	return t
-}
-
-// parseNotePayload parses the note field from a task payload.
-// The note can be either a plain string or a structured Note object with patches.
-func parseNotePayload(currentNote string, raw json.RawMessage) string {
-	// First, try to unmarshal as a string (most common case)
-	var noteStr string
-	if err := json.Unmarshal(raw, &noteStr); err == nil {
-		return noteStr
-	}
-
-	// Try to unmarshal as a structured Note
-	var note things.Note
-	if err := json.Unmarshal(raw, &note); err != nil {
-		// If both fail, return the current note unchanged
-		return currentNote
-	}
-
-	// Handle based on note type
-	switch note.Type {
-	case things.NoteTypeFullText:
-		// Full text replacement
-		return note.Value
-	case things.NoteTypeDelta:
-		// Apply patches to current note
-		return things.ApplyPatches(currentNote, note.Patches)
-	default:
-		// Unknown type, return value if present
-		if note.Value != "" {
-			return note.Value
-		}
-		return currentNote
-	}
 }

--- a/sync/replay.go
+++ b/sync/replay.go
@@ -1,0 +1,323 @@
+package sync
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+// Replay semantics evolve independently of the physical schema. Opening an
+// old database records its generation without clearing any usable offline data.
+func (s *Syncer) ensureTaskReplayState() error {
+	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS task_replay_state (
+		id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL
+	)`)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`INSERT OR IGNORE INTO task_replay_state (id, version)
+		SELECT 1, CASE WHEN
+			EXISTS(SELECT 1 FROM sync_state) OR EXISTS(SELECT 1 FROM tasks) OR
+			EXISTS(SELECT 1 FROM areas) OR EXISTS(SELECT 1 FROM tags) OR
+			EXISTS(SELECT 1 FROM checklist_items) OR EXISTS(SELECT 1 FROM change_log) OR
+			EXISTS(SELECT 1 FROM task_tags) OR EXISTS(SELECT 1 FROM area_tags)
+		THEN 1 ELSE ? END`, things.TaskReplayVersion)
+	return err
+}
+
+func (s *Syncer) taskReplayVersion() (int, error) {
+	var version int
+	err := s.db.QueryRow(`SELECT version FROM task_replay_state WHERE id = 1`).Scan(&version)
+	return version, err
+}
+
+// backupForReplay makes a consistent SQLite snapshot including committed WAL
+// content. The reserved, exclusive filename is permission restricted before
+// SQLite writes any data. Every attempt snapshots the actual current database;
+// only a byte-identical, validated retained snapshot can replace the new copy.
+// This bounds retained copies across identical retries, including process
+// restarts, while protecting externally restored databases with the same cursor.
+// Each retry still requires temporary space and I/O for a complete snapshot.
+// In-memory/temporary databases have no persistent source file to protect;
+// their original state stays in memory until the final atomic installation.
+func (s *Syncer) backupForReplay() error {
+	rows, err := s.rawDB.Query(`PRAGMA database_list`)
+	if err != nil {
+		return err
+	}
+	var path string
+	for rows.Next() {
+		var seq int
+		var name, file string
+		if err := rows.Scan(&seq, &name, &file); err != nil {
+			rows.Close()
+			return err
+		}
+		if name == "main" {
+			path = file
+		}
+	}
+	err = rows.Err()
+	rows.Close()
+	if err != nil || path == "" {
+		return err
+	}
+	before, err := readReplayBackupState(s.rawDB)
+	if err != nil {
+		return err
+	}
+	// Hash the tuple so backup filenames never expose the private history ID.
+	key := sha256.Sum256([]byte(fmt.Sprintf("%q:%d:%d", before.historyID, before.cursor, before.generation)))
+	prefix := fmt.Sprintf("%s.task7-backup-%x-", filepath.Base(path), key)
+	// Capture candidates before creating our file: never deduplicate against
+	// ourselves or a younger concurrent attempt that could also be removed.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), prefix+"*")
+	if err != nil {
+		return err
+	}
+	backupPath := f.Name()
+	if err := f.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if _, err := s.rawDB.Exec(`VACUUM INTO ?`, backupPath); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if !validReplayBackup(backupPath, before) {
+		// This file was exclusively created by this attempt. Replay has not
+		// started, so removing an invalid snapshot cannot remove its safety net.
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("task replay backup failed integrity or source-state validation")
+	}
+	currentHash, err := replayBackupHash(backupPath)
+	if err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	duplicate := false
+	for _, entry := range entries {
+		candidate := filepath.Join(filepath.Dir(path), entry.Name())
+		if !strings.HasPrefix(entry.Name(), prefix) || !validReplayBackup(candidate, before) {
+			continue
+		}
+		candidateHash, err := replayBackupHash(candidate)
+		if err == nil && candidateHash == currentHash {
+			duplicate = true
+			break
+		}
+	}
+	if err := s.checkReplayBackupState(before); err != nil {
+		_ = os.Remove(backupPath)
+		return err
+	}
+	if duplicate {
+		// Delete only this attempt's exclusive snapshot, after proving a valid
+		// retained copy contains every byte. Never remove a previous backup.
+		return os.Remove(backupPath)
+	}
+	return nil
+}
+
+func replayBackupHash(path string) ([sha256.Size]byte, error) {
+	var sum [sha256.Size]byte
+	f, err := os.Open(path)
+	if err != nil {
+		return sum, err
+	}
+	defer f.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return sum, err
+	}
+	copy(sum[:], hash.Sum(nil))
+	return sum, nil
+}
+
+type replayBackupState struct {
+	historyID          string
+	cursor, generation int
+}
+
+// One SELECT observes a coherent metadata tuple even if another writer syncs.
+func readReplayBackupState(db dbExecutor) (replayBackupState, error) {
+	var state replayBackupState
+	err := db.QueryRow(`SELECT COALESCE(s.history_id, ''), COALESCE(s.server_index, 0), r.version
+		FROM task_replay_state r LEFT JOIN sync_state s ON s.id = r.id WHERE r.id = 1`).Scan(&state.historyID, &state.cursor, &state.generation)
+	return state, err
+}
+
+func (s *Syncer) checkReplayBackupState(before replayBackupState) error {
+	after, err := readReplayBackupState(s.rawDB)
+	if err != nil {
+		return err
+	}
+	if after != before {
+		return fmt.Errorf("sync state changed while backing up task replay; retry sync")
+	}
+	return nil
+}
+
+func validReplayBackup(path string, expected replayBackupState) bool {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+		return false
+	}
+	// Standalone VACUUM snapshots need no WAL. Read-only immutable mode avoids
+	// modifying the retained snapshot or creating journal/SHM sidecar files.
+	dsn := (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro&immutable=1"}).String()
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+	var integrity string
+	if err := db.QueryRow(`PRAGMA integrity_check`).Scan(&integrity); err != nil || integrity != "ok" {
+		return false
+	}
+	actual, err := readReplayBackupState(db)
+	return err == nil && actual == expected
+}
+
+func (s *Syncer) recoverTaskReplay(historyID string, cutoff, generation, target int) ([]Change, error) {
+	if cutoff < 0 || target < cutoff {
+		return nil, fmt.Errorf("cannot recover task replay: server cursor %d is behind stored cursor %d", target, cutoff)
+	}
+	if err := s.backupForReplay(); err != nil {
+		return nil, fmt.Errorf("backing up task replay database: %w", err)
+	}
+	staged, err := Open(":memory:", s.client)
+	if err != nil {
+		return nil, fmt.Errorf("opening task replay staging database: %w", err)
+	}
+	defer staged.Close()
+	// Staging never runs nested state queries; pin its private in-memory DB
+	// to one connection without restricting live readers of a file database.
+	staged.rawDB.SetMaxOpenConns(1)
+	staged.history = s.client.HistoryWithID(s.history.ID)
+	staged.replayLogCutoff = cutoff
+	var changes []Change
+	start := 0
+	for start < target {
+		var items []things.Item
+		var more bool
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			items, more, err = staged.history.Items(things.ItemsOptions{StartIndex: start})
+			if err == nil || !isRetryableError(err) {
+				break
+			}
+			time.Sleep(retryBaseWait * time.Duration(1<<attempt))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("fetching task replay: %w", err)
+		}
+		if err := validateReplayPage(staged.history, start, target); err != nil {
+			return nil, err
+		}
+		batchChanges, err := staged.processItems(items, start)
+		if err != nil {
+			return nil, fmt.Errorf("replaying task history: %w", err)
+		}
+		changes = append(changes, batchChanges...)
+		start = staged.history.LoadedServerIndex
+		// Include growth observed in a page, following complete outer batches.
+		if more {
+			target = staged.history.LatestServerIndex
+		}
+	}
+	if err := s.installTaskReplay(staged, historyID, cutoff, generation, start); err != nil {
+		return nil, fmt.Errorf("installing task replay: %w", err)
+	}
+	return changes, nil
+}
+
+// installTaskReplay preserves the active WAL database and every original audit
+// row. Reading the guard and replacing tables in one transaction makes a
+// concurrent advance either fail the guard or fail SQLite's write upgrade.
+func (s *Syncer) installTaskReplay(staged *Syncer, historyID string, cutoff, generation, next int) error {
+	tx, err := s.rawDB.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	guard := &Syncer{db: tx}
+	actualHistory, actualIndex, err := guard.getSyncState()
+	if err != nil {
+		return err
+	}
+	actualGeneration, err := guard.taskReplayVersion()
+	if err != nil {
+		return err
+	}
+	if actualHistory != historyID || actualIndex != cutoff || actualGeneration != generation {
+		return fmt.Errorf("sync state changed during task replay; retry sync")
+	}
+	for _, table := range []string{"task_tags", "area_tags", "checklist_items", "tasks", "areas", "tags"} {
+		if _, err := tx.Exec(`DELETE FROM ` + table); err != nil {
+			return err
+		}
+		if err := copyReplayRows(tx, staged.rawDB, table, "*"); err != nil {
+			return err
+		}
+	}
+	// Omit staging IDs so SQLite allocates new IDs after the retained history.
+	if err := copyReplayRows(tx, staged.rawDB, "change_log", "server_index,synced_at,change_type,entity_type,entity_uuid,payload"); err != nil {
+		return err
+	}
+	if err := guard.saveSyncState(staged.history.ID, next); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE task_replay_state SET version = ? WHERE id = 1`, things.TaskReplayVersion); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// Only fixed internal table/column names reach this row copier. Copying the
+// complete stored rows also retains deleted flags and junction relationships.
+func copyReplayRows(tx *sql.Tx, staged *sql.DB, table, columns string) error {
+	query := `SELECT ` + columns + ` FROM ` + table
+	if table == "change_log" {
+		query += " ORDER BY id"
+	}
+	rows, err := staged.Query(query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	names, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = `"` + name + `"`
+	}
+	query = `INSERT INTO ` + table + ` (` + strings.Join(quoted, ",") + `) VALUES (` + strings.TrimSuffix(strings.Repeat("?,", len(names)), ",") + `)`
+	for rows.Next() {
+		values := make([]any, len(names))
+		refs := make([]any, len(names))
+		for i := range values {
+			refs[i] = &values[i]
+		}
+		if err := rows.Scan(refs...); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(query, values...); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}

--- a/sync/replay_backup_test.go
+++ b/sync/replay_backup_test.go
@@ -1,0 +1,301 @@
+package sync
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+func replayBackupFiles(t *testing.T, path string) []string {
+	t.Helper()
+	files, err := filepath.Glob(path + ".task7-backup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+func TestReplayBackupReusedAcrossFailedRetriesAndReopen(t *testing.T) {
+	for _, failure := range []string{"fetch", "decode"} {
+		t.Run(failure, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/items") {
+					fmt.Fprint(w, `{"latest-server-index":2}`)
+					return
+				}
+				if failure == "fetch" {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":1,"p":17}}],"current-item-index":2}`)
+			}))
+			defer server.Close()
+			path := filepath.Join(t.TempDir(), "live.db")
+			client := things.New(server.URL, "test@example.com", "password")
+			s := legacyReplayDB(t, path, client, 2)
+			var original []byte
+			for attempt := 0; attempt < 4; attempt++ {
+				if _, err := s.Sync(); err == nil {
+					t.Fatal("expected replay failure")
+				}
+				files := replayBackupFiles(t, path)
+				if len(files) != 1 {
+					t.Fatalf("attempt %d created %d backups", attempt, len(files))
+				}
+				data, err := os.ReadFile(files[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+				if attempt == 0 {
+					original = data
+				} else if !bytes.Equal(original, data) {
+					t.Fatal("reused backup changed")
+				}
+				if err := s.Close(); err != nil {
+					t.Fatal(err)
+				}
+				s, err = Open(path, client)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			defer s.Close()
+			got, err := s.getTask("task")
+			if err != nil || got.Title != "old" || s.LastSyncedIndex() != 2 {
+				t.Fatalf("failed retries changed state: %+v %v", got, err)
+			}
+		})
+	}
+}
+
+func TestReplayBackupNewCursorGetsNewSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	oldFiles := replayBackupFiles(t, path)
+	oldBytes, err := os.ReadFile(oldFiles[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.saveSyncState("history", 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if files := replayBackupFiles(t, path); len(files) != 2 {
+		t.Fatalf("want one snapshot per cursor, got %v", files)
+	}
+	got, err := os.ReadFile(oldFiles[0])
+	if err != nil || !bytes.Equal(oldBytes, got) {
+		t.Fatalf("previous backup changed: %v", err)
+	}
+}
+
+func TestReplayBackupCorruptCandidateIsPreservedAndNotReused(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	files := replayBackupFiles(t, path)
+	corrupt := []byte("user existing or damaged backup")
+	if err := os.WriteFile(files[0], corrupt, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if all := replayBackupFiles(t, path); len(all) != 2 {
+		t.Fatalf("want corrupt original plus one valid backup, got %v", all)
+	}
+	got, err := os.ReadFile(files[0])
+	if err != nil || !bytes.Equal(corrupt, got) {
+		t.Fatalf("corrupt original overwritten: %v", err)
+	}
+}
+
+func TestReplayBackupUnsafeCandidatesAreNotReused(t *testing.T) {
+	for _, condition := range []string{"metadata", "symlink", "permissions"} {
+		t.Run(condition, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "live.db")
+			s := legacyReplayDB(t, path, nil, 2)
+			defer s.Close()
+			if err := s.backupForReplay(); err != nil {
+				t.Fatal(err)
+			}
+			candidate := replayBackupFiles(t, path)[0]
+			switch condition {
+			case "metadata":
+				db, err := sql.Open("sqlite", candidate)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := db.Exec(`UPDATE sync_state SET history_id='other-history'`); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Close(); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink":
+				foreign := filepath.Join(filepath.Dir(path), "foreign.db")
+				if err := os.Rename(candidate, foreign); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(foreign, candidate); err != nil {
+					t.Fatal(err)
+				}
+			case "permissions":
+				if err := os.Chmod(candidate, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := os.ReadFile(candidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := s.backupForReplay(); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.backupForReplay(); err != nil {
+				t.Fatal(err)
+			}
+			if files := replayBackupFiles(t, path); len(files) != 2 {
+				t.Fatalf("unsafe candidate reused or retries unbounded: %v", files)
+			}
+			after, err := os.ReadFile(candidate)
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("unsafe candidate changed: %v", err)
+			}
+			if condition == "symlink" {
+				info, err := os.Lstat(candidate)
+				if err != nil || info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("symlink changed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestReplayBackupSourceGuardRejectsConcurrentAdvance(t *testing.T) {
+	for _, mutation := range []string{`UPDATE sync_state SET server_index=3`, `UPDATE sync_state SET history_id='other-history'`, `UPDATE task_replay_state SET version=2`} {
+		t.Run(mutation, func(t *testing.T) {
+			s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), nil, 2)
+			defer s.Close()
+			before, err := readReplayBackupState(s.rawDB)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.rawDB.Exec(mutation); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.checkReplayBackupState(before); err == nil {
+				t.Fatal("concurrent source advance accepted")
+			}
+		})
+	}
+}
+
+func TestReplayBackupSameTupleChangedAuditGetsCurrentSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	original := replayBackupFiles(t, path)[0]
+	originalBytes, err := os.ReadFile(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A restored/replaced database can have the identical history/cursor/read
+	// generation but a different audit trail. Metadata alone cannot identify it.
+	if _, err := s.rawDB.Exec(`UPDATE change_log SET id=84, synced_at=456, payload='{"restored":true}' WHERE id=41`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	files := replayBackupFiles(t, path)
+	if len(files) != 2 {
+		t.Fatalf("want snapshots of both distinct states, got %v", files)
+	}
+	for _, file := range files {
+		if file == original {
+			continue
+		}
+		db, err := sql.Open("sqlite", file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var id, syncedAt int
+		var payload string
+		if err := db.QueryRow(`SELECT id, synced_at, payload FROM change_log`).Scan(&id, &syncedAt, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if id != 84 || syncedAt != 456 || payload != `{"restored":true}` {
+			t.Fatalf("backup does not protect current audit: %d %d %s", id, syncedAt, payload)
+		}
+	}
+	after, err := os.ReadFile(original)
+	if err != nil || !bytes.Equal(originalBytes, after) {
+		t.Fatalf("original backup changed: %v", err)
+	}
+}
+
+func TestReplayBackupFailurePreservesRetainedSnapshot(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires effective filesystem permission checks")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "live.db")
+	s := legacyReplayDB(t, path, nil, 2)
+	defer s.Close()
+	if err := s.backupForReplay(); err != nil {
+		t.Fatal(err)
+	}
+	retained := replayBackupFiles(t, path)[0]
+	before, err := os.ReadFile(retained)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0700); err != nil {
+			t.Error(err)
+		}
+	}()
+	if err := s.backupForReplay(); err == nil {
+		t.Fatal("reused metadata without obtaining a current snapshot")
+	}
+	after, err := os.ReadFile(retained)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatalf("backup failure damaged retained snapshot: %v", err)
+	}
+}

--- a/sync/robustness_test.go
+++ b/sync/robustness_test.go
@@ -59,6 +59,65 @@ func TestSync_CursorSurvivesMidSyncFailure(t *testing.T) {
 	}
 }
 
+func TestSync_InvalidNoteDeltaRollsBackBatchAndCursor(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprint(w, `{"items":[{"existing":{"e":"Task7","t":1,"p":{"tt":"after"}}},{"created":{"e":"Task7","t":0,"p":{"tt":"must roll back"}}},{"unicode":{"e":"Task7","t":1,"p":{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}}}],"current-item-index":4,"schema":301}`)
+			return
+		}
+		fmt.Fprint(w, `{"latest-server-index":4,"latest-schema-version":301}`)
+	}))
+	defer server.Close()
+
+	client := things.New(server.URL, "test@example.com", "password")
+	syncer, err := Open(filepath.Join(t.TempDir(), "test.db"), client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	seed := []things.Item{
+		{UUID: "existing", Kind: things.ItemKindTask7, Action: things.ItemActionCreated, P: json.RawMessage(`{"tt":"before"}`)},
+		{UUID: "unicode", Kind: things.ItemKindTask7, Action: things.ItemActionCreated, P: json.RawMessage(`{"nt":"α"}`)},
+	}
+	if _, err := syncer.processItems(seed, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := syncer.saveSyncState("history", 1); err != nil {
+		t.Fatalf("saveSyncState: %v", err)
+	}
+	var auditBefore int
+	if err := syncer.db.QueryRow(`SELECT COUNT(*) FROM change_log`).Scan(&auditBefore); err != nil {
+		t.Fatalf("count audit before: %v", err)
+	}
+
+	if _, err := syncer.Sync(); err == nil {
+		t.Fatal("Sync accepted invalid note delta")
+	}
+	if got := syncer.LastSyncedIndex(); got != 1 {
+		t.Fatalf("cursor = %d, want 1", got)
+	}
+	var auditAfter int
+	if err := syncer.db.QueryRow(`SELECT COUNT(*) FROM change_log`).Scan(&auditAfter); err != nil {
+		t.Fatalf("count audit after: %v", err)
+	}
+	if auditAfter != auditBefore {
+		t.Fatalf("audit rows = %d, want unchanged %d", auditAfter, auditBefore)
+	}
+	if got, err := syncer.getTask("existing"); err != nil || got == nil || got.Title != "before" {
+		t.Fatalf("existing task changed: %+v, err=%v", got, err)
+	}
+	if got, err := syncer.getTask("created"); err != nil || got != nil {
+		t.Fatalf("created task survived rollback: %+v, err=%v", got, err)
+	}
+	if got, err := syncer.getTask("unicode"); err != nil || got == nil || got.Note != "α" {
+		t.Fatalf("unicode task changed: %+v, err=%v", got, err)
+	}
+}
+
 // TestGetTask_ExcludesSoftDeleted: getTask must filter deleted rows like
 // every other entity, otherwise delete replays emit duplicate TaskDeleted
 // events and State.Task returns tasks the user deleted.

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -5,6 +5,7 @@ package sync
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	things "github.com/arthursoares/things-cloud-sdk"
@@ -25,10 +26,11 @@ type dbExecutor interface {
 
 // Syncer manages persistent sync with Things Cloud
 type Syncer struct {
-	rawDB   *sql.DB    // underlying connection for Close() and Begin()
-	db      dbExecutor // current executor (db or tx)
-	client  *things.Client
-	history *things.History
+	rawDB           *sql.DB    // underlying connection for Close() and Begin()
+	db              dbExecutor // current executor (db or tx)
+	client          *things.Client
+	history         *things.History
+	replayLogCutoff int // staging only: suppress events below the old next-batch cursor
 }
 
 // Open creates or opens a sync database and connects to Things Cloud
@@ -37,7 +39,6 @@ func Open(dbPath string, client *things.Client) (*Syncer, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	// Enable WAL mode for better concurrent performance
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		db.Close()
@@ -51,6 +52,10 @@ func Open(dbPath string, client *things.Client) (*Syncer, error) {
 	}
 
 	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if err := s.ensureTaskReplayState(); err != nil {
 		db.Close()
 		return nil, err
 	}
@@ -77,6 +82,10 @@ func isRetryableError(err error) bool {
 func (s *Syncer) Sync() ([]Change, error) {
 	// Get current sync state first
 	storedHistoryID, startIndex, err := s.getSyncState()
+	if err != nil {
+		return nil, err
+	}
+	generation, err := s.taskReplayVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +128,9 @@ func (s *Syncer) Sync() ([]Change, error) {
 	if err != nil {
 		return nil, err
 	}
+	if generation < things.TaskReplayVersion {
+		return s.recoverTaskReplay(storedHistoryID, startIndex, generation, serverIndex)
+	}
 
 	// If our cursor is already at or beyond the server's index, nothing to fetch
 	if startIndex >= serverIndex {
@@ -148,9 +160,8 @@ func (s *Syncer) Sync() ([]Change, error) {
 			return nil, fetchErr
 		}
 
-		// No items returned means we're caught up
-		if len(items) == 0 {
-			break
+		if err := validateReplayPage(s.history, startIndex, serverIndex); err != nil {
+			return nil, err
 		}
 
 		// Process each item
@@ -172,6 +183,15 @@ func (s *Syncer) Sync() ([]Change, error) {
 	// duplicate change_log rows).
 
 	return allChanges, nil
+}
+
+// validateReplayPage checks batch cursors, including empty outer batches that
+// legitimately advance the cursor without yielding expanded entity items.
+func validateReplayPage(h *things.History, start, target int) error {
+	if h.LoadedServerIndex <= start || h.LatestServerIndex < h.LoadedServerIndex || h.LatestServerIndex < target {
+		return fmt.Errorf("invalid sync progress: start %d, loaded %d, latest %d, target %d", start, h.LoadedServerIndex, h.LatestServerIndex, target)
+	}
+	return nil
 }
 
 // LastSyncedIndex returns the server index we've synced up to

--- a/sync/task7_test.go
+++ b/sync/task7_test.go
@@ -366,6 +366,54 @@ func replayLog(t *testing.T, s *Syncer) []string {
 	return result
 }
 
+func TestTaskReplayGenerationTwoRebuildsByteOffsetNotes(t *testing.T) {
+	var starts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprint(w, `{"latest-server-index":2}`)
+			return
+		}
+		starts = append(starts, r.URL.Query().Get("start-index"))
+		fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":0,"p":{"tt":"Native task","nt":{"t":1,"v":"Native Task7 note α 🚀\nSecond line."}}}},{"task":{"e":"Task7","t":1,"p":{"nt":{"t":2,"ps":[{"r":"Update","p":26,"l":5,"ch":3672733299}]}}}}],"current-item-index":2}`)
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, things.New(server.URL, "test@example.com", "password"), 2)
+	defer s.Close()
+	mustSaveTask(t, s, &things.Task{
+		UUID:  "task",
+		Title: "Native task",
+		Note:  "Native Task7 note α 🚀\nSecoUpdatene.",
+	})
+	if _, err := s.db.Exec(`UPDATE task_replay_state SET version=2 WHERE id=1`); err != nil {
+		t.Fatal(err)
+	}
+	before := replayLog(t, s)
+
+	changes, err := s.Sync()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Note != "Native Task7 note α 🚀\nUpdated line." {
+		t.Fatalf("replayed note = %q", got.Note)
+	}
+	if len(changes) != 0 || !reflect.DeepEqual(before, replayLog(t, s)) {
+		t.Fatalf("caught-up recovery changed audit: changes=%v", changes)
+	}
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != things.TaskReplayVersion {
+		t.Fatalf("generation=%d err=%v", generation, err)
+	}
+	if !reflect.DeepEqual(starts, []string{"0"}) {
+		t.Fatalf("replay starts=%v", starts)
+	}
+}
+
 func TestTask7ReplayPreservesAuditAndReopens(t *testing.T) {
 	for _, cutoff := range []int{3, 4} {
 		t.Run(fmt.Sprint(cutoff), func(t *testing.T) {

--- a/sync/task7_test.go
+++ b/sync/task7_test.go
@@ -1,0 +1,452 @@
+package sync
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	things "github.com/arthursoares/things-cloud-sdk"
+)
+
+func TestTask7ReadAndNulls(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	apply := func(kind, payload string) {
+		t.Helper()
+		if _, err := s.processItems([]things.Item{{UUID: "task", Kind: things.ItemKind(kind), P: json.RawMessage(payload)}}, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	apply("Task6", `{"tt":"before","nt":"note","sr":100,"tir":200,"dd":300,"ato":10,"ar":["area"],"pr":["project"],"agr":["heading"],"tg":["tag"]}`)
+	old, err := s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if old.ScheduledDate == nil || old.ScheduledDate.Unix() != 100 {
+		t.Fatalf("sr was replaced by tir: %+v", old.ScheduledDate)
+	}
+	apply("Task7", `{"tt":"after"}`)
+	got, err := s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "after" || got.Note != "note" || got.ScheduledDate == nil || len(got.TagIDs) != 1 {
+		t.Fatalf("partial Task7 update: %+v", got)
+	}
+	apply("Task7", `{"sr":null,"dd":null,"ato":null,"ar":null,"pr":null,"agr":null,"tg":null,"nt":null}`)
+	got, err = s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ScheduledDate != nil || got.DeadlineDate != nil || got.AlarmTimeOffset != nil || len(got.AreaIDs)+len(got.ParentTaskIDs)+len(got.ActionGroupIDs)+len(got.TagIDs) != 0 || got.Note != "" {
+		t.Fatalf("nulls not cleared: %+v", got)
+	}
+	if _, err := s.processItems([]things.Item{{UUID: "task", Kind: "Task7", Action: things.ItemActionDeleted}}, 1); err != nil {
+		t.Fatal(err)
+	}
+	got, err = s.getTask("task")
+	if err != nil || got != nil {
+		t.Fatalf("delete: %+v %v", got, err)
+	}
+}
+
+func TestTask7ReplayFailurePreservesStateAndRetry(t *testing.T) {
+	for _, failure := range []string{"fetch", "decode", "note", "unknown", "empty", "cursor", "install", "concurrent"} {
+		t.Run(failure, func(t *testing.T) {
+			var retry atomic.Bool
+			var s *Syncer
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/items") {
+					fmt.Fprint(w, `{"latest-server-index":2}`)
+					return
+				}
+				if r.URL.Query().Get("start-index") == "0" {
+					fmt.Fprint(w, `{"items":[{"task":{"e":"Task6","t":0,"p":{"tt":"staged","nt":"there"}}}],"current-item-index":2}`)
+					return
+				}
+				if !retry.Load() {
+					switch failure {
+					case "fetch":
+						w.WriteHeader(http.StatusForbidden)
+						return
+					case "decode":
+						fmt.Fprint(w, `{"items":[{"private-uuid":{"e":"Task7","t":1,"p":17}}],"current-item-index":2}`)
+						return
+					case "note":
+						fmt.Fprint(w, `{"items":[{"private-uuid":{"e":"Task7","t":1,"p":{"nt":42}}}],"current-item-index":2}`)
+						return
+					case "unknown":
+						fmt.Fprint(w, `{"items":[{"private-uuid":{"e":"Task8","t":1,"p":{"tt":"private-title"}}}],"current-item-index":2}`)
+						return
+					case "empty":
+						fmt.Fprint(w, `{"items":[],"current-item-index":2}`)
+						return
+					case "cursor":
+						fmt.Fprint(w, `{"items":[{}],"current-item-index":1}`)
+						return
+					case "concurrent":
+						// A separate SQLite connection advances the live state while
+						// network replay is in progress; installation must reject it.
+						if _, err := s.rawDB.Exec(`UPDATE sync_state SET server_index=3 WHERE id=1`); err != nil {
+							t.Error(err)
+						}
+					}
+				}
+				fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":1,"p":{"tt":"recovered","nt":{"t":2,"ps":[{"p":0,"l":0,"r":"Hi "}]}}}}],"current-item-index":2}`)
+			}))
+			defer server.Close()
+			path := filepath.Join(t.TempDir(), "live.db")
+			s = legacyReplayDB(t, path, things.New(server.URL, "test@example.com", "password"), 2)
+			defer s.Close()
+			before := replayLog(t, s)
+			if failure == "install" {
+				if _, err := s.db.Exec(`CREATE TRIGGER fail_replay BEFORE DELETE ON tasks BEGIN SELECT RAISE(ABORT, 'injected install failure'); END`); err != nil {
+					t.Fatal(err)
+				}
+			}
+			changes, err := s.Sync()
+			if err == nil || len(changes) != 0 {
+				t.Fatalf("failure accepted: %v %v", changes, err)
+			}
+			if (failure == "unknown" || failure == "decode" || failure == "note") && strings.Contains(err.Error(), "private-") {
+				t.Fatalf("private error: %v", err)
+			}
+			old, getErr := s.getTask("task")
+			if getErr != nil || old.Title != "old" || old.Note != "Hi there" {
+				t.Fatalf("old state damaged: %+v %v", old, getErr)
+			}
+			wantIndex := 2
+			if failure == "concurrent" {
+				wantIndex = 3
+			}
+			generation, getErr := s.taskReplayVersion()
+			if getErr != nil || generation != 1 || s.LastSyncedIndex() != wantIndex || !reflect.DeepEqual(before, replayLog(t, s)) {
+				t.Fatalf("metadata/audit changed: gen=%d idx=%d err=%v", generation, s.LastSyncedIndex(), getErr)
+			}
+			if failure == "install" {
+				if _, err := s.db.Exec(`DROP TRIGGER fail_replay`); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if failure == "concurrent" {
+				if err := s.saveSyncState("history", 2); err != nil {
+					t.Fatal(err)
+				}
+			}
+			retry.Store(true)
+			if _, err := s.Sync(); err != nil {
+				t.Fatalf("retry: %v", err)
+			}
+			got, getErr := s.getTask("task")
+			if getErr != nil || got.Title != "recovered" || got.Note != "Hi there" {
+				t.Fatalf("retry state: %+v %v", got, getErr)
+			}
+			if !reflect.DeepEqual(before, replayLog(t, s)) {
+				t.Fatal("retry duplicated logs")
+			}
+		})
+	}
+}
+
+func TestTask7ReplayBackupFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires effective filesystem permission checks")
+	}
+	var fetches atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			fetches.Add(1)
+		}
+		fmt.Fprint(w, `{"latest-server-index":2}`)
+	}))
+	defer server.Close()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "live.db")
+	s := legacyReplayDB(t, path, things.New(server.URL, "test@example.com", "password"), 2)
+	defer s.Close()
+	before := replayLog(t, s)
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chmod(dir, 0700); err != nil {
+			t.Error(err)
+		}
+	}()
+	if _, err := s.Sync(); err == nil {
+		t.Fatal("backup failure ignored")
+	}
+	if fetches.Load() != 0 {
+		t.Fatal("replay started before backup")
+	}
+	got, err := s.getTask("task")
+	if err != nil || got.Title != "old" || s.LastSyncedIndex() != 2 || !reflect.DeepEqual(before, replayLog(t, s)) {
+		t.Fatalf("backup failure damaged state: %+v %v", got, err)
+	}
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != 1 {
+		t.Fatalf("generation=%d err=%v", generation, err)
+	}
+}
+
+func TestTask7ReplayEmptyOuterBatchesAndGrowth(t *testing.T) {
+	var starts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprint(w, `{"latest-server-index":1}`)
+			return
+		}
+		start := r.URL.Query().Get("start-index")
+		starts = append(starts, start)
+		if start == "0" {
+			fmt.Fprint(w, `{"items":[{}],"current-item-index":3}`)
+			return
+		}
+		fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":0,"p":{"tt":"grown"}}},{}],"current-item-index":3}`)
+	}))
+	defer server.Close()
+	s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), things.New(server.URL, "test@example.com", "password"), 1)
+	defer s.Close()
+	changes, err := s.Sync()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 || s.LastSyncedIndex() != 3 || !reflect.DeepEqual(starts, []string{"0", "1"}) {
+		t.Fatalf("changes=%d cursor=%d starts=%v", len(changes), s.LastSyncedIndex(), starts)
+	}
+}
+
+func TestTask7ReplayGuardsAllMetadata(t *testing.T) {
+	for _, mutation := range []string{`UPDATE sync_state SET history_id='other'`, `UPDATE sync_state SET server_index=3`, `UPDATE task_replay_state SET version=2`} {
+		t.Run(mutation, func(t *testing.T) {
+			s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), nil, 2)
+			defer s.Close()
+			stage, err := Open(":memory:", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stage.Close()
+			stage.history = &things.History{ID: "history"}
+			mustSaveTask(t, stage, &things.Task{UUID: "task", Title: "staged"})
+			if _, err := s.rawDB.Exec(mutation); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.installTaskReplay(stage, "history", 2, 1, 2); err == nil {
+				t.Fatal("stale installation accepted")
+			}
+			got, err := s.getTask("task")
+			if err != nil || got.Title != "old" {
+				t.Fatalf("stale state installed: %+v %v", got, err)
+			}
+		})
+	}
+}
+
+func TestTaskReplayGenerationFreshAndMemoryBackup(t *testing.T) {
+	s, err := Open(":memory:", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != things.TaskReplayVersion {
+		t.Fatalf("fresh generation=%d err=%v", generation, err)
+	}
+	if err := s.backupForReplay(); err != nil {
+		t.Fatalf("memory backup: %v", err)
+	}
+}
+
+func TestTaskReplayFinalFailureRollsBackEntitiesLogsAndCursor(t *testing.T) {
+	s := legacyReplayDB(t, filepath.Join(t.TempDir(), "live.db"), nil, 2)
+	defer s.Close()
+	before := replayLog(t, s)
+	staged, err := Open(":memory:", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer staged.Close()
+	staged.history = &things.History{ID: "history", LoadedServerIndex: 3}
+	if _, err := staged.processItems([]things.Item{{UUID: "task", Kind: "Task7", P: json.RawMessage(`{"tt":"staged","tg":["new-tag"]}`)}}, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`CREATE TRIGGER fail_generation BEFORE UPDATE ON task_replay_state BEGIN SELECT RAISE(ABORT, 'injected final failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.installTaskReplay(staged, "history", 2, 1, 3); err == nil {
+		t.Fatal("final failure ignored")
+	}
+	got, err := s.getTask("task")
+	if err != nil || got.Title != "old" || len(got.TagIDs) != 0 || s.LastSyncedIndex() != 2 || !reflect.DeepEqual(before, replayLog(t, s)) {
+		t.Fatalf("partial install: %+v %v", got, err)
+	}
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != 1 {
+		t.Fatalf("generation=%d err=%v", generation, err)
+	}
+}
+
+func TestUnknownTaskRollsBackSanitized(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "test.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	_, err = s.processItems([]things.Item{{UUID: "valid", Kind: "Task6", P: json.RawMessage(`{"tt":"valid"}`)}, {UUID: "private-uuid", Kind: "Task8", P: json.RawMessage(`{"tt":"private-title"}`)}}, 0)
+	if err == nil {
+		t.Fatal("unsupported task accepted")
+	}
+	if strings.Contains(err.Error(), "private-") {
+		t.Fatalf("private data in error: %v", err)
+	}
+	got, getErr := s.getTask("valid")
+	if getErr != nil || got != nil {
+		t.Fatalf("partial batch committed: %+v %v", got, getErr)
+	}
+}
+
+// legacyReplayDB simulates the previous reader after it saved a Task6 delta
+// and skipped a later Task7 update, including its original audit records.
+func legacyReplayDB(t *testing.T, path string, client *things.Client, cursor int) *Syncer {
+	t.Helper()
+	s, err := Open(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustSaveTask(t, s, &things.Task{UUID: "task", Title: "old", Note: "Hi there"})
+	if err := s.saveSyncState("history", cursor); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO change_log(id,server_index,synced_at,change_type,entity_type,entity_uuid,payload) VALUES(41,1,123,'TaskNoteChanged','Task','task','{"original":true}')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`DROP TABLE IF EXISTS task_replay_state`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = Open(path, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func replayLog(t *testing.T, s *Syncer) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT id,server_index,synced_at,change_type,entity_type,entity_uuid,payload FROM change_log ORDER BY id`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var id, idx, ts int
+		var kind, entity, uuid, payload string
+		if err := rows.Scan(&id, &idx, &ts, &kind, &entity, &uuid, &payload); err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, fmt.Sprint(id, "|", idx, "|", ts, "|", kind, "|", entity, "|", uuid, "|", payload))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestTask7ReplayPreservesAuditAndReopens(t *testing.T) {
+	for _, cutoff := range []int{3, 4} {
+		t.Run(fmt.Sprint(cutoff), func(t *testing.T) {
+			var starts []string
+			heads := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/items") {
+					heads++
+					fmt.Fprint(w, `{"latest-server-index":4}`)
+					return
+				}
+				starts = append(starts, r.URL.Query().Get("start-index"))
+				fmt.Fprint(w, `{"items":[{"task":{"e":"Task6","t":0,"p":{"tt":"old","nt":"there"}}},{"task":{"e":"Task6","t":1,"p":{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"Hi "}]}}}},{"task":{"e":"Task7","t":1,"p":{"tt":"recovered"}}},{"task":{"e":"Task7","t":1,"p":{"tt":"new"}}}],"current-item-index":4}`)
+			}))
+			defer server.Close()
+			path := filepath.Join(t.TempDir(), "live.db")
+			client := things.New(server.URL, "test@example.com", "password")
+			s := legacyReplayDB(t, path, client, cutoff)
+			before := replayLog(t, s)
+			old, _ := s.getTask("task")
+			if old.Title != "old" || s.LastSyncedIndex() != cutoff {
+				t.Fatal("Open rebuilt offline")
+			}
+			changes, err := s.Sync()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := s.getTask("task")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Title != "new" || got.Note != "Hi there" {
+				t.Fatalf("replay state: %+v", got)
+			}
+			after := replayLog(t, s)
+			if !reflect.DeepEqual(before, after[:len(before)]) {
+				t.Fatalf("audit changed: %v -> %v", before, after)
+			}
+			if len(changes) != 4-cutoff || len(after) != len(before)+4-cutoff {
+				t.Fatalf("cutoff changes=%d logs=%d", len(changes), len(after))
+			}
+			if s.LastSyncedIndex() != 4 || !reflect.DeepEqual(starts, []string{"0"}) || heads != 1 {
+				t.Fatalf("cursor=%d starts=%v heads=%d", s.LastSyncedIndex(), starts, heads)
+			}
+			backups, err := filepath.Glob(path + ".task7-backup-*")
+			if err != nil || len(backups) != 1 {
+				t.Fatalf("backups: %v %v", backups, err)
+			}
+			info, err := os.Stat(backups[0])
+			if err != nil || info.Mode().Perm() != 0600 {
+				t.Fatalf("backup permissions: %v %v", info, err)
+			}
+			backup, err := sql.Open("sqlite", backups[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			var backupTitle string
+			if err := backup.QueryRow(`SELECT title FROM tasks WHERE uuid='task'`).Scan(&backupTitle); err != nil {
+				t.Fatal(err)
+			}
+			if backupTitle != "old" || !reflect.DeepEqual(before, replayLog(t, &Syncer{db: backup})) {
+				t.Fatal("backup did not retain pre-recovery WAL state")
+			}
+			if err := backup.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.Close(); err != nil {
+				t.Fatal(err)
+			}
+			s, err = Open(path, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer s.Close()
+			changes, err = s.Sync()
+			if err != nil || len(changes) != 0 {
+				t.Fatalf("repeat: %v %v", changes, err)
+			}
+			if !reflect.DeepEqual(after, replayLog(t, s)) || len(starts) != 1 {
+				t.Fatal("repeat replayed history")
+			}
+		})
+	}
+}

--- a/task7_write_test.go
+++ b/task7_write_test.go
@@ -1,0 +1,582 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type rawWriteProbe struct {
+	id   string
+	body string
+}
+
+func (p rawWriteProbe) UUID() string { return p.id }
+
+func (p rawWriteProbe) MarshalJSON() ([]byte, error) { return []byte(p.body), nil }
+
+func task7CreateBody(title string) string {
+	return fmt.Sprintf(`{"e":"Task7","t":0,"p":{"tp":0,"sr":null,"dds":null,"rt":[],"rmd":null,"ss":0,"tr":false,"dl":[],"icp":false,"st":0,"ar":[],"tt":%s,"do":0,"lai":null,"tir":null,"tg":[],"agr":[],"ix":0,"cd":1770000000.25,"lt":false,"icc":0,"md":null,"ti":0,"dd":null,"ato":null,"nt":{"_t":"tx","ch":0,"v":"","t":1},"icsd":null,"pr":[],"rp":null,"acrd":null,"sp":null,"sb":0,"rr":null,"xx":{"sn":{},"_t":"oo"}}}`, strconv.Quote(title))
+}
+
+func task7UpdateBody(fields string) string {
+	if fields != "" {
+		fields = "," + fields
+	}
+	return `{"e":"Task7","t":1,"p":{"md":1770000001.5` + fields + `}}`
+}
+
+func historyPage(head int, batches ...string) string {
+	return fmt.Sprintf(`{"items":[%s],"current-item-index":%d,"schema":301}`, strings.Join(batches, ","), head)
+}
+
+func taskHistoryBatch(id string, kind ItemKind, action int, payload string) string {
+	return fmt.Sprintf(`{%s:{"e":%s,"t":%d,"p":%s}}`, strconv.Quote(id), strconv.Quote(string(kind)), action, payload)
+}
+
+func TestHistoryWriteAcceptsVerifiedTask7CreateWithoutPreflight(t *testing.T) {
+	var methods []string
+	var posted map[string]json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected %s request for create-only write", r.Method)
+		}
+		if got := r.URL.Query().Get("ancestor-index"); got != "9" {
+			t.Errorf("ancestor-index = %q, want 9", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprint(w, `{"server-head-index":10}`)
+	}))
+	defer server.Close()
+
+	id := NewUUID()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	h.LatestServerIndex = 9
+	if err := h.Write(rawWriteProbe{id: id, body: task7CreateBody("ordinary")}); err != nil {
+		t.Fatalf("Write(valid Task7 create): %v", err)
+	}
+	if len(methods) != 1 || methods[0] != http.MethodPost {
+		t.Fatalf("methods = %v, want [POST]", methods)
+	}
+	if !strings.Contains(string(posted[id]), `"e":"Task7"`) {
+		t.Fatalf("posted envelope = %s, want Task7", posted[id])
+	}
+}
+
+func TestHistoryWriteTask7UpdatePreflightsRawHistoryAndPinsAncestor(t *testing.T) {
+	target := NewUUID()
+	var starts []string
+	var posts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			starts = append(starts, r.URL.Query().Get("start-index"))
+			switch r.URL.Query().Get("start-index") {
+			case "0":
+				fmt.Fprint(w, historyPage(3,
+					taskHistoryBatch(target, ItemKindTask, 0, `{"tt":"legacy generation","rr":null,"rp":null,"rt":[]}`),
+					taskHistoryBatch(target, ItemKindTask7, 1, `{"tt":"current generation"}`),
+				))
+			case "2":
+				fmt.Fprint(w, historyPage(4, `{}`)) // growing head must not be chased
+			default:
+				t.Fatalf("unexpected start-index %q", r.URL.Query().Get("start-index"))
+			}
+		case http.MethodPost:
+			posts++
+			if got := r.URL.Query().Get("ancestor-index"); got != "3" {
+				t.Errorf("ancestor-index = %q, want frozen head 3", got)
+			}
+			fmt.Fprint(w, `{"server-head-index":4}`)
+		}
+	}))
+	defer server.Close()
+
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	h.LatestServerIndex = 99
+	if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"renamed"`)}); err != nil {
+		t.Fatalf("Write(valid ordinary update): %v", err)
+	}
+	if strings.Join(starts, ",") != "0,2" || posts != 1 {
+		t.Fatalf("starts=%v posts=%d, want [0 2] and one POST", starts, posts)
+	}
+	if h.LatestServerIndex != 4 {
+		t.Errorf("LatestServerIndex=%d, want commit head 4", h.LatestServerIndex)
+	}
+}
+
+func TestHistoryWriteRejectsRecurringAndAmbiguousTask7TargetsBeforePost(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "repeater rule", payload: `{"rr":{"f":1},"rp":null,"rt":[]}`},
+		{name: "repeater payload", payload: `{"rr":null,"rp":"opaque","rt":[]}`},
+		{name: "linked instance", payload: `{"rr":null,"rp":null,"rt":["` + NewUUID() + `"]}`},
+		{name: "instance creation marker", payload: `{"rr":null,"rp":null,"rt":[],"icsd":1770000000}`},
+		{name: "after completion marker", payload: `{"rr":null,"rp":null,"rt":[],"acrd":1770000000}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewUUID()
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posts++
+				}
+				fmt.Fprint(w, historyPage(1, taskHistoryBatch(target, ItemKindTask7, 0, tt.payload)))
+			}))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"unsafe"`)}); err == nil {
+				t.Fatal("Write(recurring target) succeeded")
+			}
+			if posts != 0 {
+				t.Fatalf("sent %d POSTs, want zero", posts)
+			}
+		})
+	}
+}
+
+func TestHistoryWriteTask7PreflightTracksOmissionsNullClearsDeletesAndKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		batches func(string) []string
+		wantOK  bool
+	}{
+		{name: "omission preserves recurrence", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":{"f":1},"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKindTask7, 1, `{"tt":"still recurring"}`),
+			}
+		}},
+		{name: "explicit null clears recurrence", wantOK: true, batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":{"f":1},"rp":"opaque","rt":["`+NewUUID()+`"],"icsd":1,"acrd":2}`),
+				taskHistoryBatch(id, ItemKindTask7, 1, `{"rr":null,"rp":null,"rt":[],"icsd":null,"acrd":null}`),
+			}
+		}},
+		{name: "legacy sparse create lacks recurrence proof", batches: func(id string) []string {
+			return []string{taskHistoryBatch(id, ItemKind("Task6"), 0, `{"tt":"unknown recurrence state"}`)}
+		}},
+		{name: "direct task deletion", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKindTask7, 2, `{}`),
+			}
+		}},
+		{name: "tombstone deletion", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(NewUUID(), ItemKindTombstone, 0, `{"dloid":"`+id+`","dld":1}`),
+			}
+		}},
+		{name: "future target kind", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task8"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+			}
+		}},
+		{name: "future kind hidden by later create", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task8"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+			}
+		}},
+		{name: "non-task modification on target", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKind("Area3"), 1, `{}`),
+			}
+		}},
+		{name: "duplicate target creation", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+			}
+		}},
+		{name: "missing target", batches: func(string) []string { return []string{`{}`} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewUUID()
+			batches := tt.batches(target)
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posts++
+					fmt.Fprint(w, `{"server-head-index":20}`)
+					return
+				}
+				fmt.Fprint(w, historyPage(len(batches), batches...))
+			}))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"update"`)})
+			if (err == nil) != tt.wantOK {
+				t.Fatalf("Write() error=%v, wantOK=%v", err, tt.wantOK)
+			}
+			if (posts == 1) != tt.wantOK {
+				t.Fatalf("posts=%d, wantOK=%v", posts, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestHistoryWriteValidatesEntireTask7BatchBeforeNetwork(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown create field", body: strings.Replace(task7CreateBody("x"), `"xx":`, `"unknown":1,"xx":`, 1)},
+		{name: "create recurrence", body: strings.Replace(task7CreateBody("x"), `"rr":null`, `"rr":{"f":1}`, 1)},
+		{name: "inbox create with dates", body: strings.NewReplacer(`"sr":null`, `"sr":1770000002`, `"tir":null`, `"tir":1770000002`).Replace(task7CreateBody("x"))},
+		{name: "create dates differ", body: strings.NewReplacer(`"st":0`, `"st":1`, `"sr":null`, `"sr":1770000002`, `"tir":null`, `"tir":1770000003`).Replace(task7CreateBody("x"))},
+		{name: "create dates null mismatch", body: strings.NewReplacer(`"st":0`, `"st":1`, `"sr":null`, `"sr":1770000002`).Replace(task7CreateBody("x"))},
+		{name: "multiple area parents", body: strings.Replace(task7CreateBody("x"), `"ar":[]`, `"ar":["`+NewUUID()+`","`+NewUUID()+`"]`, 1)},
+		{name: "malformed modification date", body: task7UpdateBody(`"tt":"x"`)[:len(task7UpdateBody(`"tt":"x"`))-2] + `,"md":"bad"}}`},
+		{name: "delta note", body: task7UpdateBody(`"nt":{"_t":"tx","t":2,"ps":[]}`)},
+		{name: "unknown update field", body: task7UpdateBody(`"private":"fixture"`)},
+		{name: "deleted action", body: `{"e":"Task7","t":2,"p":{}}`},
+		{name: "quoted action", body: strings.Replace(task7CreateBody("x"), `"t":0`, `"t":"0"`, 1)},
+		{name: "quoted payload integer", body: strings.Replace(task7CreateBody("x"), `"tp":0`, `"tp":"0"`, 1)},
+		{name: "null title", body: task7UpdateBody(`"tt":null`)},
+		{name: "null trash", body: task7UpdateBody(`"tr":null`)},
+		{name: "null create boolean", body: strings.Replace(task7CreateBody("x"), `"icp":false`, `"icp":null`, 1)},
+		{name: "null note value", body: strings.Replace(task7CreateBody("x"), `"v":""`, `"v":null`, 1)},
+		{name: "status without stop date", body: task7UpdateBody(`"ss":3`)},
+		{name: "stop date without status", body: task7UpdateBody(`"sp":1770000002`)},
+		{name: "reopen with stop date", body: task7UpdateBody(`"ss":0,"sp":1770000002`)},
+		{name: "complete with null stop date", body: task7UpdateBody(`"ss":3,"sp":null`)},
+		{name: "schedule without dates", body: task7UpdateBody(`"st":1`)},
+		{name: "schedule dates differ", body: task7UpdateBody(`"st":1,"sr":1770000002,"tir":1770000003`)},
+		{name: "inbox with dates", body: task7UpdateBody(`"st":0,"sr":1770000002,"tir":1770000002`)},
+		{name: "unpaired surrogate", body: strings.Replace(task7CreateBody("x"), `"tt":"x"`, `"tt":"\uD800"`, 1)},
+		{name: "duplicate recurrence field", body: strings.Replace(task7CreateBody("x"), `"rr":null`, `"rr":{"f":1},"rr":null`, 1)},
+		{name: "duplicate nested note field", body: strings.Replace(task7CreateBody("x"), `"_t":"tx"`, `"_t":"private","_t":"tx"`, 1)},
+		{name: "duplicate envelope kind", body: strings.Replace(task7CreateBody("x"), `{"e":"Task7"`, `{"e":"Tag4","e":"Task7"`, 1)},
+		{name: "missing payload", body: `{"e":"Task7","t":1}`},
+		{name: "payload not object", body: `{"e":"Task7","t":1,"p":null}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			err := h.Write(
+				rawWriteProbe{id: NewUUID(), body: task7CreateBody("valid sibling")},
+				rawWriteProbe{id: NewUUID(), body: tt.body},
+			)
+			if err == nil {
+				t.Fatal("Write(invalid Task7 batch) succeeded")
+			}
+			if requests != 0 {
+				t.Fatalf("sent %d requests, want zero", requests)
+			}
+		})
+	}
+}
+
+func TestHistoryWriteAcceptsVerifiedTask7FutureCreate(t *testing.T) {
+	body := strings.NewReplacer(
+		`"st":0`, `"st":2`,
+		`"sr":null`, `"sr":1770000002`,
+		`"tir":null`, `"tir":1770000002`,
+	).Replace(task7CreateBody("future"))
+	posts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("future create sent %s, want POST", r.Method)
+		}
+		posts++
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: body}); err != nil {
+		t.Fatalf("Write(valid future Task7 create): %v", err)
+	}
+	if posts != 1 {
+		t.Fatalf("posts=%d, want one", posts)
+	}
+}
+
+func TestHistoryWriteRejectsInvalidUTF8Task7BeforeNetwork(t *testing.T) {
+	body := strings.Replace(task7CreateBody("x"), `"tt":"x"`, "\"tt\":\"\xff\"", 1)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: body}); err == nil {
+		t.Fatal("Write(invalid UTF-8 Task7) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteAcceptsPairedJSONSurrogate(t *testing.T) {
+	body := strings.Replace(task7CreateBody("x"), `"tt":"x"`, `"tt":"\uD83D\uDE80"`, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: body}); err != nil {
+		t.Fatalf("Write(valid paired surrogate): %v", err)
+	}
+}
+
+func TestHistoryWriteTask7RejectsMalformedCompanionTombstoneBeforeNetwork(t *testing.T) {
+	target := NewUUID()
+	tombstone := rawWriteProbe{
+		id:   NewUUID(),
+		body: `{"e":"Tombstone2","t":0,"p":{"dloid":"` + target + `","dloid":"` + NewUUID() + `","dld":1770000001}}`,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: task7CreateBody("x")}, tombstone); err == nil {
+		t.Fatal("Write(Task7 plus malformed tombstone) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteTask7BatchRejectsOneRecurringTargetBeforeAllPosts(t *testing.T) {
+	ordinary, recurring := NewUUID(), NewUUID()
+	gets, posts := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			posts++
+			return
+		}
+		gets++
+		fmt.Fprint(w, historyPage(2,
+			taskHistoryBatch(ordinary, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`),
+			taskHistoryBatch(recurring, ItemKindTask7, 0, `{"rr":{"f":1},"rp":null,"rt":[]}`),
+		))
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	err := h.Write(
+		rawWriteProbe{id: ordinary, body: task7UpdateBody(`"tt":"safe"`)},
+		rawWriteProbe{id: recurring, body: task7UpdateBody(`"tt":"unsafe"`)},
+	)
+	if err == nil {
+		t.Fatal("Write(mixed recurrence batch) succeeded")
+	}
+	if gets != 1 || posts != 0 {
+		t.Fatalf("gets=%d posts=%d, want one shared GET and zero POSTs", gets, posts)
+	}
+}
+
+func TestHistoryWriteTask7RejectsSameBatchTombstoneAmbiguityBeforeNetwork(t *testing.T) {
+	target := NewUUID()
+	tombstone := rawWriteProbe{
+		id:   NewUUID(),
+		body: `{"e":"Tombstone2","t":0,"p":{"dloid":"` + target + `","dld":1770000001}}`,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)}, tombstone); err == nil {
+		t.Fatal("Write(Task7 modification plus target tombstone) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteTask7RejectsSameBatchCreateAndTombstoneBeforeNetwork(t *testing.T) {
+	target := NewUUID()
+	tombstone := rawWriteProbe{
+		id:   NewUUID(),
+		body: `{"e":"Tombstone2","t":0,"p":{"dloid":"` + target + `","dld":1770000001}}`,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: target, body: task7CreateBody("x")}, tombstone); err == nil {
+		t.Fatal("Write(Task7 create plus target tombstone) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteTask7RejectsAmbiguousSameHistoryIndexRegardlessOfMapOrder(t *testing.T) {
+	target := NewUUID()
+	tombstoneID := NewUUID()
+	batch := fmt.Sprintf(`{%s:{"e":"Task7","t":0,"p":{"rr":null,"rp":null,"rt":[]}},%s:{"e":"Tombstone2","t":0,"p":{"dloid":%s,"dld":1}}}`,
+		strconv.Quote(target), strconv.Quote(tombstoneID), strconv.Quote(target))
+	posts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			posts++
+			return
+		}
+		fmt.Fprint(w, historyPage(1, batch))
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	for i := 0; i < 25; i++ {
+		if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)}); err == nil {
+			t.Fatalf("iteration %d accepted ambiguous same-index history", i)
+		}
+	}
+	if posts != 0 {
+		t.Fatalf("sent %d POSTs, want zero", posts)
+	}
+}
+
+func TestHistoryWriteTask7RejectsAmbiguousRawHistoryPayloads(t *testing.T) {
+	tests := []struct {
+		name    string
+		batches func(string) []string
+	}{
+		{name: "duplicate recurrence key", batches: func(id string) []string {
+			return []string{taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":{"f":1},"rr":null,"rp":null,"rt":[]}`)}
+		}},
+		{name: "duplicate tombstone target", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(NewUUID(), ItemKind("Tombstone2"), 0, `{"dloid":"`+NewUUID()+`","dloid":"`+id+`","dld":1}`),
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewUUID()
+			batches := tt.batches(target)
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posts++
+					return
+				}
+				fmt.Fprint(w, historyPage(len(batches), batches...))
+			}))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)}); err == nil {
+				t.Fatal("Write(ambiguous raw history) succeeded")
+			}
+			if posts != 0 {
+				t.Fatalf("sent %d POSTs, want zero", posts)
+			}
+		})
+	}
+}
+
+func TestTask7PreflightRejectsInvalidUTF8TargetPayload(t *testing.T) {
+	target := NewUUID()
+	states := map[string]*task7TargetState{target: {lastAffectedIndex: -1}}
+	item := Item{
+		UUID:           target,
+		Kind:           ItemKind("Task7"),
+		Action:         ItemActionCreated,
+		P:              json.RawMessage("{\"rr\":null,\"rp\":null,\"rt\":[],\"tt\":\"\xff\"}"),
+		ServerIndex:    0,
+		HasServerIndex: true,
+	}
+	if err := applyTask7PreflightItem(states, item); err != nil {
+		t.Fatalf("applyTask7PreflightItem returned transport-level error: %v", err)
+	}
+	if !states[target].ambiguous {
+		t.Fatal("invalid UTF-8 target payload was not marked ambiguous")
+	}
+}
+
+func TestHistoryWriteTask7PreflightFailureDoesNotMutateHistory(t *testing.T) {
+	target := NewUUID()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("start-index") == "0" {
+			fmt.Fprint(w, historyPage(3, taskHistoryBatch(target, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`)))
+			return
+		}
+		fmt.Fprint(w, historyPage(3))
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	h.LatestServerIndex, h.LoadedServerIndex = 8, 4
+	err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)})
+	if err == nil {
+		t.Fatal("Write(zero-progress history) succeeded")
+	}
+	if h.LatestServerIndex != 8 || h.LoadedServerIndex != 4 {
+		t.Fatalf("history mutated on preflight failure: latest=%d loaded=%d", h.LatestServerIndex, h.LoadedServerIndex)
+	}
+}
+
+func TestHistoryWriteLegacyTaskStillSkipsPreflight(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPost {
+			t.Fatalf("legacy write sent %s, want POST", r.Method)
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(taskWriteProbe{id: NewUUID(), kind: ItemKindTask}); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests=%d, want one POST", requests)
+	}
+}
+
+func TestHistoryWriteMutableKindVariablesCannotEnableFutureTaskWrites(t *testing.T) {
+	originalTask, originalTask7 := ItemKindTask, ItemKindTask7
+	ItemKindTask, ItemKindTask7 = "Task8", "Task8"
+	defer func() {
+		ItemKindTask, ItemKindTask7 = originalTask, originalTask7
+	}()
+
+	futureTarget := NewUUID()
+	requests, posts := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, historyPage(1, taskHistoryBatch(futureTarget, ItemKind("Task8"), 0, `{"rr":null,"rp":null,"rt":[]}`)))
+			return
+		}
+		posts++
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(taskWriteProbe{id: NewUUID(), kind: ItemKindTask}); err == nil {
+		t.Fatal("mutated ItemKindTask enabled serialized Task8")
+	}
+	if requests != 0 {
+		t.Fatalf("future task write sent %d requests, want zero", requests)
+	}
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: task7CreateBody("literal Task7")}); err != nil {
+		t.Fatalf("literal Task7 was not validated by its serialized kind: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("literal Task7 sent %d requests, want one POST", requests)
+	}
+	if err := h.Write(rawWriteProbe{id: futureTarget, body: task7UpdateBody(`"tt":"x"`)}); err == nil {
+		t.Fatal("mutated ItemKindTask7 made raw Task8 target look supported during preflight")
+	}
+	if requests != 2 || posts != 1 {
+		t.Fatalf("preflight mutation case requests=%d posts=%d, want two total requests and one POST", requests, posts)
+	}
+}

--- a/task_read.go
+++ b/task_read.go
@@ -1,0 +1,151 @@
+package thingscloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TaskReplayVersion identifies the task read semantics used to build derived
+// state. Cached state from older generations must be replayed from scratch.
+const TaskReplayVersion = 2
+
+// UnsupportedTaskKindError means the task state would be incomplete if replay
+// continued. ServerIndex is -1 when the source did not provide an index.
+type UnsupportedTaskKindError struct {
+	Kind        ItemKind
+	ServerIndex int
+}
+
+func (e *UnsupportedTaskKindError) Error() string {
+	kind := taskKindDiagnostic(e.Kind)
+	if e.ServerIndex >= 0 {
+		return fmt.Sprintf("incomplete sync: unsupported task kind %s at server index %d", kind, e.ServerIndex)
+	}
+	return fmt.Sprintf("incomplete sync: unsupported task kind %s", kind)
+}
+
+func taskKindDiagnostic(value ItemKind) string {
+	// Only print the protocol's Task<number> shape. Do not let an arbitrary
+	// server-supplied kind embed private text or control characters in logs.
+	kind := string(value)
+	suffix := strings.TrimPrefix(kind, "Task")
+	if suffix == kind || suffix == "" || len(suffix) > 12 || strings.Trim(suffix, "0123456789") != "" {
+		kind = "Task*"
+	}
+	return kind
+}
+
+// ValidateTaskReadKinds preflights an entire batch before any task state is
+// mutated. Unrelated unknown entities retain their existing handling.
+func ValidateTaskReadKinds(items []Item) error {
+	for _, item := range items {
+		switch item.Kind {
+		case ItemKindTask, ItemKindTask7, ItemKindTask4, ItemKindTask3, ItemKindTaskPlain:
+			continue
+		}
+		if strings.HasPrefix(string(item.Kind), "Task") {
+			index := -1
+			if item.HasServerIndex {
+				index = item.ServerIndex
+			}
+			return &UnsupportedTaskKindError{Kind: item.Kind, ServerIndex: index}
+		}
+	}
+	return nil
+}
+
+// TaskReadPayload adds explicit-null tracking to the existing wire payload
+// without changing its write representation. Unknown properties remain
+// available in the original Item.P; this helper interprets supported fields.
+type TaskReadPayload struct {
+	TaskActionItemPayload
+	nullFields map[string]bool
+}
+
+// DecodeTaskReadPayload distinguishes an omitted property (preserve existing
+// state) from an explicit null (clear a nullable property).
+func DecodeTaskReadPayload(raw json.RawMessage) (TaskReadPayload, error) {
+	var result TaskReadPayload
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 || data[0] != '{' {
+		return result, fmt.Errorf("task payload must be a JSON object")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return result, fmt.Errorf("decoding task payload: %w", err)
+	}
+	if err := json.Unmarshal(data, &result.TaskActionItemPayload); err != nil {
+		return result, fmt.Errorf("decoding task payload: %w", err)
+	}
+	if note, ok := fields["nt"]; ok {
+		if err := validateTaskReadNote(note); err != nil {
+			return result, err
+		}
+	}
+	for key, value := range fields {
+		if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			if result.nullFields == nil {
+				result.nullFields = make(map[string]bool)
+			}
+			result.nullFields[key] = true
+		}
+	}
+	return result, nil
+}
+
+func validateTaskReadNote(raw json.RawMessage) error {
+	value := bytes.TrimSpace(raw)
+	if bytes.Equal(value, []byte("null")) || (len(value) > 0 && value[0] == '"') {
+		return nil // The enclosing JSON decoder already checked string syntax.
+	}
+	if len(value) == 0 || value[0] != '{' {
+		return fmt.Errorf("task note must be text, null, or a supported structured note")
+	}
+	var note Note
+	if err := json.Unmarshal(value, &note); err != nil {
+		return fmt.Errorf("decoding task note: %w", err)
+	}
+	if note.Type != NoteTypeFullText && note.Type != NoteTypeDelta {
+		return fmt.Errorf("unsupported task note type %d", note.Type)
+	}
+	return nil
+}
+
+// ApplyNulls clears nullable fields after the ordinary non-nil payload fields
+// have been applied. In particular, tir is a reference date and never changes
+// ScheduledDate; only sr controls that field.
+func (p TaskReadPayload) ApplyNulls(task *Task) {
+	for key := range p.nullFields {
+		switch key {
+		case "cd":
+			task.CreationDate = time.Time{}
+		case "md":
+			task.ModificationDate = nil
+		case "sr":
+			task.ScheduledDate = nil
+		case "sp":
+			task.CompletionDate = nil
+		case "dd":
+			task.DeadlineDate = nil
+		case "ato":
+			task.AlarmTimeOffset = nil
+		case "ar":
+			task.AreaIDs = nil
+		case "pr":
+			task.ParentTaskIDs = nil
+		case "agr":
+			task.ActionGroupIDs = nil
+		case "tg":
+			task.TagIDs = nil
+		case "rt":
+			task.RecurrenceIDs = nil
+		case "dl":
+			task.DelegateIDs = nil
+		case "nt":
+			task.Note = ""
+		}
+	}
+}

--- a/task_read.go
+++ b/task_read.go
@@ -10,7 +10,7 @@ import (
 
 // TaskReplayVersion identifies the task read semantics used to build derived
 // state. Cached state from older generations must be replayed from scratch.
-const TaskReplayVersion = 2
+const TaskReplayVersion = 3
 
 // UnsupportedTaskKindError means the task state would be incomplete if replay
 // continued. ServerIndex is -1 when the source did not provide an index.

--- a/task_read.go
+++ b/task_read.go
@@ -114,6 +114,39 @@ func validateTaskReadNote(raw json.RawMessage) error {
 	return nil
 }
 
+// ResolveNote applies the note field to current using the read protocol's
+// plain-text, full-text, delta, and explicit-null semantics.
+func (p TaskReadPayload) ResolveNote(current string) (string, error) {
+	if p.nullFields["nt"] {
+		return "", nil
+	}
+	if len(p.Note) == 0 {
+		return current, nil
+	}
+
+	var noteText string
+	if err := json.Unmarshal(p.Note, &noteText); err == nil {
+		return noteText, nil
+	}
+
+	var note Note
+	if err := json.Unmarshal(p.Note, &note); err != nil {
+		return "", fmt.Errorf("decoding task note: %w", err)
+	}
+	switch note.Type {
+	case NoteTypeFullText:
+		return note.Value, nil
+	case NoteTypeDelta:
+		result, err := ApplyPatchesChecked(current, note.Patches)
+		if err != nil {
+			return "", fmt.Errorf("applying task note delta: %w", err)
+		}
+		return result, nil
+	default:
+		return "", fmt.Errorf("unsupported task note type %d", note.Type)
+	}
+}
+
 // ApplyNulls clears nullable fields after the ordinary non-nil payload fields
 // have been applied. In particular, tir is a reference date and never changes
 // ScheduledDate; only sr controls that field.

--- a/task_read_test.go
+++ b/task_read_test.go
@@ -50,6 +50,52 @@ func TestTaskReadPayloadAcceptsKnownNoteFormats(t *testing.T) {
 	}
 }
 
+func TestTaskReadPayloadResolveNote(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		current string
+		raw     string
+		want    string
+	}{
+		{name: "omitted", current: "unchanged", raw: `{}`, want: "unchanged"},
+		{name: "null", current: "old", raw: `{"nt":null}`, want: ""},
+		{name: "plain", current: "old", raw: `{"nt":"a plain note"}`, want: "a plain note"},
+		{name: "full", current: "old", raw: `{"nt":{"t":1,"v":"full replacement"}}`, want: "full replacement"},
+		{name: "delta", current: "there", raw: `{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"Hi "}]}}`, want: "Hi there"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload, err := DecodeTaskReadPayload([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("DecodeTaskReadPayload: %v", err)
+			}
+			got, err := payload.ResolveNote(tt.current)
+			if err != nil {
+				t.Fatalf("ResolveNote: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveNote = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskReadPayloadRejectsUnknownAndMalformedNotes(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		`{"nt":42}`,
+		`{"nt":{"t":3,"v":"unsupported"}}`,
+		`{"nt":{"t":2,"ps":"malformed"}}`,
+	} {
+		if _, err := DecodeTaskReadPayload([]byte(raw)); err == nil {
+			t.Errorf("DecodeTaskReadPayload accepted %s", raw)
+		}
+	}
+}
+
 func TestTaskReadKindsAndSanitizedError(t *testing.T) {
 	if err := ValidateTaskReadKinds([]Item{{Kind: "Task6"}, {Kind: "Task7"}, {Kind: "Task4"}, {Kind: "Settings5"}}); err != nil {
 		t.Fatal(err)

--- a/task_read_test.go
+++ b/task_read_test.go
@@ -1,0 +1,69 @@
+package thingscloud
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTaskReadPayloadNullsAndOmissions(t *testing.T) {
+	date := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	alarm := 30
+	task := Task{Title: "keep", Note: "clear", ScheduledDate: &date, DeadlineDate: &date,
+		CompletionDate: &date, ModificationDate: &date, AlarmTimeOffset: &alarm,
+		AreaIDs: []string{"area"}, ParentTaskIDs: []string{"project"}, ActionGroupIDs: []string{"heading"}, TagIDs: []string{"tag"}}
+	omitted, err := DecodeTaskReadPayload([]byte(`{"tt":"unrelated","tir":null}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	omitted.ApplyNulls(&task)
+	if task.ScheduledDate != &date || task.Note != "clear" || len(task.AreaIDs) != 1 {
+		t.Fatal("omitted fields or null tir changed existing state")
+	}
+	cleared, err := DecodeTaskReadPayload([]byte(`{"sr":null,"dd":null,"sp":null,"md":null,"ato":null,"ar":null,"pr":null,"agr":null,"tg":null,"nt":null}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleared.ApplyNulls(&task)
+	if task.ScheduledDate != nil || task.DeadlineDate != nil || task.CompletionDate != nil || task.ModificationDate != nil || task.AlarmTimeOffset != nil {
+		t.Error("explicit null did not clear optional dates/alarm")
+	}
+	if len(task.AreaIDs)+len(task.ParentTaskIDs)+len(task.ActionGroupIDs)+len(task.TagIDs) != 0 || task.Note != "" || task.Title != "keep" {
+		t.Error("explicit null did not clear relationships/notes or changed unrelated title")
+	}
+}
+
+func TestTaskReadPayloadRejectsNonObjects(t *testing.T) {
+	for _, raw := range []string{"", "null", "[]", `"text"`, `{"tt":[]}`, `{"nt":42}`, `{"nt":true}`, `{"nt":[]}`, `{"nt":{"t":"bad"}}`, `{"nt":{"t":3,"v":"private"}}`, `{"nt":{"t":2,"ps":"bad"}}`} {
+		if _, err := DecodeTaskReadPayload([]byte(raw)); err == nil {
+			t.Errorf("accepted invalid task payload %q", raw)
+		}
+	}
+}
+
+func TestTaskReadPayloadAcceptsKnownNoteFormats(t *testing.T) {
+	for _, raw := range []string{`{"nt":null}`, `{"nt":"legacy text"}`, `{"nt":{"t":1,"v":""}}`, `{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"hello"}]}}`} {
+		if _, err := DecodeTaskReadPayload([]byte(raw)); err != nil {
+			t.Errorf("known note format rejected: %v", err)
+		}
+	}
+}
+
+func TestTaskReadKindsAndSanitizedError(t *testing.T) {
+	if err := ValidateTaskReadKinds([]Item{{Kind: "Task6"}, {Kind: "Task7"}, {Kind: "Task4"}, {Kind: "Settings5"}}); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateTaskReadKinds([]Item{{Kind: "Task8", UUID: "private-id", P: []byte(`{"tt":"private title"}`), ServerIndex: 42, HasServerIndex: true}})
+	var unsupported *UnsupportedTaskKindError
+	if !errors.As(err, &unsupported) || unsupported.Kind != "Task8" || unsupported.ServerIndex != 42 {
+		t.Fatalf("expected indexed unsupported-task error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "private") || !strings.Contains(err.Error(), "Task8") {
+		t.Fatalf("unexpected diagnostic: %v", err)
+	}
+	err = ValidateTaskReadKinds([]Item{{Kind: "Task8\nprivate payload"}})
+	if err == nil || strings.Contains(err.Error(), "private") || strings.Contains(err.Error(), "\n") {
+		t.Fatalf("unsafe kind diagnostic: %v", err)
+	}
+}

--- a/task_write.go
+++ b/task_write.go
@@ -1,0 +1,29 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// validateTaskWriteKinds checks the serialized envelopes, including custom
+// Identifiable implementations. Supporting a new kind for reads must not
+// accidentally enable writes whose contract has not been verified.
+func validateTaskWriteKinds(body []byte) error {
+	var envelopes map[string]struct {
+		Kind ItemKind `json:"e"`
+	}
+	if err := json.Unmarshal(body, &envelopes); err != nil {
+		return fmt.Errorf("refusing to write an invalid item envelope")
+	}
+	for _, envelope := range envelopes {
+		switch envelope.Kind {
+		case "Task6", "Task4", "Task3", "Task":
+			continue // Preserve existing write kinds; the CLI still emits Task6.
+		}
+		if strings.HasPrefix(string(envelope.Kind), "Task") {
+			return fmt.Errorf("refusing to write unverified task kind %s", taskKindDiagnostic(envelope.Kind))
+		}
+	}
+	return nil
+}

--- a/task_write.go
+++ b/task_write.go
@@ -1,29 +1,594 @@
 package thingscloud
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
+	"io"
+	"math"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
-// validateTaskWriteKinds checks the serialized envelopes, including custom
-// Identifiable implementations. Supporting a new kind for reads must not
-// accidentally enable writes whose contract has not been verified.
-func validateTaskWriteKinds(body []byte) error {
-	var envelopes map[string]struct {
-		Kind ItemKind `json:"e"`
-	}
+type task7WritePlan struct {
+	modificationTargets map[string]struct{}
+	creationTargets     map[string]struct{}
+	tombstoneTargets    map[string]struct{}
+}
+
+func (p *task7WritePlan) needsPreflight() bool { return len(p.modificationTargets) != 0 }
+
+func validateTaskWrites(body []byte) (*task7WritePlan, error) {
+	var envelopes map[string]json.RawMessage
 	if err := json.Unmarshal(body, &envelopes); err != nil {
-		return fmt.Errorf("refusing to write an invalid item envelope")
+		return nil, fmt.Errorf("refusing to write an invalid item envelope")
 	}
-	for _, envelope := range envelopes {
-		switch envelope.Kind {
+	plan := &task7WritePlan{
+		modificationTargets: make(map[string]struct{}),
+		creationTargets:     make(map[string]struct{}),
+		tombstoneTargets:    make(map[string]struct{}),
+	}
+	type tombstoneEnvelope struct {
+		kind string
+		raw  json.RawMessage
+	}
+	var tombstones []tombstoneEnvelope
+	for id, raw := range envelopes {
+		if err := rejectDuplicateJSONKeys(raw, false); err != nil {
+			return nil, fmt.Errorf("refusing to write an invalid item envelope")
+		}
+		var legacyEnvelope struct {
+			Kind ItemKind `json:"e"`
+		}
+		if err := json.Unmarshal(raw, &legacyEnvelope); err != nil {
+			return nil, fmt.Errorf("refusing to write an invalid item envelope")
+		}
+		kind := string(legacyEnvelope.Kind)
+		switch kind {
+		case "Task7":
+			if !utf8.Valid(raw) || rejectUnpairedJSONSurrogates(raw) != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			if err := rejectDuplicateJSONKeys(raw, true); err != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			fields, err := jsonObject(raw)
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			action, ok := jsonInteger(fields["t"])
+			if !ok || len(fields) != 3 {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			payload, err := jsonObject(fields["p"])
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 payload")
+			}
+			switch action {
+			case int64(ItemActionCreated):
+				err = validateTask7Create(payload)
+				if err == nil {
+					plan.creationTargets[id] = struct{}{}
+				}
+			case int64(ItemActionModified):
+				err = validateTask7Modification(payload)
+				if err == nil {
+					plan.modificationTargets[id] = struct{}{}
+				}
+			default:
+				err = fmt.Errorf("Task7 action %d is outside the verified write scope", action)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write Task7: %w", err)
+			}
 		case "Task6", "Task4", "Task3", "Task":
-			continue // Preserve existing write kinds; the CLI still emits Task6.
+			// Preserve existing write kinds and serialization behavior.
+		case "Tombstone2", "Tombstone":
+			tombstones = append(tombstones, tombstoneEnvelope{kind: kind, raw: raw})
+		default:
+			if strings.HasPrefix(kind, "Task") {
+				return nil, fmt.Errorf("refusing to write unverified task kind %s", taskKindDiagnostic(ItemKind(kind)))
+			}
 		}
-		if strings.HasPrefix(string(envelope.Kind), "Task") {
-			return fmt.Errorf("refusing to write unverified task kind %s", taskKindDiagnostic(envelope.Kind))
+	}
+	if len(plan.creationTargets)+len(plan.modificationTargets) != 0 {
+		for _, tombstone := range tombstones {
+			target, err := validateTask7CompanionTombstone(tombstone.raw, tombstone.kind)
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write Task7 batch: invalid tombstone companion")
+			}
+			plan.tombstoneTargets[target] = struct{}{}
 		}
+	}
+	for _, targets := range []map[string]struct{}{plan.creationTargets, plan.modificationTargets} {
+		for target := range targets {
+			if _, ambiguous := plan.tombstoneTargets[target]; ambiguous {
+				return nil, fmt.Errorf("refusing to write Task7: target %s is both changed and deleted in one commit", target)
+			}
+		}
+	}
+	return plan, nil
+}
+
+func validateTask7CompanionTombstone(raw json.RawMessage, kind string) (string, error) {
+	if !utf8.Valid(raw) || rejectUnpairedJSONSurrogates(raw) != nil || rejectDuplicateJSONKeys(raw, true) != nil {
+		return "", fmt.Errorf("invalid tombstone envelope")
+	}
+	fields, err := jsonObject(raw)
+	if err != nil || exactKeys(fields, map[string]struct{}{"e": {}, "t": {}, "p": {}}) != nil {
+		return "", fmt.Errorf("invalid tombstone envelope")
+	}
+	action, ok := jsonInteger(fields["t"])
+	if !ok || action != 0 {
+		return "", fmt.Errorf("invalid tombstone action")
+	}
+	payload, err := jsonObject(fields["p"])
+	if err != nil || exactKeys(payload, map[string]struct{}{"dloid": {}, "dld": {}}) != nil {
+		return "", fmt.Errorf("invalid tombstone payload")
+	}
+	target, ok := jsonString(payload["dloid"])
+	if !ok || target == "" || requiredTimestamp(payload["dld"], true) != nil {
+		return "", fmt.Errorf("invalid tombstone payload")
+	}
+	if kind == "Tombstone2" {
+		if ValidateUUID(target) != nil {
+			return "", fmt.Errorf("invalid tombstone target")
+		}
+	} else if ValidateUUID(target) != nil {
+		target = EncodeLegacyIdentifier(target)
+	}
+	return target, nil
+}
+
+var task7CreateKeys = map[string]struct{}{
+	"tp": {}, "sr": {}, "dds": {}, "rt": {}, "rmd": {}, "ss": {}, "tr": {}, "dl": {},
+	"icp": {}, "st": {}, "ar": {}, "tt": {}, "do": {}, "lai": {}, "tir": {}, "tg": {},
+	"agr": {}, "ix": {}, "cd": {}, "lt": {}, "icc": {}, "md": {}, "ti": {}, "dd": {},
+	"ato": {}, "nt": {}, "icsd": {}, "pr": {}, "rp": {}, "acrd": {}, "sp": {}, "sb": {},
+	"rr": {}, "xx": {},
+}
+
+func validateTask7Create(p map[string]json.RawMessage) error {
+	if err := exactKeys(p, task7CreateKeys); err != nil {
+		return fmt.Errorf("create payload %w", err)
+	}
+	tp, ok := jsonInteger(p["tp"])
+	if !ok || tp < 0 || tp > 2 {
+		return fmt.Errorf("create tp must be 0, 1, or 2")
+	}
+	st, ok := jsonInteger(p["st"])
+	if !ok || st < 0 || st > 2 || (tp != 0 && st != 1) {
+		return fmt.Errorf("create st is invalid for task type")
+	}
+	if ss, ok := jsonInteger(p["ss"]); !ok || ss != 0 {
+		return fmt.Errorf("create ss must be 0")
+	}
+	if tr, ok := jsonBool(p["tr"]); !ok || tr {
+		return fmt.Errorf("create tr must be false")
+	}
+	for _, key := range []string{"icp", "lt"} {
+		if value, ok := jsonBool(p[key]); !ok || value {
+			return fmt.Errorf("create %s must be false", key)
+		}
+	}
+	for _, key := range []string{"do", "ix", "icc", "ti", "sb"} {
+		if value, ok := jsonInteger(p[key]); !ok || value != 0 {
+			return fmt.Errorf("create %s must be 0", key)
+		}
+	}
+	if _, ok := jsonString(p["tt"]); !ok {
+		return fmt.Errorf("create tt must be a string")
+	}
+	if err := requiredTimestamp(p["cd"], true); err != nil {
+		return fmt.Errorf("create cd %w", err)
+	}
+	for _, key := range []string{"sr", "tir", "dd"} {
+		if err := nullableTimestamp(p[key]); err != nil {
+			return fmt.Errorf("create %s %w", key, err)
+		}
+	}
+	srNull, tirNull := jsonNull(p["sr"]), jsonNull(p["tir"])
+	if srNull != tirNull {
+		return fmt.Errorf("create sr and tir must have the same date")
+	}
+	if st == 0 && !srNull {
+		return fmt.Errorf("create st 0 requires null sr and tir")
+	}
+	if !srNull {
+		var sr, tir float64
+		_ = json.Unmarshal(p["sr"], &sr)
+		_ = json.Unmarshal(p["tir"], &tir)
+		if sr != tir {
+			return fmt.Errorf("create sr and tir must have the same date")
+		}
+	}
+	for _, key := range []string{"dds", "rmd", "lai", "md", "ato", "icsd", "rp", "acrd", "sp", "rr"} {
+		if !jsonNull(p[key]) {
+			return fmt.Errorf("create %s must be null", key)
+		}
+	}
+	for _, key := range []string{"rt", "dl"} {
+		values, err := jsonStringArray(p[key])
+		if err != nil || len(values) != 0 {
+			return fmt.Errorf("create %s must be an empty array", key)
+		}
+	}
+	for _, key := range []string{"ar", "pr", "agr", "tg"} {
+		if err := validateReferenceArray(p[key]); err != nil {
+			return fmt.Errorf("create %s %w", key, err)
+		}
+		if key != "tg" {
+			values, _ := jsonStringArray(p[key])
+			if len(values) > 1 {
+				return fmt.Errorf("create %s supports at most one parent identifier", key)
+			}
+		}
+	}
+	if err := validateFullTextNote(p["nt"]); err != nil {
+		return fmt.Errorf("create nt %w", err)
+	}
+	if err := validateDefaultExtension(p["xx"]); err != nil {
+		return fmt.Errorf("create xx %w", err)
+	}
+	return nil
+}
+
+var task7ModificationKeys = map[string]struct{}{
+	"md": {}, "tt": {}, "nt": {}, "st": {}, "sr": {}, "tir": {}, "dd": {}, "ar": {},
+	"pr": {}, "agr": {}, "tg": {}, "ss": {}, "sp": {}, "tr": {}, "ix": {}, "ti": {}, "do": {},
+}
+
+func validateTask7Modification(p map[string]json.RawMessage) error {
+	for key := range p {
+		if _, ok := task7ModificationKeys[key]; !ok {
+			return fmt.Errorf("modification contains a property outside the verified write scope")
+		}
+	}
+	if err := requiredTimestamp(p["md"], true); err != nil {
+		return fmt.Errorf("modification md %w", err)
+	}
+	if raw, ok := p["tt"]; ok {
+		if _, ok := jsonString(raw); !ok {
+			return fmt.Errorf("modification tt must be a string")
+		}
+	}
+	if raw, ok := p["nt"]; ok {
+		if err := validateFullTextNote(raw); err != nil {
+			return fmt.Errorf("modification nt %w", err)
+		}
+	}
+	if raw, ok := p["st"]; ok {
+		value, ok := jsonInteger(raw)
+		if !ok || value < 0 || value > 2 {
+			return fmt.Errorf("modification st must be 0, 1, or 2")
+		}
+	}
+	if raw, ok := p["ss"]; ok {
+		value, ok := jsonInteger(raw)
+		if !ok || (value != 0 && value != 3) {
+			return fmt.Errorf("modification ss must be 0 or 3")
+		}
+	}
+	ssRaw, hasStatus := p["ss"]
+	spRaw, hasStopDate := p["sp"]
+	if hasStatus != hasStopDate {
+		return fmt.Errorf("modification ss and sp must be written together")
+	}
+	if hasStatus {
+		status, _ := jsonInteger(ssRaw)
+		if status == 0 && !jsonNull(spRaw) {
+			return fmt.Errorf("modification ss 0 requires null sp")
+		}
+		if status == 3 {
+			if jsonNull(spRaw) || requiredTimestamp(spRaw, true) != nil {
+				return fmt.Errorf("modification ss 3 requires a positive sp timestamp")
+			}
+		}
+	}
+	_, hasSchedule := p["st"]
+	_, hasStartDate := p["sr"]
+	_, hasTodayReference := p["tir"]
+	if hasSchedule || hasStartDate || hasTodayReference {
+		if !hasSchedule || !hasStartDate || !hasTodayReference {
+			return fmt.Errorf("modification st, sr, and tir must be written together")
+		}
+		st, _ := jsonInteger(p["st"])
+		srNull, tirNull := jsonNull(p["sr"]), jsonNull(p["tir"])
+		if srNull != tirNull {
+			return fmt.Errorf("modification sr and tir must have the same date")
+		}
+		if st == 0 && !srNull {
+			return fmt.Errorf("modification st 0 requires null sr and tir")
+		}
+		if !srNull {
+			var sr, tir float64
+			_ = json.Unmarshal(p["sr"], &sr)
+			_ = json.Unmarshal(p["tir"], &tir)
+			if sr != tir {
+				return fmt.Errorf("modification sr and tir must have the same date")
+			}
+		}
+	}
+	for _, key := range []string{"sr", "tir", "dd", "sp"} {
+		if raw, ok := p[key]; ok {
+			if err := nullableTimestamp(raw); err != nil {
+				return fmt.Errorf("modification %s %w", key, err)
+			}
+		}
+	}
+	for _, key := range []string{"ar", "pr", "agr", "tg"} {
+		if raw, ok := p[key]; ok {
+			if err := validateReferenceArray(raw); err != nil {
+				return fmt.Errorf("modification %s %w", key, err)
+			}
+		}
+	}
+	if raw, ok := p["tr"]; ok {
+		if _, ok := jsonBool(raw); !ok {
+			return fmt.Errorf("modification tr must be a boolean")
+		}
+	}
+	for _, key := range []string{"ix", "ti", "do"} {
+		if raw, ok := p[key]; ok {
+			if _, ok := jsonInteger(raw); !ok {
+				return fmt.Errorf("modification %s must be an integer", key)
+			}
+		}
+	}
+	return nil
+}
+
+func validateFullTextNote(raw json.RawMessage) error {
+	note, err := jsonObject(raw)
+	if err != nil {
+		return fmt.Errorf("must be an object")
+	}
+	want := map[string]struct{}{"_t": {}, "ch": {}, "v": {}, "t": {}}
+	if err := exactKeys(note, want); err != nil {
+		return err
+	}
+	tag, tagOK := jsonString(note["_t"])
+	typ, typeOK := jsonInteger(note["t"])
+	value, valueOK := jsonString(note["v"])
+	checksum, checksumOK := jsonInteger(note["ch"])
+	if !tagOK || tag != "tx" || !typeOK || typ != NoteTypeFullText || !valueOK || !checksumOK || checksum < 0 || checksum > math.MaxUint32 {
+		return fmt.Errorf("must be a tx full-text note with string value and CRC32 checksum")
+	}
+	if uint32(checksum) != crc32.ChecksumIEEE([]byte(value)) {
+		return fmt.Errorf("has a checksum that does not match its full text")
+	}
+	return nil
+}
+
+func validateDefaultExtension(raw json.RawMessage) error {
+	extension, err := jsonObject(raw)
+	if err != nil {
+		return fmt.Errorf("must be an object")
+	}
+	if err := exactKeys(extension, map[string]struct{}{"sn": {}, "_t": {}}); err != nil {
+		return err
+	}
+	tag, ok := jsonString(extension["_t"])
+	if !ok || tag != "oo" {
+		return fmt.Errorf("must have _t oo")
+	}
+	sn, err := jsonObject(extension["sn"])
+	if err != nil || len(sn) != 0 {
+		return fmt.Errorf("must have an empty sn object")
+	}
+	return nil
+}
+
+func validateReferenceArray(raw json.RawMessage) error {
+	values, err := jsonStringArray(raw)
+	if err != nil {
+		return fmt.Errorf("must be an array of identifiers")
+	}
+	for _, id := range values {
+		if err := ValidateUUID(id); err != nil {
+			return fmt.Errorf("contains an invalid identifier")
+		}
+	}
+	return nil
+}
+
+func jsonObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 || data[0] != '{' {
+		return nil, fmt.Errorf("must be an object")
+	}
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(data, &result); err != nil || result == nil {
+		return nil, fmt.Errorf("must be an object")
+	}
+	return result, nil
+}
+
+func exactKeys(values map[string]json.RawMessage, want map[string]struct{}) error {
+	if len(values) != len(want) {
+		return fmt.Errorf("must contain exactly the verified properties")
+	}
+	for key := range values {
+		if _, ok := want[key]; !ok {
+			return fmt.Errorf("contains unsupported property %q", key)
+		}
+	}
+	return nil
+}
+
+func jsonNull(raw json.RawMessage) bool { return bytes.Equal(bytes.TrimSpace(raw), []byte("null")) }
+
+func jsonString(raw json.RawMessage) (string, bool) {
+	data := bytes.TrimSpace(raw)
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return "", false
+	}
+	var value string
+	if json.Unmarshal(data, &value) != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func jsonBool(raw json.RawMessage) (bool, bool) {
+	switch string(bytes.TrimSpace(raw)) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func jsonInteger(raw json.RawMessage) (int64, bool) {
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(string(data), 10, 64)
+	return value, err == nil
+}
+
+// rejectDuplicateJSONKeys checks the envelope object itself for every write.
+// Task7 additionally checks every nested object because validation must not
+// approve one interpretation while the server applies another duplicate key.
+func rejectDuplicateJSONKeys(raw json.RawMessage, recursive bool) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := consumeJSONValue(decoder, recursive, 0); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return fmt.Errorf("extra JSON value")
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder, recursive bool, depth int) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("object key is not a string")
+			}
+			if depth == 0 || recursive {
+				if _, duplicate := seen[key]; duplicate {
+					return fmt.Errorf("duplicate object key")
+				}
+				seen[key] = struct{}{}
+			}
+			if err := consumeJSONValue(decoder, recursive, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return fmt.Errorf("unterminated object")
+		}
+	case '[':
+		for decoder.More() {
+			if err := consumeJSONValue(decoder, recursive, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return fmt.Errorf("unterminated array")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter")
+	}
+	return nil
+}
+
+func rejectUnpairedJSONSurrogates(raw []byte) error {
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '"' {
+			continue
+		}
+		for i++; i < len(raw) && raw[i] != '"'; i++ {
+			if raw[i] != '\\' {
+				continue
+			}
+			i++
+			if i >= len(raw) || raw[i] != 'u' {
+				continue
+			}
+			value, ok := jsonHex16(raw, i+1)
+			if !ok {
+				return fmt.Errorf("invalid unicode escape")
+			}
+			i += 4
+			switch {
+			case value >= 0xd800 && value <= 0xdbff:
+				if i+6 >= len(raw) || raw[i+1] != '\\' || raw[i+2] != 'u' {
+					return fmt.Errorf("unpaired unicode surrogate")
+				}
+				low, ok := jsonHex16(raw, i+3)
+				if !ok || low < 0xdc00 || low > 0xdfff {
+					return fmt.Errorf("unpaired unicode surrogate")
+				}
+				i += 6
+			case value >= 0xdc00 && value <= 0xdfff:
+				return fmt.Errorf("unpaired unicode surrogate")
+			}
+		}
+	}
+	return nil
+}
+
+func jsonHex16(raw []byte, start int) (uint16, bool) {
+	if start+4 > len(raw) {
+		return 0, false
+	}
+	value, err := strconv.ParseUint(string(raw[start:start+4]), 16, 16)
+	return uint16(value), err == nil
+}
+
+func jsonStringArray(raw json.RawMessage) ([]string, error) {
+	var values []string
+	if len(raw) == 0 || json.Unmarshal(raw, &values) != nil || values == nil {
+		return nil, fmt.Errorf("must be an array of strings")
+	}
+	return values, nil
+}
+
+const (
+	minTaskTimestamp = -62135596800.0
+	maxTaskTimestamp = 253402300799.0
+)
+
+func nullableTimestamp(raw json.RawMessage) error {
+	if jsonNull(raw) {
+		return nil
+	}
+	return requiredTimestamp(raw, false)
+}
+
+func requiredTimestamp(raw json.RawMessage, positive bool) error {
+	var value float64
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("must be a finite timestamp")
+	}
+	if value < minTaskTimestamp || value > maxTaskTimestamp || (positive && value <= 0) {
+		return fmt.Errorf("must be a valid timestamp")
 	}
 	return nil
 }

--- a/task_write_test.go
+++ b/task_write_test.go
@@ -22,7 +22,7 @@ func (p taskWriteProbe) MarshalJSON() ([]byte, error) {
 }
 
 func TestHistoryWriteRejectsUnverifiedTaskKinds(t *testing.T) {
-	for _, kind := range []ItemKind{"Task7", "Task8", "Task8\nprivate fixture title"} {
+	for _, kind := range []ItemKind{"Task8", "Task8\nprivate fixture title"} {
 		t.Run(string(kind), func(t *testing.T) {
 			var requests atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/task_write_test.go
+++ b/task_write_test.go
@@ -1,0 +1,45 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type taskWriteProbe struct {
+	id   string
+	kind ItemKind
+}
+
+func (p taskWriteProbe) UUID() string { return p.id }
+
+func (p taskWriteProbe) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{"e": p.kind, "t": 0, "p": map[string]any{"tt": "private fixture title"}})
+}
+
+func TestHistoryWriteRejectsUnverifiedTaskKinds(t *testing.T) {
+	for _, kind := range []ItemKind{"Task7", "Task8", "Task8\nprivate fixture title"} {
+		t.Run(string(kind), func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				fmt.Fprint(w, `{"server-head-index":1}`)
+			}))
+			defer server.Close()
+			history := New(server.URL, "test@example.com", "test-password").HistoryWithID("test-history")
+			err := history.Write(taskWriteProbe{id: NewUUID(), kind: kind})
+			if err == nil {
+				t.Error("unverified task kind was accepted for writing")
+			} else if strings.Contains(err.Error(), "private fixture title") {
+				t.Error("write diagnostic exposed fixture contents")
+			}
+			if requests.Load() != 0 {
+				t.Errorf("sent %d requests, want zero", requests.Load())
+			}
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -60,8 +60,8 @@ var (
 	ItemKindChecklistItem3 ItemKind = "ChecklistItem3"
 	// ItemKindTask identifies a Task or Subtask
 	ItemKindTask ItemKind = "Task6"
-	// ItemKindTask7 is supported for reading current histories. Writes continue
-	// to use ItemKindTask until the Task7 write contract is verified.
+	// ItemKindTask7 identifies the explicitly validated Task7 read/write scope.
+	// ItemKindTask remains Task6 for compatibility with existing callers.
 	ItemKindTask7     ItemKind = "Task7"
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"

--- a/types.go
+++ b/types.go
@@ -59,7 +59,10 @@ var (
 	ItemKindChecklistItem2 ItemKind = "ChecklistItem2"
 	ItemKindChecklistItem3 ItemKind = "ChecklistItem3"
 	// ItemKindTask identifies a Task or Subtask
-	ItemKindTask      ItemKind = "Task6"
+	ItemKindTask ItemKind = "Task6"
+	// ItemKindTask7 is supported for reading current histories. Writes continue
+	// to use ItemKindTask until the Task7 write contract is verified.
+	ItemKindTask7     ItemKind = "Task7"
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"
 	ItemKindTaskPlain ItemKind = "Task"
@@ -241,7 +244,7 @@ type TaskActionItemPayload struct {
 	SubtaskBehavior           *int                   `json:"sb,omitempty"`
 	DelegateIDs               *[]string              `json:"dl,omitempty"`
 	LastActionItemID          *Timestamp             `json:"lai,omitempty"`
-	ReminderDate              *Timestamp             `json:"rmd,omitempty"`
+	ReminderDate              *Timestamp             `json:"rmd,omitempty"` // legacy API name: repeater migration date, not a reminder
 	AlarmTimeOffset           *int                   `json:"ato,omitempty"`
 	ActionRequiredDate        *Timestamp             `json:"acrd,omitempty"`
 	DeadlineSuppression       *Timestamp             `json:"dds,omitempty"`

--- a/verify.go
+++ b/verify.go
@@ -28,10 +28,10 @@ type VerifyResponse struct {
 // Verify checks that the provided API credentials are valid.
 func (c *Client) Verify() (*VerifyResponse, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("/version/1/account/%s", c.EMail), nil)
-	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Password %s", c.password))
 	resp, err := c.do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Prepare v0.6.0 from `develop`: verified ordinary Task7 CLI writes, recovery of skipped Task7 records, Unicode note repair, malformed-write prevention, correct future scheduling, and explicit clearing of old container relationships.

## Included changes

- #28: request-construction error handling and focused cleanup.
- #30: canonical identifier/date/schedule/type validation and strict batch input.
- #31: correct Upcoming scheduling while retaining explicit schedule precedence.
- #32: Task7 reads, nullable fields, sr/tir separation, and staged recovery that preserves SQLite audit rows.
- #34: UTF-8 byte-offset note replay and generation-3 cache repair.
- #35: checked note replay with atomic memory/SQLite failure handling.
- #36: explicit Task7 write policy, CLI migration, raw recurrence preflight, and corrected area/project moves.

## Validation

Full build, race and coverage suites, vet, lint, diff checks, and independent reviews passed. Real-capture recovery restored seven missing tasks, removed 265 date mismatches, and retained 5,352 audit rows byte-for-byte. Disposable-account cloud/app/SDK checks covered ordinary Task7 operations and the migrated CLI's create, edit, completion, trash, and corrected moves. Recurring-template and mixed-batch refusal left history unchanged; a controlled stale-ancestor write returned HTTP 409. Native recurrence capture showed why instance completion requires a companion template update.

## Upgrade and limits

Old derived state replays from full history with private backups, preserving SQLite audit rows and suppressing duplicate historical notifications. Task7 update preflight adds history reads. Recurring or ambiguous targets, including sparse histories without explicit rr/rp/rt, are refused rather than guessed. Existing SDK Task6 callers retain their prior behavior; project/heading creates are limited to Anytime in this first Task7 scope.

Recurrence writes, modern non-null rp, direct note-delta writes, Task7 deletion events, broader offline convergence, and power-loss/process-kill recovery tests remain outside the verified scope. No dependencies were added; Go 1.25 remains required.

The v0.6.0 GitHub release remains a draft. This PR prepares promotion to main; it does not publish the release.
