### PR TITLE
Repair Unicode note replay and rebuild affected cached state

### DIFF
--- a/cmd/things-cli/cache_recovery_test.go
+++ b/cmd/things-cli/cache_recovery_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 func oldReplayCache() []byte {
-	return []byte(`{"version":1,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{}}}`)
+	return []byte(`{"version":2,"historyId":"test-history","serverIndex":2,"state":{"Tasks":{"BXmAcvS6yK1eDhW31MuZrL":{"UUID":"BXmAcvS6yK1eDhW31MuZrL","Title":"Native task","Note":"Native Task7 note α 🚀\nSecoUpdatene."}}}}`)
 }
 
-func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
+func TestCLIStateCacheRebuildsByteOffsetNotesAtHead(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.json")
 	old := oldReplayCache()
 	if err := os.WriteFile(path, old, 0o600); err != nil {
@@ -42,8 +42,9 @@ func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
 	c := things.New(server.URL, "test@example.com", "test-password")
 	ctx := cliContext{client: c, history: c.HistoryWithID("test-history")}
 	state := ctx.loadState()
-	if len(state.Tasks) != 1 || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"] == nil || state.Tasks["BXmAcvS6yK1eDhW31MuZrL"].Title != "New task" {
-		t.Fatal("old caught-up cache was not rebuilt with the missing Task7 task")
+	task := state.Tasks["BXmAcvS6yK1eDhW31MuZrL"]
+	if len(state.Tasks) != 1 || task == nil || task.Title != "Native task" || task.Note != "Native Task7 note α 🚀\nUpdated line." {
+		t.Fatalf("old caught-up cache was not rebuilt with the byte-offset note: %+v", task)
 	}
 	if len(starts) != 1 || starts[0] != "0" {
 		t.Fatalf("replay starts = %v, want [0]", starts)
@@ -70,7 +71,7 @@ func TestCLIStateCacheRebuildsTask7AtHead(t *testing.T) {
 	}
 }
 
-const task7CachePage = `{"items":[{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":0,"p":{"tt":"","tp":0,"st":0,"ss":0}}},{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":1,"p":{"tt":"New task"}}}],"current-item-index":2}`
+const task7CachePage = `{"items":[{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":0,"p":{"tt":"Native task","tp":0,"st":0,"ss":0,"nt":{"t":1,"v":"Native Task7 note α 🚀\nSecond line."}}}},{"BXmAcvS6yK1eDhW31MuZrL":{"e":"Task7","t":1,"p":{"nt":{"t":2,"ps":[{"r":"Update","p":26,"l":5,"ch":3672733299}]}}}}],"current-item-index":2}`
 
 func TestCLIStateCacheReplacementFailurePreservesOriginal(t *testing.T) {
 	if os.Geteuid() == 0 {

--- a/docs/task7-write-verification.md
+++ b/docs/task7-write-verification.md
@@ -1,0 +1,90 @@
+# Task7 disposable-account verification — 2026-09-06
+
+## Result and scope
+
+Ten explicit Task7 commits succeeded in an isolated disposable Things Cloud
+account using Things 3.23.3 (32303501), schema 301. Each commit was read back
+with the exact submitted property dictionary. Native app synchronization and
+read-only SQLite queries confirmed the resulting state. SDK reads confirmed
+the tested values, with the Unicode replay correction described below.
+
+This establishes a tested subset, not a complete Task7 write specification.
+The production `History.Write` Task7 guard remains unchanged; normal SDK/CLI
+writes remain Task6. No account credentials or private history captures are
+included in this repository.
+
+## Method
+
+- Confirmed the disposable and original accounts had distinct history IDs.
+  The original account was used only for this read-only separation check.
+- Created a named control task in Things, edited its Unicode note, and set it
+  to Today. Captured those Task7 events from cloud history. These are persisted
+  native events, not an interception of the native outgoing HTTP request.
+- Used a private test-only HTTP writer to submit explicit `e: "Task7"` events
+  for one owned test UUID. It checked account separation and the current head,
+  recorded each write intent, and refused automatic retries or duplicate stages.
+- Reused captured native creation, note, and Today shapes. Future scheduling,
+  date clearing, completion, reopening, and trash/restoration used the existing
+  SDK property conventions with an explicit Task7 envelope.
+- Compared cloud readback, candidate SDK output, and Things' local database
+  opened read-only. Inspected creation/notes in the UI and the restored task
+  after a normal app quit and relaunch. Intermediate lifecycle verification
+  used the local database; it did not independently inspect every view.
+
+## Passed cases
+
+| Operation | Verified fields or behavior |
+| --- | --- |
+| Create ordinary task | Native 34-property shape; empty note; task opens in Things |
+| Initial Unicode note | Captured insertion into empty note |
+| Interior Unicode edit | Captured byte-offset delta after Greek text and emoji |
+| Today | Native `st=1`, `sr`, `tir`, `ix`, `md` shape |
+| Future schedule and deadline | `st=2`; September 10 start; September 11 deadline |
+| Clear dates | Explicit null `sr`, `tir`, `dd`; `st=1` |
+| Complete | `ss=3` and non-null `sp` |
+| Reopen | `ss=0`, null `sp` |
+| Recoverable trash | `tr=true` |
+| Restore | `tr=false`; task remains open with its correct note after restart |
+
+Native creation used the same 34 property names as the current Task6 create
+payload. That observation alone does not establish equal semantics for every
+field or justify changing the production envelope.
+
+## Unicode defect and correction
+
+Starting text: `Native Task7 note α 🚀\nSecond line.`
+
+The native app emitted this delta:
+
+```json
+{"_t":"tx","t":2,"ps":[{"r":"Update","p":26,"l":5,"ch":3672733299}]}
+```
+
+Things produced `Native Task7 note α 🚀\nUpdated line.`. Offset 26 is the UTF-8
+byte position of `Second`; its Unicode scalar position is 22 and its UTF-16
+position is 23. The old rune-index decoder instead produced `SecoUpdatene.`.
+Replaying the identical delta through an explicit Task7 write reproduced the
+correct native result and the incorrect SDK result.
+
+`ApplyPatches` now uses byte offsets and bounds lengths before addition to avoid
+integer overflow. Replay generation 3 invalidates older CLI/SQLite derived
+state. Regression tests cover the native delta, malformed numeric ranges, and
+caught-up version-2 cache/database recovery with preserved SQLite audit rows.
+The actual disposable-account version-2 CLI cache was also repaired by the
+new binary and matched the app after restart.
+
+## Remaining verification gaps
+
+- Non-null `rp`/`rr`, modern recurrence and repeat-instance operations.
+- Direct Task7 project/heading creation, relationship moves, tags, checklists,
+  reminders, ordering under concurrency, and bulk writes.
+- Permanent deletion and wire action `t=2` were not exercised in this write test.
+- Conflict/retry behavior, offline concurrent edits, and multi-device convergence.
+- Raw native HTTP headers/body equivalence; server persistence may normalize
+  requests. No TLS interception or certificate changes were used.
+- The general malformed-patch/checksum contract is not established by this
+  successful Unicode example. A malformed byte range splitting a multibyte
+  character can still yield invalid UTF-8; checked replay with transactional
+  error propagation would require a separate change.
+
+These limits must stay explicit in any proposal to enable Task7 writes.

--- a/notes.go
+++ b/notes.go
@@ -23,36 +23,32 @@ type Note struct {
 	Patches  []NotePatch `json:"ps,omitempty"`
 }
 
-// ApplyPatches applies a series of text patches to an original string
+// ApplyPatches applies a series of text patches using UTF-8 byte offsets.
 func ApplyPatches(original string, patches []NotePatch) string {
-	runes := []rune(original)
+	text := []byte(original)
 	for _, p := range patches {
-		if p.Position < 0 {
-			p.Position = 0
+		position := p.Position
+		if position < 0 {
+			position = 0
 		}
-		if p.Position > len(runes) {
-			p.Position = len(runes)
+		if position > len(text) {
+			position = len(text)
 		}
-		end := p.Position + p.Length
-		if end > len(runes) {
-			end = len(runes)
+
+		length := p.Length
+		if length < 0 {
+			length = 0
 		}
-		if end < p.Position {
-			// Negative length in a corrupt/hostile patch: treat as a
-			// pure insertion instead of slicing out of bounds.
-			end = p.Position
+		remaining := len(text) - position
+		if length > remaining {
+			length = remaining
 		}
-		actualLength := end - p.Position
-		replacementRunes := []rune(p.Replacement)
-		newCap := len(runes) - actualLength + len(replacementRunes)
-		if newCap < 0 {
-			newCap = len(replacementRunes)
-		}
-		result := make([]rune, 0, newCap)
-		result = append(result, runes[:p.Position]...)
-		result = append(result, replacementRunes...)
-		result = append(result, runes[end:]...)
-		runes = result
+		end := position + length
+
+		result := append([]byte(nil), text[:position]...)
+		result = append(result, p.Replacement...)
+		result = append(result, text[end:]...)
+		text = result
 	}
-	return string(runes)
+	return string(text)
 }

--- a/notes_negative_patch_test.go
+++ b/notes_negative_patch_test.go
@@ -2,6 +2,15 @@ package thingscloud
 
 import "testing"
 
+func TestApplyPatches_NegativePositionClampsToStart(t *testing.T) {
+	t.Parallel()
+
+	got := ApplyPatches("hello", []NotePatch{{Replacement: "X", Position: -1, Length: 1}})
+	if got != "Xello" {
+		t.Errorf("ApplyPatches negative position = %q, want %q", got, "Xello")
+	}
+}
+
 func TestApplyPatches_NegativeLengthDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
@@ -15,5 +24,15 @@ func TestApplyPatches_NegativeLengthDoesNotPanic(t *testing.T) {
 	got = ApplyPatches("hello", []NotePatch{{Replacement: "", Position: 3, Length: -1}})
 	if got != "hello" {
 		t.Errorf("ApplyPatches negative length no-op = %q, want %q", got, "hello")
+	}
+}
+
+func TestApplyPatches_LengthOverflowClampsToEnd(t *testing.T) {
+	t.Parallel()
+
+	maxInt := int(^uint(0) >> 1)
+	got := ApplyPatches("AB", []NotePatch{{Replacement: "X", Position: 1, Length: maxInt}})
+	if got != "AX" {
+		t.Errorf("ApplyPatches overflowing length = %q, want %q", got, "AX")
 	}
 }

--- a/notes_test.go
+++ b/notes_test.go
@@ -45,6 +45,21 @@ func TestNote_ApplyPatch(t *testing.T) {
 	}
 }
 
+func TestNote_ApplyPatch_UsesUTF8ByteOffsets(t *testing.T) {
+	original := "Native Task7 note α 🚀\nSecond line."
+	patch := NotePatch{
+		Position:    26,
+		Length:      5,
+		Replacement: "Update",
+		Checksum:    3672733299,
+	}
+
+	result := ApplyPatches(original, []NotePatch{patch})
+	if result != "Native Task7 note α 🚀\nUpdated line." {
+		t.Errorf("expected native Task7 note replay, got %q", result)
+	}
+}
+
 func TestNote_ApplyPatch_PositionBeyondLength(t *testing.T) {
 	// Patch position is beyond the string — should not panic
 	result := ApplyPatches("", []NotePatch{{Position: 10, Length: 0, Replacement: "hello"}})

--- a/sync/task7_test.go
+++ b/sync/task7_test.go
@@ -366,6 +366,54 @@ func replayLog(t *testing.T, s *Syncer) []string {
 	return result
 }
 
+func TestTaskReplayGenerationTwoRebuildsByteOffsetNotes(t *testing.T) {
+	var starts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprint(w, `{"latest-server-index":2}`)
+			return
+		}
+		starts = append(starts, r.URL.Query().Get("start-index"))
+		fmt.Fprint(w, `{"items":[{"task":{"e":"Task7","t":0,"p":{"tt":"Native task","nt":{"t":1,"v":"Native Task7 note α 🚀\nSecond line."}}}},{"task":{"e":"Task7","t":1,"p":{"nt":{"t":2,"ps":[{"r":"Update","p":26,"l":5,"ch":3672733299}]}}}}],"current-item-index":2}`)
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "live.db")
+	s := legacyReplayDB(t, path, things.New(server.URL, "test@example.com", "password"), 2)
+	defer s.Close()
+	mustSaveTask(t, s, &things.Task{
+		UUID:  "task",
+		Title: "Native task",
+		Note:  "Native Task7 note α 🚀\nSecoUpdatene.",
+	})
+	if _, err := s.db.Exec(`UPDATE task_replay_state SET version=2 WHERE id=1`); err != nil {
+		t.Fatal(err)
+	}
+	before := replayLog(t, s)
+
+	changes, err := s.Sync()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.getTask("task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Note != "Native Task7 note α 🚀\nUpdated line." {
+		t.Fatalf("replayed note = %q", got.Note)
+	}
+	if len(changes) != 0 || !reflect.DeepEqual(before, replayLog(t, s)) {
+		t.Fatalf("caught-up recovery changed audit: changes=%v", changes)
+	}
+	generation, err := s.taskReplayVersion()
+	if err != nil || generation != things.TaskReplayVersion {
+		t.Fatalf("generation=%d err=%v", generation, err)
+	}
+	if !reflect.DeepEqual(starts, []string{"0"}) {
+		t.Fatalf("replay starts=%v", starts)
+	}
+}
+
 func TestTask7ReplayPreservesAuditAndReopens(t *testing.T) {
 	for _, cutoff := range []int{3, 4} {
 		t.Run(fmt.Sprint(cutoff), func(t *testing.T) {

--- a/task_read.go
+++ b/task_read.go
@@ -10,7 +10,7 @@ import (
 
 // TaskReplayVersion identifies the task read semantics used to build derived
 // state. Cached state from older generations must be replayed from scratch.
-const TaskReplayVersion = 2
+const TaskReplayVersion = 3
 
 // UnsupportedTaskKindError means the task state would be incomplete if replay
 // continued. ServerIndex is -1 when the source did not provide an index.


### PR DESCRIPTION
Native Things note edits after Unicode text were replayed at the wrong position because the decoder counted characters instead of UTF-8 bytes. For example, a captured edit produced `SecoUpdatene.` in the SDK where Things displayed `Updated line.`.

This change applies byte offsets, bounds numeric ranges without integer overflow, and bumps replay generation to 3. Existing CLI caches and SQLite state rebuild even when already caught up; SQLite audit rows and original cache backups are preserved. Public method signatures and production Task6 writes remain unchanged.

Validation: full race and coverage suites, build, vet, lint, independent review, captured native Unicode regression, live disposable-account cache repair, and normal Things restart all passed. The included verification report records ten direct test-only Task7 operations and the remaining limits.

Malformed byte ranges can still yield invalid UTF-8; checked transactional replay is follow-up work. Recurrence and the full Task7 write contract remain unverified.
