### PR TITLE
Prevent malformed note deltas from advancing synchronized state

### DIFF
--- a/docs/task7-write-verification.md
+++ b/docs/task7-write-verification.md
@@ -73,18 +73,41 @@ caught-up version-2 cache/database recovery with preserved SQLite audit rows.
 The actual disposable-account version-2 CLI cache was also repaired by the
 new binary and matched the app after restart.
 
+## Follow-up: checked replay and relationship tests
+
+Checked note replay now rejects invalid UTF-8 before applying a memory batch
+or committing a SQLite transaction. Existing public `ApplyPatches` behavior
+remains available; the state backends use the checked path. The decoder does
+not infer checksum semantics from this example.
+
+A further seven-object commit created a Task7 project in the disposable area,
+a Task7 heading, two Task7 child tasks, a Tag4 tag, and two ChecklistItem3
+children. One task was created under the heading with the tag and checklist;
+the other was created directly under the project. Exact cloud readback,
+SDK state, and read-only Things database checks passed for all objects and
+relationships. The project, heading, and tasks displayed correctly in Things.
+
+A subsequent two-task commit moved the first child from its heading/project
+to the disposable area, cleared its tag, and moved the second child into the
+heading with that tag. Explicit empty relationship arrays and the submitted
+ordering values matched both the SDK and Things database after sync. The
+project view showed the second child under the heading.
+
+This verifies those particular batch and relationship shapes. It does not
+test concurrent reordering, every checklist operation, or repeat-instance
+relationships. The default SDK/CLI write envelope remains Task6.
+
 ## Remaining verification gaps
 
 - Non-null `rp`/`rr`, modern recurrence and repeat-instance operations.
-- Direct Task7 project/heading creation, relationship moves, tags, checklists,
-  reminders, ordering under concurrency, and bulk writes.
+- Reminders, ordering under concurrency, and broader bulk/checklist operations
+  beyond the specific creation and move cases above.
 - Permanent deletion and wire action `t=2` were not exercised in this write test.
 - Conflict/retry behavior, offline concurrent edits, and multi-device convergence.
 - Raw native HTTP headers/body equivalence; server persistence may normalize
   requests. No TLS interception or certificate changes were used.
 - The general malformed-patch/checksum contract is not established by this
-  successful Unicode example. A malformed byte range splitting a multibyte
-  character can still yield invalid UTF-8; checked replay with transactional
-  error propagation would require a separate change.
+  successful Unicode example. Checked replay rejects invalid UTF-8 results;
+  it does not detect every semantically wrong patch that still yields valid text.
 
 These limits must stay explicit in any proposal to enable Task7 writes.

--- a/notes.go
+++ b/notes.go
@@ -1,5 +1,10 @@
 package thingscloud
 
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
 // NoteTypeFullText indicates a note with complete text
 const NoteTypeFullText = 1
 
@@ -25,8 +30,24 @@ type Note struct {
 
 // ApplyPatches applies a series of text patches using UTF-8 byte offsets.
 func ApplyPatches(original string, patches []NotePatch) string {
+	result, _ := applyPatches(original, patches, false)
+	return result
+}
+
+// ApplyPatchesChecked applies byte-offset patches and rejects any patch that
+// leaves the note in an invalid UTF-8 state. ApplyPatches remains available for
+// callers that rely on its historical unchecked behavior.
+func ApplyPatchesChecked(original string, patches []NotePatch) (string, error) {
+	return applyPatches(original, patches, true)
+}
+
+func applyPatches(original string, patches []NotePatch, validateUTF8 bool) (string, error) {
+	if validateUTF8 && !utf8.ValidString(original) {
+		return "", fmt.Errorf("original note is not valid UTF-8")
+	}
+
 	text := []byte(original)
-	for _, p := range patches {
+	for i, p := range patches {
 		position := p.Position
 		if position < 0 {
 			position = 0
@@ -48,7 +69,10 @@ func ApplyPatches(original string, patches []NotePatch) string {
 		result := append([]byte(nil), text[:position]...)
 		result = append(result, p.Replacement...)
 		result = append(result, text[end:]...)
+		if validateUTF8 && !utf8.Valid(result) {
+			return "", fmt.Errorf("note patch %d produced invalid UTF-8", i)
+		}
 		text = result
 	}
-	return string(text)
+	return string(text), nil
 }

--- a/notes_test.go
+++ b/notes_test.go
@@ -2,7 +2,9 @@ package thingscloud
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestNote_FullText(t *testing.T) {
@@ -83,5 +85,87 @@ func TestNote_ApplyMultiplePatches(t *testing.T) {
 	result := ApplyPatches(original, patches)
 	if result != "XBCDEF" {
 		t.Errorf("expected 'XBCDEF', got '%s'", result)
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	_, err := ApplyPatchesChecked("α", []NotePatch{{Position: 1, Length: 1}})
+	if err == nil {
+		t.Fatal("ApplyPatchesChecked accepted a patch that split a UTF-8 encoding")
+	}
+	if !strings.Contains(err.Error(), "patch 0") {
+		t.Fatalf("error %q does not identify the invalid patch", err)
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidOriginal(t *testing.T) {
+	t.Parallel()
+
+	invalid := string([]byte{0xff})
+	for _, patches := range [][]NotePatch{
+		nil,
+		{{Position: 0, Length: 1, Replacement: "valid"}},
+	} {
+		if _, err := ApplyPatchesChecked(invalid, patches); err == nil {
+			t.Fatalf("ApplyPatchesChecked accepted invalid original with patches %+v", patches)
+		}
+	}
+}
+
+func TestApplyPatchesCheckedAllowsMidCodePointNoOpWhenResultIsValid(t *testing.T) {
+	t.Parallel()
+
+	got, err := ApplyPatchesChecked("α", []NotePatch{{Position: 1}})
+	if err != nil {
+		t.Fatalf("ApplyPatchesChecked rejected a valid result: %v", err)
+	}
+	if got != "α" {
+		t.Fatalf("ApplyPatchesChecked = %q, want α", got)
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidIntermediateResult(t *testing.T) {
+	t.Parallel()
+
+	patches := []NotePatch{
+		{Position: 1, Length: 1}, // Leaves only the first byte of α.
+		{Position: 0, Length: 1}, // Would make the final result valid again.
+	}
+	if got := ApplyPatches("α", patches); got != "" || !utf8.ValidString(got) {
+		t.Fatalf("test setup produced %q, want a valid empty final result", got)
+	}
+	if _, err := ApplyPatchesChecked("α", patches); err == nil {
+		t.Fatal("ApplyPatchesChecked accepted an invalid intermediate result")
+	}
+}
+
+func TestApplyPatchesCheckedRejectsInvalidLaterPatch(t *testing.T) {
+	t.Parallel()
+
+	patches := []NotePatch{
+		{Position: 0, Length: 0, Replacement: "A"},
+		{Position: 2, Length: 1}, // Splits α after the valid insertion.
+	}
+	if _, err := ApplyPatchesChecked("α", patches); err == nil || !strings.Contains(err.Error(), "patch 1") {
+		t.Fatalf("ApplyPatchesChecked error = %v, want invalid patch 1", err)
+	}
+}
+
+func TestApplyPatchesCheckedValidNativeUnicodeDelta(t *testing.T) {
+	t.Parallel()
+
+	got, err := ApplyPatchesChecked("Native Task7 note α 🚀\nSecond line.", []NotePatch{{
+		Position:    26,
+		Length:      5,
+		Replacement: "Update",
+		Checksum:    3672733299,
+	}})
+	if err != nil {
+		t.Fatalf("ApplyPatchesChecked: %v", err)
+	}
+	if got != "Native Task7 note α 🚀\nUpdated line." {
+		t.Fatalf("ApplyPatchesChecked = %q", got)
 	}
 }

--- a/state/memory/memory.go
+++ b/state/memory/memory.go
@@ -146,22 +146,6 @@ func (s *State) updateTask(item things.TaskActionItem) *things.Task {
 		ids := *item.P.ParentTaskIDs
 		t.ParentTaskIDs = ids
 	}
-	if item.P.Note != nil {
-		var noteStr string
-		if err := json.Unmarshal(item.P.Note, &noteStr); err == nil {
-			t.Note = noteStr
-		} else {
-			var note things.Note
-			if err := json.Unmarshal(item.P.Note, &note); err == nil {
-				switch note.Type {
-				case things.NoteTypeFullText:
-					t.Note = note.Value
-				case things.NoteTypeDelta:
-					t.Note = things.ApplyPatches(t.Note, note.Patches)
-				}
-			}
-		}
-	}
 	if item.P.AlarmTimeOffset != nil {
 		t.AlarmTimeOffset = item.P.AlarmTimeOffset
 	}
@@ -261,9 +245,25 @@ func (s *State) Update(items ...things.Item) error {
 	// especially note deltas that would be applied twice on retry.
 	taskPayloads := make([]things.TaskReadPayload, len(items))
 	decodedTaskPayload := make([]bool, len(items))
+	resolvedTaskNotes := make([]string, len(items))
+	resolvedTaskNote := make([]bool, len(items))
+	type noteState struct {
+		value  string
+		exists bool
+	}
+	notes := make(map[string]noteState)
 	for i, rawItem := range items {
 		switch rawItem.Kind {
 		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+			legacy := isLegacyItemKind(rawItem.Kind)
+			id := rawItem.UUID
+			if legacy && things.ValidateUUID(id) != nil {
+				id = things.EncodeLegacyIdentifier(id)
+			}
+			if rawItem.Action == things.ItemActionDeleted {
+				notes[id] = noteState{}
+				continue
+			}
 			if rawItem.Action != things.ItemActionCreated && rawItem.Action != things.ItemActionModified {
 				continue
 			}
@@ -273,6 +273,33 @@ func (s *State) Update(items ...things.Item) error {
 			}
 			taskPayloads[i] = payload
 			decodedTaskPayload[i] = true
+
+			current := ""
+			if state, ok := notes[id]; ok {
+				if state.exists {
+					current = state.value
+				}
+			} else if task := s.Tasks[id]; task != nil {
+				current = task.Note
+			}
+			resolved, err := payload.ResolveNote(current)
+			if err != nil {
+				return err
+			}
+			resolvedTaskNotes[i] = resolved
+			resolvedTaskNote[i] = true
+			notes[id] = noteState{value: resolved, exists: true}
+
+		case things.ItemKindTombstone, things.ItemKindTombstonePlain:
+			var payload things.TombstoneActionItemPayload
+			if err := json.Unmarshal(rawItem.P, &payload); err != nil {
+				continue
+			}
+			oid := payload.DeletedObjectID
+			if isLegacyItemKind(rawItem.Kind) && things.ValidateUUID(oid) != nil {
+				oid = things.EncodeLegacyIdentifier(oid)
+			}
+			notes[oid] = noteState{}
 		}
 	}
 
@@ -303,6 +330,9 @@ func (s *State) Update(items ...things.Item) error {
 				fallthrough
 			case things.ItemActionModified:
 				task := s.updateTask(item)
+				if resolvedTaskNote[i] {
+					task.Note = resolvedTaskNotes[i]
+				}
 				payload.ApplyNulls(task)
 				s.Tasks[item.UUID()] = task
 			case things.ItemActionDeleted:

--- a/state/memory/task7_test.go
+++ b/state/memory/task7_test.go
@@ -234,6 +234,121 @@ func TestStateUpdateRejectsMalformedTaskPayloadBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestStateUpdateRejectsInvalidNoteDeltaBeforeBatchMutation(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	if err := state.Update(
+		taskReadItem("first", task7Kind, things.ItemActionCreated, `{"tt":"before","nt":"safe"}`),
+		taskReadItem("unicode", task7Kind, things.ItemActionCreated, `{"nt":"α"}`),
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := state.Update(
+		taskReadItem("first", task7Kind, things.ItemActionModified, `{"tt":"after","nt":"changed"}`),
+		taskReadItem("created", task7Kind, things.ItemActionCreated, `{"tt":"must roll back"}`),
+		taskReadItem("unicode", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+	)
+	if err == nil {
+		t.Fatal("Update accepted a note delta that produced invalid UTF-8")
+	}
+	if got := requireTask(t, state, "first"); got.Title != "before" || got.Note != "safe" {
+		t.Fatalf("earlier task mutated: %+v", got)
+	}
+	if _, ok := state.Tasks["created"]; ok {
+		t.Fatal("earlier task create survived rejected batch")
+	}
+	if got := requireTask(t, state, "unicode").Note; got != "α" {
+		t.Fatalf("invalid delta changed note to %q", got)
+	}
+}
+
+func TestStateUpdateNotePreflightTracksEarlierBatchEvents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create then malformed delta", func(t *testing.T) {
+		state := NewState()
+		err := state.Update(
+			taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`),
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		)
+		if err == nil {
+			t.Fatal("Update accepted malformed delta against an earlier create")
+		}
+		if _, ok := state.Tasks["note"]; ok {
+			t.Fatal("create survived rejected batch")
+		}
+	})
+
+	t.Run("valid edit then malformed delta", func(t *testing.T) {
+		state := NewState()
+		if err := state.Update(taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		err := state.Update(
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"A"}]}}`),
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":2,"l":1,"r":""}]}}`),
+		)
+		if err == nil {
+			t.Fatal("Update accepted malformed delta against an earlier edit")
+		}
+		if got := requireTask(t, state, "note").Note; got != "α" {
+			t.Fatalf("batch changed note to %q", got)
+		}
+	})
+
+	t.Run("delete then delta starts from empty note", func(t *testing.T) {
+		state := NewState()
+		if err := state.Update(taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.Update(
+			taskReadItem("note", task7Kind, things.ItemActionDeleted, `{}`),
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		); err != nil {
+			t.Fatalf("delta after delete should use an empty note: %v", err)
+		}
+		if got := requireTask(t, state, "note").Note; got != "" {
+			t.Fatalf("note after delete and clamped delta = %q", got)
+		}
+	})
+
+	t.Run("tombstone then delta starts from empty note", func(t *testing.T) {
+		state := NewState()
+		if err := state.Update(taskReadItem("note", task7Kind, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.Update(
+			things.Item{UUID: "tombstone", Kind: things.ItemKindTombstone, P: json.RawMessage(`{"dloid":"note"}`)},
+			taskReadItem("note", task7Kind, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		); err != nil {
+			t.Fatalf("delta after tombstone should use an empty note: %v", err)
+		}
+		if got := requireTask(t, state, "note").Note; got != "" {
+			t.Fatalf("note after tombstone and clamped delta = %q", got)
+		}
+	})
+
+	t.Run("legacy tombstone and task share normalized identity", func(t *testing.T) {
+		const legacyID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+		currentID := things.EncodeLegacyIdentifier(legacyID)
+		state := NewState()
+		if err := state.Update(taskReadItem(legacyID, things.ItemKindTaskPlain, things.ItemActionCreated, `{"nt":"α"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := state.Update(
+			things.Item{UUID: "legacy-tombstone", Kind: things.ItemKindTombstonePlain, P: json.RawMessage(`{"dloid":"` + legacyID + `"}`)},
+			taskReadItem(legacyID, things.ItemKindTaskPlain, things.ItemActionModified, `{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}`),
+		); err != nil {
+			t.Fatalf("delta after legacy tombstone should use an empty note: %v", err)
+		}
+		if got := requireTask(t, state, currentID).Note; got != "" {
+			t.Fatalf("note after legacy tombstone and clamped delta = %q", got)
+		}
+	})
+}
+
 func TestStateUpdateTask7DatePrecision(t *testing.T) {
 	t.Parallel()
 

--- a/sync/coverage_test.go
+++ b/sync/coverage_test.go
@@ -389,47 +389,10 @@ func TestProcessTagChecklistTombstone(t *testing.T) {
 	})
 }
 
-// TestProcessNotePayloads covers parseNotePayload for plain-string, full-text,
-// and delta note representations.
+// TestProcessNotePayloads covers delivery of a decoded note through the
+// transactional sync path.
 func TestProcessNotePayloads(t *testing.T) {
 	t.Parallel()
-
-	t.Run("plain string note", func(t *testing.T) {
-		t.Parallel()
-		got := parseNotePayload("old", json.RawMessage(`"a plain note"`))
-		if got != "a plain note" {
-			t.Errorf("expected plain string note, got %q", got)
-		}
-	})
-
-	t.Run("full text note", func(t *testing.T) {
-		t.Parallel()
-		raw, _ := json.Marshal(things.Note{Type: things.NoteTypeFullText, Value: "full replacement"})
-		got := parseNotePayload("old", raw)
-		if got != "full replacement" {
-			t.Errorf("expected full-text replacement, got %q", got)
-		}
-	})
-
-	t.Run("delta note applies patches", func(t *testing.T) {
-		t.Parallel()
-		raw, _ := json.Marshal(things.Note{
-			Type:    things.NoteTypeDelta,
-			Patches: []things.NotePatch{{Position: 0, Length: 0, Replacement: "Hi "}},
-		})
-		got := parseNotePayload("there", raw)
-		if got != "Hi there" {
-			t.Errorf("expected patched note 'Hi there', got %q", got)
-		}
-	})
-
-	t.Run("invalid note keeps current value", func(t *testing.T) {
-		t.Parallel()
-		got := parseNotePayload("unchanged", json.RawMessage(`12345`))
-		if got != "unchanged" {
-			t.Errorf("expected current note preserved, got %q", got)
-		}
-	})
 
 	t.Run("note delivered through processItems", func(t *testing.T) {
 		t.Parallel()

--- a/sync/process.go
+++ b/sync/process.go
@@ -135,6 +135,11 @@ func (s *Syncer) processTaskItem(item things.Item, serverIndex int, ts time.Time
 
 	// Apply payload to build new state
 	newTask := applyTaskPayload(old, item.UUID, payload.TaskActionItemPayload)
+	resolvedNote, err := payload.ResolveNote(newTask.Note)
+	if err != nil {
+		return nil, err
+	}
+	newTask.Note = resolvedNote
 	payload.ApplyNulls(newTask)
 
 	// Save the new state
@@ -467,43 +472,5 @@ func applyTaskPayload(old *things.Task, uuid string, p things.TaskActionItemPayl
 		t.DelegateIDs = *p.DelegateIDs
 	}
 
-	// Handle Note specially: can be string or Note struct with patches
-	if len(p.Note) > 0 {
-		t.Note = parseNotePayload(t.Note, p.Note)
-	}
-
 	return t
-}
-
-// parseNotePayload parses the note field from a task payload.
-// The note can be either a plain string or a structured Note object with patches.
-func parseNotePayload(currentNote string, raw json.RawMessage) string {
-	// First, try to unmarshal as a string (most common case)
-	var noteStr string
-	if err := json.Unmarshal(raw, &noteStr); err == nil {
-		return noteStr
-	}
-
-	// Try to unmarshal as a structured Note
-	var note things.Note
-	if err := json.Unmarshal(raw, &note); err != nil {
-		// If both fail, return the current note unchanged
-		return currentNote
-	}
-
-	// Handle based on note type
-	switch note.Type {
-	case things.NoteTypeFullText:
-		// Full text replacement
-		return note.Value
-	case things.NoteTypeDelta:
-		// Apply patches to current note
-		return things.ApplyPatches(currentNote, note.Patches)
-	default:
-		// Unknown type, return value if present
-		if note.Value != "" {
-			return note.Value
-		}
-		return currentNote
-	}
 }

--- a/sync/robustness_test.go
+++ b/sync/robustness_test.go
@@ -59,6 +59,65 @@ func TestSync_CursorSurvivesMidSyncFailure(t *testing.T) {
 	}
 }
 
+func TestSync_InvalidNoteDeltaRollsBackBatchAndCursor(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/items") {
+			fmt.Fprint(w, `{"items":[{"existing":{"e":"Task7","t":1,"p":{"tt":"after"}}},{"created":{"e":"Task7","t":0,"p":{"tt":"must roll back"}}},{"unicode":{"e":"Task7","t":1,"p":{"nt":{"t":2,"ps":[{"p":1,"l":1,"r":""}]}}}}],"current-item-index":4,"schema":301}`)
+			return
+		}
+		fmt.Fprint(w, `{"latest-server-index":4,"latest-schema-version":301}`)
+	}))
+	defer server.Close()
+
+	client := things.New(server.URL, "test@example.com", "password")
+	syncer, err := Open(filepath.Join(t.TempDir(), "test.db"), client)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer syncer.Close()
+
+	seed := []things.Item{
+		{UUID: "existing", Kind: things.ItemKindTask7, Action: things.ItemActionCreated, P: json.RawMessage(`{"tt":"before"}`)},
+		{UUID: "unicode", Kind: things.ItemKindTask7, Action: things.ItemActionCreated, P: json.RawMessage(`{"nt":"α"}`)},
+	}
+	if _, err := syncer.processItems(seed, 0); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := syncer.saveSyncState("history", 1); err != nil {
+		t.Fatalf("saveSyncState: %v", err)
+	}
+	var auditBefore int
+	if err := syncer.db.QueryRow(`SELECT COUNT(*) FROM change_log`).Scan(&auditBefore); err != nil {
+		t.Fatalf("count audit before: %v", err)
+	}
+
+	if _, err := syncer.Sync(); err == nil {
+		t.Fatal("Sync accepted invalid note delta")
+	}
+	if got := syncer.LastSyncedIndex(); got != 1 {
+		t.Fatalf("cursor = %d, want 1", got)
+	}
+	var auditAfter int
+	if err := syncer.db.QueryRow(`SELECT COUNT(*) FROM change_log`).Scan(&auditAfter); err != nil {
+		t.Fatalf("count audit after: %v", err)
+	}
+	if auditAfter != auditBefore {
+		t.Fatalf("audit rows = %d, want unchanged %d", auditAfter, auditBefore)
+	}
+	if got, err := syncer.getTask("existing"); err != nil || got == nil || got.Title != "before" {
+		t.Fatalf("existing task changed: %+v, err=%v", got, err)
+	}
+	if got, err := syncer.getTask("created"); err != nil || got != nil {
+		t.Fatalf("created task survived rollback: %+v, err=%v", got, err)
+	}
+	if got, err := syncer.getTask("unicode"); err != nil || got == nil || got.Note != "α" {
+		t.Fatalf("unicode task changed: %+v, err=%v", got, err)
+	}
+}
+
 // TestGetTask_ExcludesSoftDeleted: getTask must filter deleted rows like
 // every other entity, otherwise delete replays emit duplicate TaskDeleted
 // events and State.Task returns tasks the user deleted.

--- a/task_read.go
+++ b/task_read.go
@@ -114,6 +114,39 @@ func validateTaskReadNote(raw json.RawMessage) error {
 	return nil
 }
 
+// ResolveNote applies the note field to current using the read protocol's
+// plain-text, full-text, delta, and explicit-null semantics.
+func (p TaskReadPayload) ResolveNote(current string) (string, error) {
+	if p.nullFields["nt"] {
+		return "", nil
+	}
+	if len(p.Note) == 0 {
+		return current, nil
+	}
+
+	var noteText string
+	if err := json.Unmarshal(p.Note, &noteText); err == nil {
+		return noteText, nil
+	}
+
+	var note Note
+	if err := json.Unmarshal(p.Note, &note); err != nil {
+		return "", fmt.Errorf("decoding task note: %w", err)
+	}
+	switch note.Type {
+	case NoteTypeFullText:
+		return note.Value, nil
+	case NoteTypeDelta:
+		result, err := ApplyPatchesChecked(current, note.Patches)
+		if err != nil {
+			return "", fmt.Errorf("applying task note delta: %w", err)
+		}
+		return result, nil
+	default:
+		return "", fmt.Errorf("unsupported task note type %d", note.Type)
+	}
+}
+
 // ApplyNulls clears nullable fields after the ordinary non-nil payload fields
 // have been applied. In particular, tir is a reference date and never changes
 // ScheduledDate; only sr controls that field.

--- a/task_read_test.go
+++ b/task_read_test.go
@@ -50,6 +50,52 @@ func TestTaskReadPayloadAcceptsKnownNoteFormats(t *testing.T) {
 	}
 }
 
+func TestTaskReadPayloadResolveNote(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		current string
+		raw     string
+		want    string
+	}{
+		{name: "omitted", current: "unchanged", raw: `{}`, want: "unchanged"},
+		{name: "null", current: "old", raw: `{"nt":null}`, want: ""},
+		{name: "plain", current: "old", raw: `{"nt":"a plain note"}`, want: "a plain note"},
+		{name: "full", current: "old", raw: `{"nt":{"t":1,"v":"full replacement"}}`, want: "full replacement"},
+		{name: "delta", current: "there", raw: `{"nt":{"t":2,"ps":[{"p":0,"l":0,"r":"Hi "}]}}`, want: "Hi there"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload, err := DecodeTaskReadPayload([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("DecodeTaskReadPayload: %v", err)
+			}
+			got, err := payload.ResolveNote(tt.current)
+			if err != nil {
+				t.Fatalf("ResolveNote: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveNote = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTaskReadPayloadRejectsUnknownAndMalformedNotes(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		`{"nt":42}`,
+		`{"nt":{"t":3,"v":"unsupported"}}`,
+		`{"nt":{"t":2,"ps":"malformed"}}`,
+	} {
+		if _, err := DecodeTaskReadPayload([]byte(raw)); err == nil {
+			t.Errorf("DecodeTaskReadPayload accepted %s", raw)
+		}
+	}
+}
+
 func TestTaskReadKindsAndSanitizedError(t *testing.T) {
 	if err := ValidateTaskReadKinds([]Item{{Kind: "Task6"}, {Kind: "Task7"}, {Kind: "Task4"}, {Kind: "Settings5"}}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
A malformed byte-offset note delta could leave invalid UTF-8 in synchronized state. Checked replay now rejects that result before a memory batch mutates anything or a SQLite transaction commits entities, audit rows, or its cursor.

The memory preflight resolves earlier creates, edits, direct deletions, and current/legacy tombstones in order. SQLite uses its existing transaction rollback. The public `ApplyPatches` signature and unchecked behavior remain compatible; state backends use the additive checked helper. The obsolete unchecked parser was removed and its useful coverage moved to the production decoder. Replay generation stays at 3 and default writes remain Task6.

Validation covers the captured native Unicode delta, invalid initial/intermediate text, failed later edits, tombstone ordering, and unchanged SQLite state/cursor/audit on failure. Full race tests, vet, lint, and independent review passed. The verification report also records successful disposable-account project/heading creation, tag/checklist relationships, and batch moves.

Checksum semantics, recurrence writes, and concurrent/offline convergence remain unverified.
