### PR TITLE
Move verified task writes to Task7 without guessing recurrence state

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,13 @@ func main() {
 }
 ```
 
-### Task7 reads and recovery
+### Task7 writes, reads, and recovery
 
-The readers accept Task7 alongside Task6 and older task kinds. Task7 write semantics are still unverified: `History.Write` rejects Task7 and unsupported future task kinds, and the CLI continues to send Task6. New read support does not change the outgoing payload format.
+The CLI uses Task7 for validated ordinary task, project, and heading creation and modification. `History.Write` also accepts explicit `ItemKindTask7` envelopes within that scope. It checks existing update targets against raw history and rejects recurring or unknown targets before posting. This adds a history read for update requests. Direct recurrence configuration, note-delta writes, and Task7 deletion events remain unsupported; other entity formats, including Tombstone2 purge, are unchanged.
+
+Older or sparse task histories that never explicitly establish `rr`, `rp`, and `rt` are also rejected by CLI updates, even when the task may be ordinary. This is a compatibility limit of the first Task7 rollout: the checker does not guess missing recurrence state and does not silently retry through Task6.
+
+Existing SDK callers retain `ItemKindTask == "Task6"` and their previous write behavior. The readers accept both versions and older task kinds. Migrating outgoing writes does not rewrite stored tasks or history. See [Task7 write policy](docs/task7-write-policy.md) for the exact boundary, SDK usage, and mixed-version live evidence.
 
 The first read after this upgrade replays state built by an older task reader:
 
@@ -393,7 +397,7 @@ Key findings from reverse engineering the Things Cloud sync protocol:
 - **Status field (`ss`)**: `0` = Pending, `2` = Canceled, `3` = Completed. Don't confuse with `st` (schedule)!
 - **Headings (`tp=2`) must have `st=1`** (anytime). `st=0` (inbox) crashes Things.app.
 - **Tasks in projects, headings, or areas** should default to `st=1` (anytime) — they've been triaged out of inbox.
-- **Kind strings**: `Task6`, `Tag4`, `ChecklistItem3`, `Area3`, `Tombstone2`
+- **Kind strings**: `Task7` for verified CLI task writes; `Task6` remains supported for existing SDK callers; `Tag4`, `ChecklistItem3`, `Area3`, `Tombstone2` for other entities.
 
 Since v0.3.0 the SDK enforces the identifier rules instead of trusting callers: `things.NewUUID()` generates canonical Base58 identifiers (one leading `1` per leading zero byte — a subtlety whose absence used to corrupt ~1 in 256 creates), `things.ValidateUUID()` checks any identifier, and `History.Write()` refuses items with invalid or duplicate UUIDs before anything reaches the server.
 

--- a/cmd/things-cli/main.go
+++ b/cmd/things-cli/main.go
@@ -43,6 +43,8 @@ type writeEnvelope struct {
 	payload any
 }
 
+const task7WriteKind = "Task7"
+
 func (w writeEnvelope) UUID() string { return w.id }
 
 func (w writeEnvelope) MarshalJSON() ([]byte, error) {
@@ -182,6 +184,13 @@ func validateTaskOpts(opts map[string]string) error {
 		if v, ok := opts[key]; ok && parseDate(v) == nil {
 			return fmt.Errorf("--%s: %q is invalid; expected a calendar date in YYYY-MM-DD format", key, v)
 		}
+	}
+	return nil
+}
+
+func validateEditContainers(area, project, heading string) error {
+	if area != "" && (project != "" || heading != "") {
+		return fmt.Errorf("--area cannot be combined with --project or --heading when editing a task")
 	}
 	return nil
 }
@@ -524,11 +533,15 @@ func (u *taskUpdate) Scheduled(sr, tir int64) *taskUpdate {
 
 func (u *taskUpdate) Area(uuid string) *taskUpdate {
 	u.fields["ar"] = []string{uuid}
+	u.fields["pr"] = []string{}
+	u.fields["agr"] = []string{}
 	return u
 }
 
 func (u *taskUpdate) Project(uuid string) *taskUpdate {
 	u.fields["pr"] = []string{uuid}
+	u.fields["ar"] = []string{}
+	u.fields["agr"] = []string{}
 	return u
 }
 
@@ -985,7 +998,7 @@ func cmdCreate(history *thingscloud.History, args []string) {
 	}
 
 	payload := newTaskCreatePayload(title, opts)
-	env := writeEnvelope{id: taskUUID, action: 0, kind: "Task6", payload: payload}
+	env := writeEnvelope{id: taskUUID, action: 0, kind: task7WriteKind, payload: payload}
 	if err := history.Write(env); err != nil {
 		fatal("create task", err)
 	}
@@ -1019,6 +1032,9 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 		fatal("edit", err)
 	}
 	if err := validateTaskOpts(opts); err != nil {
+		fatal("edit", err)
+	}
+	if err := validateEditContainers(opts["area"], opts["project"], opts["heading"]); err != nil {
 		fatal("edit", err)
 	}
 
@@ -1085,7 +1101,7 @@ func cmdEdit(history *thingscloud.History, taskUUID string, args []string) {
 		u.Tags(strings.Split(v, ","))
 	}
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("edit task", err)
 	}
@@ -1097,7 +1113,7 @@ func cmdComplete(history *thingscloud.History, taskUUID string) {
 	ts := nowTs()
 	u := newTaskUpdate().Status(3).StopDate(ts)
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("complete task", err)
 	}
@@ -1108,7 +1124,7 @@ func cmdComplete(history *thingscloud.History, taskUUID string) {
 func cmdTrash(history *thingscloud.History, taskUUID string) {
 	u := newTaskUpdate().Trash(true)
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("trash task", err)
 	}
@@ -1137,7 +1153,7 @@ func cmdPurge(history *thingscloud.History, taskUUID string) {
 func cmdMoveToToday(history *thingscloud.History, taskUUID string) {
 	u := newTaskUpdate().Today()
 
-	env := writeEnvelope{id: taskUUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: taskUUID, action: 1, kind: task7WriteKind, payload: u.build()}
 	if err := history.Write(env); err != nil {
 		fatal("move to today", err)
 	}
@@ -1360,7 +1376,7 @@ func buildBatchCreate(op BatchOp) (thingscloud.Identifiable, map[string]string, 
 	}
 
 	payload := newTaskCreatePayload(op.Title, opts)
-	env := writeEnvelope{id: taskUUID, action: 0, kind: "Task6", payload: payload}
+	env := writeEnvelope{id: taskUUID, action: 0, kind: task7WriteKind, payload: payload}
 
 	return env, map[string]string{"cmd": "create", "uuid": taskUUID, "title": op.Title}, nil
 }
@@ -1372,7 +1388,7 @@ func buildBatchComplete(op BatchOp) (thingscloud.Identifiable, map[string]string
 
 	ts := nowTs()
 	u := newTaskUpdate().Status(3).StopDate(ts)
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "complete", "uuid": op.UUID}, nil
 }
@@ -1383,7 +1399,7 @@ func buildBatchTrash(op BatchOp) (thingscloud.Identifiable, map[string]string, e
 	}
 
 	u := newTaskUpdate().Trash(true)
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "trash", "uuid": op.UUID}, nil
 }
@@ -1412,7 +1428,7 @@ func buildBatchMoveToToday(op BatchOp) (thingscloud.Identifiable, map[string]str
 	}
 
 	u := newTaskUpdate().Today()
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-today", "uuid": op.UUID}, nil
 }
@@ -1429,7 +1445,7 @@ func buildBatchMoveToProject(op BatchOp) (thingscloud.Identifiable, map[string]s
 	}
 
 	u := newTaskUpdate().Project(op.Project).Anytime()
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-project", "uuid": op.UUID, "project": op.Project}, nil
 }
@@ -1446,7 +1462,7 @@ func buildBatchMoveToArea(op BatchOp) (thingscloud.Identifiable, map[string]stri
 	}
 
 	u := newTaskUpdate().Area(op.Area).Anytime()
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "move-to-area", "uuid": op.UUID, "area": op.Area}, nil
 }
@@ -1466,6 +1482,9 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 		opts["deadline"] = op.Deadline
 	}
 	if err := validateTaskOpts(opts); err != nil {
+		return nil, nil, err
+	}
+	if err := validateEditContainers(op.Area, op.Project, op.Heading); err != nil {
 		return nil, nil, err
 	}
 
@@ -1516,7 +1535,7 @@ func buildBatchEdit(op BatchOp) (thingscloud.Identifiable, map[string]string, er
 		u.Tags(op.Tags)
 	}
 
-	env := writeEnvelope{id: op.UUID, action: 1, kind: "Task6", payload: u.build()}
+	env := writeEnvelope{id: op.UUID, action: 1, kind: task7WriteKind, payload: u.build()}
 
 	return env, map[string]string{"cmd": "edit", "uuid": op.UUID}, nil
 }

--- a/cmd/things-cli/main_test.go
+++ b/cmd/things-cli/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,6 +53,64 @@ func TestTaskUpdateAnytimeClearsScheduleDates(t *testing.T) {
 	assertAnytimeSchedule(t, payload)
 	if got := payload["pr"]; got == nil {
 		t.Fatal("project field was not set")
+	}
+}
+
+func TestTaskContainerMoveReplayClearsPreviousContainer(t *testing.T) {
+	tests := []struct {
+		name       string
+		initial    string
+		update     map[string]any
+		wantArea   []string
+		wantParent []string
+	}{
+		{
+			name:       "project and heading to area",
+			initial:    fmt.Sprintf(`{"tt":"child","pr":[%q],"agr":[%q]}`, testProjectID, testHeadingID),
+			update:     newTaskUpdate().Area(testAreaID).build(),
+			wantArea:   []string{testAreaID},
+			wantParent: []string{},
+		},
+		{
+			name:       "area and heading to project",
+			initial:    fmt.Sprintf(`{"tt":"child","ar":[%q],"agr":[%q]}`, testAreaID, testHeadingID),
+			update:     newTaskUpdate().Project(testProjectID).build(),
+			wantArea:   []string{},
+			wantParent: []string{testProjectID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := memory.NewState()
+			if err := state.Update(thingscloud.Item{
+				UUID: testTaskID, Kind: thingscloud.ItemKindTask7, Action: thingscloud.ItemActionCreated,
+				P: json.RawMessage(tt.initial),
+			}); err != nil {
+				t.Fatalf("seed task: %v", err)
+			}
+			payload, err := json.Marshal(tt.update)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := state.Update(thingscloud.Item{
+				UUID: testTaskID, Kind: thingscloud.ItemKindTask7, Action: thingscloud.ItemActionModified,
+				P: payload,
+			}); err != nil {
+				t.Fatalf("replay move: %v", err)
+			}
+
+			task := state.Tasks[testTaskID]
+			if fmt.Sprint(task.AreaIDs) != fmt.Sprint(tt.wantArea) {
+				t.Errorf("AreaIDs = %v, want %v", task.AreaIDs, tt.wantArea)
+			}
+			if fmt.Sprint(task.ParentTaskIDs) != fmt.Sprint(tt.wantParent) {
+				t.Errorf("ParentTaskIDs = %v, want %v", task.ParentTaskIDs, tt.wantParent)
+			}
+			if len(task.ActionGroupIDs) != 0 {
+				t.Errorf("ActionGroupIDs = %v, want cleared", task.ActionGroupIDs)
+			}
+		})
 	}
 }
 
@@ -279,7 +338,7 @@ func TestScheduledOptionValidation(t *testing.T) {
 
 func TestDirectCommandsRejectInvalidScheduledBeforeWrite(t *testing.T) {
 	if command := os.Getenv("THINGS_CLI_INVALID_SCHEDULE_COMMAND"); command != "" {
-		h, commits := newWireRecorder(t)
+		h, commits, _ := newWireRecorder(t)
 		switch command {
 		case "create":
 			cmdCreate(h, []string{"invalid", "--scheduled", "tomorrow", "--project", testProjectID})
@@ -367,6 +426,18 @@ func TestBatchMoveToProjectUsesNullScheduleDates(t *testing.T) {
 
 	payload := requirePayloadMap(t, env)
 	assertAnytimeSchedule(t, payload)
+	if got := payload["pr"].([]string); len(got) != 1 || got[0] != testProjectID {
+		t.Fatalf("pr = %v, want [%s]", got, testProjectID)
+	}
+	if got := payload["ar"].([]string); len(got) != 0 {
+		t.Fatalf("ar = %v, want []", got)
+	}
+	if got := payload["agr"].([]string); len(got) != 0 {
+		t.Fatalf("agr = %v, want []", got)
+	}
+	if len(payload) != 7 {
+		t.Fatalf("payload fields = %v, want only md, st, sr, tir, pr, ar, agr", payload)
+	}
 
 	bs, err := json.Marshal(env)
 	if err != nil {
@@ -395,7 +466,20 @@ func TestBatchMoveToAreaUsesNullScheduleDates(t *testing.T) {
 		t.Fatalf("buildBatchMoveToArea failed: %v", err)
 	}
 
-	assertAnytimeSchedule(t, requirePayloadMap(t, env))
+	payload := requirePayloadMap(t, env)
+	assertAnytimeSchedule(t, payload)
+	if got := payload["ar"].([]string); len(got) != 1 || got[0] != testAreaID {
+		t.Fatalf("ar = %v, want [%s]", got, testAreaID)
+	}
+	if got := payload["pr"].([]string); len(got) != 0 {
+		t.Fatalf("pr = %v, want []", got)
+	}
+	if got := payload["agr"].([]string); len(got) != 0 {
+		t.Fatalf("agr = %v, want []", got)
+	}
+	if len(payload) != 7 {
+		t.Fatalf("payload fields = %v, want only md, st, sr, tir, ar, pr, agr", payload)
+	}
 }
 
 func TestBatchEditAutoAnytimeUsesNullScheduleDates(t *testing.T) {
@@ -748,6 +832,26 @@ func TestBuildBatchEditRejectsInvalidRef(t *testing.T) {
 	_, _, err = buildBatchEdit(BatchOp{UUID: "bad uuid", Title: "y"})
 	if err == nil {
 		t.Error("buildBatchEdit with invalid target UUID: got nil error, want validation error")
+	}
+}
+
+func TestBuildBatchEditAllowsProjectWithHeading(t *testing.T) {
+	env, _, err := buildBatchEdit(BatchOp{
+		UUID: testTaskID, Project: testProjectID, Heading: testHeadingID,
+	})
+	if err != nil {
+		t.Fatalf("project with heading: %v", err)
+	}
+
+	payload := requirePayloadMap(t, env)
+	if got := payload["pr"].([]string); len(got) != 1 || got[0] != testProjectID {
+		t.Fatalf("pr = %v, want [%s]", got, testProjectID)
+	}
+	if got := payload["agr"].([]string); len(got) != 1 || got[0] != testHeadingID {
+		t.Fatalf("agr = %v, want [%s]", got, testHeadingID)
+	}
+	if got := payload["ar"].([]string); len(got) != 0 {
+		t.Fatalf("ar = %v, want []", got)
 	}
 }
 

--- a/cmd/things-cli/validation_test.go
+++ b/cmd/things-cli/validation_test.go
@@ -35,12 +35,13 @@ func TestCLIValidationHelper(t *testing.T) {
 }
 
 type cliValidationCloud struct {
-	server *httptest.Server
-	mu     sync.Mutex
-	bodies [][]byte
+	server       *httptest.Server
+	mu           sync.Mutex
+	bodies       [][]byte
+	historyReads int
 }
 
-func newCLIValidationCloud(t *testing.T) *cliValidationCloud {
+func newCLIValidationCloud(t *testing.T, ordinaryTaskIDs ...string) *cliValidationCloud {
 	t.Helper()
 	c := &cliValidationCloud{}
 	c.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,7 +57,36 @@ func newCLIValidationCloud(t *testing.T) *cliValidationCloud {
 			c.mu.Unlock()
 			_, _ = io.WriteString(w, `{"server-head-index":2}`)
 		case strings.HasSuffix(r.URL.Path, "/items"):
-			_, _ = io.WriteString(w, `{"items":[],"current-item-index":1,"schema":301}`)
+			c.mu.Lock()
+			c.historyReads++
+			c.mu.Unlock()
+			items := []map[string]any{}
+			if len(ordinaryTaskIDs) > 0 {
+				created := make(map[string]any, len(ordinaryTaskIDs))
+				for _, id := range ordinaryTaskIDs {
+					created[id] = map[string]any{
+						"e": "Task7",
+						"t": 0,
+						"p": map[string]any{
+							"tt": "seeded ordinary task",
+							"tp": 0,
+							"st": 1,
+							"ss": 0,
+							"rr": nil,
+							"rp": nil,
+							"rt": []string{},
+						},
+					}
+				}
+				items = append(items, created)
+			}
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items":              items,
+				"current-item-index": 1,
+				"schema":             301,
+			}); err != nil {
+				t.Errorf("encode history fixture: %v", err)
+			}
 		case strings.Contains(r.URL.Path, "/account/"):
 			_, _ = io.WriteString(w, `{"email":"validation@example.com","status":"SYAccountStatusActive","history-key":"validation-history"}`)
 		default:
@@ -71,6 +101,12 @@ func (c *cliValidationCloud) commits() [][]byte {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([][]byte(nil), c.bodies...)
+}
+
+func (c *cliValidationCloud) historyReadCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.historyReads
 }
 
 func runValidationCLI(t *testing.T, cloud *cliValidationCloud, stdin string, args ...string) (int, string) {
@@ -128,6 +164,8 @@ func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
 		{"create padded tag", []string{"create", "Task", "--tags", " " + id + " "}, "", "tags"},
 		{"edit padded tag", []string{"edit", id, "--tags", " " + otherID + " "}, "", "tags"},
 		{"edit empty tags value", []string{"edit", id, "--tags", ""}, "", "tags"},
+		{"edit area with project", []string{"edit", id, "--area", id, "--project", otherID}, "", "area"},
+		{"edit area with heading", []string{"edit", id, "--area", id, "--heading", otherID}, "", "area"},
 		{"create invalid when", []string{"create", "Task", "--when", "tomorrow"}, "", "when"},
 		{"create empty when", []string{"create", "Task", "--when", ""}, "", "when"},
 		{"create missing when value", []string{"create", "Task", "--when"}, "", "when"},
@@ -158,6 +196,8 @@ func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
 		{"batch edit invalid when", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"when":"tomorrow"}]`, id), "when"},
 		{"batch edit invalid deadline", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"deadline":"bad-date"}]`, id), "deadline"},
 		{"batch edit padded tag", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"tags":[%q]}]`, id, " "+otherID+" "), "tags"},
+		{"batch edit area with project", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"area":%q,"project":%q}]`, id, id, otherID), "area"},
+		{"batch edit area with heading", []string{"batch"}, fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"area":%q,"heading":%q}]`, id, id, otherID), "area"},
 		{"batch extra project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":"bad-project"}}]`, id), "project"},
 		{"batch extra empty project overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","project":%q,"extra":{"project":""}}]`, id), "project"},
 		{"batch extra tags overrides valid field", []string{"batch"}, fmt.Sprintf(`[{"cmd":"create","title":"x","tags":[%q],"extra":{"tags":"bad-tag"}}]`, id), "tags"},
@@ -187,6 +227,9 @@ func TestCLIWriteValidationRejectsInvalidInputBeforeCommit(t *testing.T) {
 			}
 			if got := len(cloud.commits()); got != 0 {
 				t.Errorf("commit requests = %d, want 0", got)
+			}
+			if got := cloud.historyReadCount(); got != 1 {
+				t.Errorf("history reads = %d, want only the initial head sync and no write preflight", got)
 			}
 		})
 	}
@@ -236,7 +279,7 @@ func TestCLIWriteValidationAcceptsBatchDatesAndScheduledExtra(t *testing.T) {
 		{"cmd":"create","title":"dated","uuid":%q,"when":"someday","deadline":"2026-10-14","project":%q,"tags":[%q],"extra":{"when":"anytime","deadline":"2026-10-15","scheduled":"2026-10-12"}},
 		{"cmd":"edit","uuid":%q,"when":"someday","deadline":"2026-10-20"}
 	]`, createID, projectID, tagID, editID)
-	cloud := newCLIValidationCloud(t)
+	cloud := newCLIValidationCloud(t, editID)
 	exitCode, output := runValidationCLI(t, cloud, input, "batch")
 	if exitCode != 0 {
 		t.Fatalf("exit code = %d: %s", exitCode, output)
@@ -259,21 +302,23 @@ func TestCLIWriteValidationAcceptsBatchDatesAndScheduledExtra(t *testing.T) {
 func TestCLIWriteValidationAcceptsUnsetBatchOptionals(t *testing.T) {
 	id := thingscloud.NewUUID()
 	tests := []struct {
-		name  string
-		input string
+		name            string
+		input           string
+		ordinaryTaskIDs []string
 	}{
 		{
-			"empty top-level strings without extra",
-			`[{"cmd":"create","title":"empty optionals","uuid":"","note":"","when":"","deadline":"","project":"","area":"","heading":"","tags":[],"type":""}]`,
+			name:  "empty top-level strings without extra",
+			input: `[{"cmd":"create","title":"empty optionals","uuid":"","note":"","when":"","deadline":"","project":"","area":"","heading":"","tags":[],"type":""}]`,
 		},
 		{
-			"null extra",
-			fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"title":"updated","extra":null}]`, id),
+			name:            "null extra",
+			input:           fmt.Sprintf(`[{"cmd":"edit","uuid":%q,"title":"updated","extra":null}]`, id),
+			ordinaryTaskIDs: []string{id},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cloud := newCLIValidationCloud(t)
+			cloud := newCLIValidationCloud(t, tc.ordinaryTaskIDs...)
 			exitCode, output := runValidationCLI(t, cloud, tc.input, "batch")
 			if exitCode != 0 {
 				t.Fatalf("exit code = %d: %s", exitCode, output)

--- a/cmd/things-cli/wire_test.go
+++ b/cmd/things-cli/wire_test.go
@@ -49,6 +49,10 @@ func TestTaskUpdateBuilderFields(t *testing.T) {
 			map[string]any{"dd": int64(1770000000)}},
 		{"Scheduled", func() map[string]any { return newTaskUpdate().Scheduled(100, 200).build() },
 			map[string]any{"sr": int64(100), "tir": int64(200)}},
+		{"Area", func() map[string]any { return newTaskUpdate().Area("area").build() },
+			map[string]any{"ar": []string{"area"}, "pr": []string{}, "agr": []string{}}},
+		{"Project", func() map[string]any { return newTaskUpdate().Project("project").build() },
+			map[string]any{"pr": []string{"project"}, "ar": []string{}, "agr": []string{}}},
 		{"Tags", func() map[string]any { return newTaskUpdate().Tags([]string{"a1", "b2"}).build() },
 			map[string]any{"tg": []string{"a1", "b2"}}},
 	}
@@ -233,14 +237,16 @@ type capturedCommit struct {
 	}
 }
 
-// newWireRecorder returns a History wired to a fake server plus a slice
-// collecting every commit POSTed through it.
-func newWireRecorder(t *testing.T) (*thingscloud.History, *[]capturedCommit) {
+// newWireRecorder returns a History wired to a fake server plus slices
+// collecting history preflight GETs and every commit POSTed through it.
+func newWireRecorder(t *testing.T, ordinaryTaskIDs ...string) (*thingscloud.History, *[]capturedCommit, *[]string) {
 	t.Helper()
 	var commits []capturedCommit
+	var historyRequests []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.Method == "POST" && strings.Contains(r.URL.Path, "/commit") {
+		switch {
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/commit"):
 			var cc capturedCommit
 			cc.ancestorIndex = r.URL.Query().Get("ancestor-index")
 			if err := json.NewDecoder(r.Body).Decode(&cc.body); err != nil {
@@ -248,15 +254,59 @@ func newWireRecorder(t *testing.T) (*thingscloud.History, *[]capturedCommit) {
 			}
 			commits = append(commits, cc)
 			fmt.Fprint(w, `{"server-head-index":42}`)
-			return
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/items"):
+			historyRequests = append(historyRequests, r.URL.RequestURI())
+			if got := r.URL.Query().Get("start-index"); got != "0" {
+				t.Errorf("preflight start-index = %q, want 0", got)
+			}
+			created := make(map[string]any, len(ordinaryTaskIDs))
+			for _, id := range ordinaryTaskIDs {
+				created[id] = map[string]any{
+					"e": "Task7",
+					"t": 0,
+					"p": map[string]any{
+						"tt": "seeded ordinary task",
+						"tp": 0,
+						"st": 1,
+						"ss": 0,
+						"rr": nil,
+						"rp": nil,
+						"rt": []string{},
+					},
+				}
+			}
+			items := make([]map[string]any, 7)
+			items[0] = created
+			for i := 1; i < len(items); i++ {
+				items[i] = map[string]any{}
+			}
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items":              items,
+				"current-item-index": 7,
+				"schema":             301,
+			}); err != nil {
+				t.Errorf("encode history fixture: %v", err)
+			}
+		default:
+			fmt.Fprint(w, `{}`)
 		}
-		fmt.Fprint(w, `{}`)
 	}))
 	t.Cleanup(server.Close)
 
 	c := thingscloud.New(server.URL, "test@example.com", "pw")
 	h := &thingscloud.History{Client: c, ID: "wire-test-history", LatestServerIndex: 7}
-	return h, &commits
+	return h, &commits, &historyRequests
+}
+
+func assertTaskPreflight(t *testing.T, historyRequests []string, commit capturedCommit) {
+	t.Helper()
+	want := "/version/1/history/wire-test-history/items?start-index=0"
+	if len(historyRequests) != 1 || historyRequests[0] != want {
+		t.Fatalf("history preflight requests = %q, want [%q]", historyRequests, want)
+	}
+	if commit.ancestorIndex != "7" {
+		t.Errorf("ancestor-index = %q, want preflight head 7", commit.ancestorIndex)
+	}
 }
 
 func singleItem(t *testing.T, cc capturedCommit) (uuid string, action int, kind string, payload map[string]any) {
@@ -275,7 +325,7 @@ func singleItem(t *testing.T, cc capturedCommit) (uuid string, action int, kind 
 }
 
 func TestCmdCreateWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, historyRequests := newWireRecorder(t)
 	id := thingscloud.NewUUID()
 
 	cmdCreate(h, []string{"Wire task", "--uuid", id, "--when", "today", "--note", "body"})
@@ -283,13 +333,16 @@ func TestCmdCreateWire(t *testing.T) {
 	if len(*commits) != 1 {
 		t.Fatalf("%d commits, want 1", len(*commits))
 	}
+	if len(*historyRequests) != 0 {
+		t.Fatalf("Task7 create made history preflight requests: %q", *historyRequests)
+	}
 	cc := (*commits)[0]
 	if cc.ancestorIndex != "7" {
 		t.Errorf("ancestor-index = %q, want 7 (the synced head)", cc.ancestorIndex)
 	}
 	gotID, action, kind, p := singleItem(t, cc)
-	if gotID != id || action != 0 || kind != "Task6" {
-		t.Errorf("envelope = (%s, %d, %s), want (%s, 0, Task6)", gotID, action, kind, id)
+	if gotID != id || action != 0 || kind != "Task7" {
+		t.Errorf("envelope = (%s, %d, %s), want (%s, 0, Task7)", gotID, action, kind, id)
 	}
 	if p["md"] != nil {
 		t.Errorf("create sent md = %v, must be null on creates", p["md"])
@@ -304,14 +357,15 @@ func TestCmdCreateWire(t *testing.T) {
 }
 
 func TestCmdCompleteWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 
 	cmdComplete(h, id)
 
 	_, action, kind, p := singleItem(t, (*commits)[0])
-	if action != 1 || kind != "Task6" {
-		t.Errorf("envelope action/kind = %d/%s, want 1/Task6", action, kind)
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if action != 1 || kind != "Task7" {
+		t.Errorf("envelope action/kind = %d/%s, want 1/Task7", action, kind)
 	}
 	if p["ss"] != float64(3) {
 		t.Errorf("ss = %v, want 3 (completed)", p["ss"])
@@ -325,19 +379,20 @@ func TestCmdCompleteWire(t *testing.T) {
 }
 
 func TestCmdTrashWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 
 	cmdTrash(h, id)
 
 	_, action, kind, p := singleItem(t, (*commits)[0])
-	if action != 1 || kind != "Task6" || p["tr"] != true {
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if action != 1 || kind != "Task7" || p["tr"] != true {
 		t.Errorf("trash wire = action %d kind %s tr %v", action, kind, p["tr"])
 	}
 }
 
 func TestCmdPurgeWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	target := thingscloud.NewUUID()
 
 	cmdPurge(h, target)
@@ -358,11 +413,13 @@ func TestCmdPurgeWire(t *testing.T) {
 }
 
 func TestCmdMoveToTodayWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 
-	cmdMoveToToday(h, thingscloud.NewUUID())
+	cmdMoveToToday(h, id)
 
 	_, _, _, p := singleItem(t, (*commits)[0])
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
 	if p["st"] != float64(1) {
 		t.Errorf("st = %v, want 1", p["st"])
 	}
@@ -372,7 +429,7 @@ func TestCmdMoveToTodayWire(t *testing.T) {
 }
 
 func TestCmdCreateAreaWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	id := thingscloud.NewUUID()
 
 	cmdCreateArea(h, []string{"Wire Area", "--uuid", id})
@@ -388,7 +445,7 @@ func TestCmdCreateAreaWire(t *testing.T) {
 }
 
 func TestCmdCreateTagWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	id := thingscloud.NewUUID()
 
 	cmdCreateTag(h, []string{"Wire Tag", "--uuid", id})
@@ -403,7 +460,7 @@ func TestCmdCreateTagWire(t *testing.T) {
 }
 
 func TestCmdAddChecklistWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
+	h, commits, _ := newWireRecorder(t)
 	task := thingscloud.NewUUID()
 
 	cmdAddChecklist(h, task, []string{"one,two"})
@@ -433,14 +490,15 @@ func TestCmdAddChecklistWire(t *testing.T) {
 }
 
 func TestCmdEditWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 	proj := thingscloud.NewUUID()
 
 	cmdEdit(h, id, []string{"--title", "renamed", "--project", proj})
 
 	gotID, action, kind, p := singleItem(t, (*commits)[0])
-	if gotID != id || action != 1 || kind != "Task6" {
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task7" {
 		t.Errorf("edit envelope = (%s, %d, %s)", gotID, action, kind)
 	}
 	if p["tt"] != "renamed" {
@@ -450,6 +508,12 @@ func TestCmdEditWire(t *testing.T) {
 	if len(pr) != 1 || pr[0] != proj {
 		t.Errorf("pr = %v, want [%s]", p["pr"], proj)
 	}
+	if ar, ok := p["ar"].([]any); !ok || len(ar) != 0 {
+		t.Errorf("ar = %v, want [] when moving to a project", p["ar"])
+	}
+	if agr, ok := p["agr"].([]any); !ok || len(agr) != 0 {
+		t.Errorf("agr = %v, want [] when moving to a project", p["agr"])
+	}
 	// Assigning a project without an explicit schedule must move the task
 	// out of inbox with null dates (Bug 8 + PR #9 semantics).
 	if p["st"] != float64(1) || p["sr"] != nil || p["tir"] != nil {
@@ -458,8 +522,8 @@ func TestCmdEditWire(t *testing.T) {
 }
 
 func TestCmdEditFutureScheduledWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 	proj := thingscloud.NewUUID()
 	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 	wantDate := float64(parseDate(future).Unix())
@@ -467,8 +531,9 @@ func TestCmdEditFutureScheduledWire(t *testing.T) {
 	cmdEdit(h, id, []string{"--scheduled", future, "--project", proj})
 
 	gotID, action, kind, p := singleItem(t, (*commits)[0])
-	if gotID != id || action != 1 || kind != "Task6" {
-		t.Fatalf("edit envelope = (%s, %d, %s), want (%s, 1, Task6)", gotID, action, kind, id)
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
+	if gotID != id || action != 1 || kind != "Task7" {
+		t.Fatalf("edit envelope = (%s, %d, %s), want (%s, 1, Task7)", gotID, action, kind, id)
 	}
 	if p["st"] != float64(2) || p["sr"] != wantDate || p["tir"] != wantDate {
 		t.Fatalf("future schedule = st:%v sr:%v tir:%v, want 2/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
@@ -477,14 +542,14 @@ func TestCmdEditFutureScheduledWire(t *testing.T) {
 	if !ok || len(pr) != 1 || pr[0] != proj {
 		t.Fatalf("pr = %v, want [%s]", p["pr"], proj)
 	}
-	if len(p) != 5 {
-		t.Fatalf("edit payload fields = %v, want only md, st, sr, tir, pr", p)
+	if len(p) != 7 {
+		t.Fatalf("edit payload fields = %v, want only md, st, sr, tir, pr, ar, agr", p)
 	}
 }
 
 func TestCmdEditExplicitWhenOverridesScheduledClassification(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id := thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id)
 	area := thingscloud.NewUUID()
 	future := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 	wantDate := float64(parseDate(future).Unix())
@@ -492,12 +557,19 @@ func TestCmdEditExplicitWhenOverridesScheduledClassification(t *testing.T) {
 	cmdEdit(h, id, []string{"--scheduled", future, "--when", "anytime", "--area", area})
 
 	_, _, _, p := singleItem(t, (*commits)[0])
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
 	if p["st"] != float64(1) || p["sr"] != wantDate || p["tir"] != wantDate {
 		t.Fatalf("explicit anytime schedule = st:%v sr:%v tir:%v, want 1/%v/%v", p["st"], p["sr"], p["tir"], wantDate, wantDate)
 	}
 	areas, ok := p["ar"].([]any)
 	if !ok || len(areas) != 1 || areas[0] != area {
 		t.Fatalf("ar = %v, want [%s]", p["ar"], area)
+	}
+	if pr, ok := p["pr"].([]any); !ok || len(pr) != 0 {
+		t.Errorf("pr = %v, want [] when moving to an area", p["pr"])
+	}
+	if agr, ok := p["agr"].([]any); !ok || len(agr) != 0 {
+		t.Errorf("agr = %v, want [] when moving to an area", p["agr"])
 	}
 }
 
@@ -573,8 +645,8 @@ func TestLoadStateBuildsAndCachesState(t *testing.T) {
 }
 
 func TestCmdBatchWire(t *testing.T) {
-	h, commits := newWireRecorder(t)
 	id1, id2 := thingscloud.NewUUID(), thingscloud.NewUUID()
+	h, commits, historyRequests := newWireRecorder(t, id2)
 
 	// cmdBatch reads ops from stdin.
 	ops := fmt.Sprintf(`[
@@ -592,16 +664,17 @@ func TestCmdBatchWire(t *testing.T) {
 	if len(*commits) != 1 {
 		t.Fatalf("%d commits, want 1 — batch must send all ops in a single HTTP request", len(*commits))
 	}
+	assertTaskPreflight(t, *historyRequests, (*commits)[0])
 	body := (*commits)[0].body
 	if len(body) != 2 {
 		t.Fatalf("commit has %d items, want 2", len(body))
 	}
 	create, complete := body[id1], body[id2]
-	if create.E != "Task6" || create.T != 0 {
-		t.Errorf("create envelope = %s/%d, want Task6/0", create.E, create.T)
+	if create.E != "Task7" || create.T != 0 {
+		t.Errorf("create envelope = %s/%d, want Task7/0", create.E, create.T)
 	}
-	if complete.T != 1 {
-		t.Errorf("complete envelope action = %d, want 1", complete.T)
+	if complete.E != "Task7" || complete.T != 1 {
+		t.Errorf("complete envelope = %s/%d, want Task7/1", complete.E, complete.T)
 	}
 	var p map[string]any
 	if err := json.Unmarshal(complete.P, &p); err != nil || p["ss"] != float64(3) {

--- a/docs/task7-write-policy.md
+++ b/docs/task7-write-policy.md
@@ -1,0 +1,106 @@
+# Task7 write support
+
+Task6 and Task7 are versions of history-event payloads. The same task UUID can
+have a Task7 creation followed by a Task6 modification. Migrating a writer
+changes the envelopes it sends; it does not require rewriting an account's
+existing tasks or history.
+
+## Supported scope
+
+The CLI sends Task7 for supported task, project, and heading creation and task
+modification operations. Tag4, Area3, ChecklistItem3, and Tombstone2 operations
+keep their existing formats. The SDK also accepts explicit `ItemKindTask7`
+envelopes within the validated scope.
+
+For compatibility, `ItemKindTask` remains Task6. Existing SDK callers continue
+to emit the kind they requested. The readers retain support for both versions;
+do not change their shared Task6 discriminator to migrate a writer.
+
+- Creation uses the verified complete payload, including null modification
+  date and recurrence configuration, and empty recurrence links.
+- Project and heading creation is limited to Anytime in this first scope;
+  ordinary task creation supports the verified Inbox/Anytime/Someday and
+  corresponding date-based scheduling encodings.
+- Updates are sparse: omitted properties remain omitted. Supported operations
+  include full-note replacement, ordinary scheduling, relationships, tags,
+  completion/reopening, and recoverable trash/restoration.
+- Direct note-delta writes, recurrence configuration, unsupported properties,
+  and Task7 permanent-deletion events are outside this first write contract.
+
+Area and project moves explicitly clear incompatible parent relationships.
+An edit cannot combine area with project or heading; project plus heading is
+supported. This avoids silently choosing between conflicting destinations or
+leaving a task attached to its previous container.
+
+Task7 modifications require an existing, nonrecurring target. Before posting,
+`History.Write` reads raw history from index zero and classifies the targeted
+UUIDs. A single scan covers every Task7 update in the batch. This avoids
+relying on the public `Task` projection, which does not retain every recurrence
+field. Unknown/missing targets and recurring templates or instances fail
+before any operation in that write request is posted.
+
+This also rejects older or sparse histories without explicit values for all
+three recurrence markers (`rr`, `rp`, `rt`), including tasks created by the
+legacy sparse SDK example. Such a task may be ordinary, but the new checker
+does not infer that from incomplete evidence. CLI updates therefore have a
+compatibility limitation for these records; there is no automatic Task6
+fallback. Existing explicit Task6 SDK calls keep their previous behavior.
+
+This preflight adds network reads and work proportional to the history size
+for update requests. It uses a fixed checked history head as the commit
+ancestor; it does not silently retry a failed commit. Existing Task6 writes
+keep their prior behavior and do not gain this recurrence protection.
+
+A controlled stale-ancestor test wrote one title update, then submitted a
+second update to the same UUID and field using the preceding head. The server
+returned HTTP 409 for the second request and history contained only the first
+event. This verifies rejection in that case; broader concurrent/offline
+convergence remains outside the tested scope.
+
+## Explicit SDK update
+
+```go
+update := things.TaskActionItem{
+    Item: things.Item{
+        UUID: taskUUID,
+        Kind: things.ItemKindTask7,
+        Action: things.ItemActionModified,
+    },
+    P: things.TaskActionItemPayload{
+        Title: things.String("Updated title"),
+        ModificationDate: things.Time(time.Now()),
+    },
+}
+if err := history.Write(update); err != nil {
+    return err
+}
+```
+
+Do not serialize a projected task back as a complete replacement: unmodeled
+properties such as modern repeater data cannot be reconstructed from it.
+Use the CLI's complete creation payload or an equivalent validated full
+envelope for Task7 creation; its required nulls differ from the legacy SDK's
+sparse `TaskActionItemPayload` encoding.
+
+## Mixed-version evidence
+
+In the disposable account, the current Task6 CLI performed a title-only edit
+on an ordinary Task7 task and on a native Task7 repeating template. Both writes
+were persisted as Task6 modifications containing only `tt` and `md`, on the
+original UUIDs. Things applied the titles and preserved the checked notes,
+scheduling, status, and recurrence columns. The template's stored recurrence
+rule remained byte-identical.
+
+The native weekly-after-completion control used a non-null `rr` object with
+`rrv=4`, `tp=1`, `fu=256`, and `fa=1`; `rp` was null. The app created a template
+and a separate instance linked through `rt`. Completing the instance in Things
+emitted a Task7 `ss`/`sp`/`md` update on the instance and an `acrd`/`tir` update
+on its template. The app then showed September 13 as the next occurrence.
+
+That confirms title-only mixed-version compatibility for these cases. It
+does not establish recurring lifecycle support: changing an envelope's kind
+does not synthesize the companion template updates. Non-null modern `rp`,
+other recurrence modes, and concurrent/offline convergence remain unverified.
+
+See [the live verification report](task7-write-verification.md) for the tested
+ordinary-operation matrix and its limits.

--- a/docs/task7-write-verification.md
+++ b/docs/task7-write-verification.md
@@ -9,9 +9,10 @@ read-only SQLite queries confirmed the resulting state. SDK reads confirmed
 the tested values, with the Unicode replay correction described below.
 
 This establishes a tested subset, not a complete Task7 write specification.
-The production `History.Write` Task7 guard remains unchanged; normal SDK/CLI
-writes remain Task6. No account credentials or private history captures are
-included in this repository.
+The initial tests used a private writer while production writes remained
+Task6. The subsequent [Task7 write policy](task7-write-policy.md) uses this
+evidence to scope supported writes and reject recurrence updates. No account
+credentials or private history captures are included in this repository.
 
 ## Method
 
@@ -95,11 +96,49 @@ project view showed the second child under the heading.
 
 This verifies those particular batch and relationship shapes. It does not
 test concurrent reordering, every checklist operation, or repeat-instance
-relationships. The default SDK/CLI write envelope remains Task6.
+relationships.
+
+## Follow-up: mixed-version edits and native recurrence
+
+A normal Task6 CLI title edit was applied to both an existing ordinary Task7
+task and a native Task7 recurrence template. Both events used the same UUIDs
+and contained only `tt`/`md`. App and SDK readback passed; checked non-title
+fields were unchanged, including the exact stored recurrence-rule bytes.
+
+The native weekly-after-completion example used `rr` version 4, not a non-null
+`rp`. It created a template plus an `rt`-linked instance. Native completion
+updated the instance (`ss`/`sp`/`md`) and its template (`acrd`/`tir`), after which
+the app showed September 13 as the next occurrence. This is evidence for that
+particular native lifecycle, not complete SDK recurrence-write support.
+
+## Migrated CLI acceptance
+
+The migrated CLI was exercised through its normal `History.Write` path, rather
+than the private direct writer. Creation with a full Unicode note and future
+start/deadline dates, sparse title/note/date editing, completion, and recoverable
+trash all emitted Task7 and matched both the app database and SDK readback.
+
+An edit of the known recurring template was rejected. A batch combining an
+ordinary edit and recurring-instance completion was also rejected in full.
+The cloud head remained unchanged in both cases.
+
+The real CLI move-to-area probe exposed a pre-existing omission: it set `ar`
+without clearing `pr`/`agr`, leaving the task attached to its old project and
+heading. The corrected command explicitly clears those arrays. Its live retest
+left only the area relationship and removed the task from the old project view.
+The inverse move-to-project cleared `ar`/`agr` and left only the project; app
+database and SDK readback agreed. Ambiguous area-plus-project/heading edits are
+rejected before preflight or POST. Creation and standalone heading behavior
+were not changed by this move correction.
+
+A same-UUID, same-field stale-ancestor test returned HTTP 409 for the second
+write and produced no second history event. This is a bounded conflict result,
+not a complete concurrency or offline-convergence test.
 
 ## Remaining verification gaps
 
-- Non-null `rp`/`rr`, modern recurrence and repeat-instance operations.
+- Non-null modern `rp`, broader `rr` configurations, and SDK-driven recurrence
+  creation and repeat-instance lifecycle operations.
 - Reminders, ordering under concurrency, and broader bulk/checklist operations
   beyond the specific creation and move cases above.
 - Permanent deletion and wire action `t=2` were not exercised in this write test.

--- a/histories.go
+++ b/histories.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strconv"
+	"strings"
+	"unicode/utf8"
 )
 
 // History represents a synchronization stream. It's identified with a uuid v4
@@ -242,8 +244,20 @@ func (h *History) Write(items ...Identifiable) error {
 	if err != nil {
 		return err
 	}
-	if err := validateTaskWriteKinds(bs); err != nil {
+	plan, err := validateTaskWrites(bs)
+	if err != nil {
 		return err
+	}
+	ancestorIndex := h.LatestServerIndex
+	if plan.needsPreflight() {
+		checkedHead, err := h.preflightTask7Modifications(plan.modificationTargets)
+		if err != nil {
+			return err
+		}
+		// Use the fixed raw-history snapshot head as the commit ancestor. The
+		// method deliberately does not retry if the server rejects the write.
+		h.LatestServerIndex = checkedHead
+		ancestorIndex = checkedHead
 	}
 	req, err := http.NewRequest("POST", fmt.Sprintf("/version/1/history/%s/commit", h.ID), bytes.NewReader(bs))
 	if err != nil {
@@ -255,7 +269,7 @@ func (h *History) Write(items ...Identifiable) error {
 	req.Header.Add("App-Instance-Id", "000000000000000000000000000000000000000000000000000000000000000-com.culturedcode.ThingsMac-000000000000000000000000000000000000000000000000000000000000000")
 	req.Header.Add("App-Id", "com.culturedcode.ThingsMac")
 	query := req.URL.Query()
-	query.Add("ancestor-index", strconv.Itoa(h.LatestServerIndex))
+	query.Add("ancestor-index", strconv.Itoa(ancestorIndex))
 	query.Add("_cnt", "1")
 	req.URL.RawQuery = query.Encode()
 	resp, err := h.Client.do(req)
@@ -278,4 +292,208 @@ func (h *History) Write(items ...Identifiable) error {
 	}
 	h.LatestServerIndex = w.ServerHeadIndex
 	return nil
+}
+
+type task7TargetState struct {
+	exists             bool
+	ambiguous          bool
+	future             bool
+	lastAffectedIndex  int
+	sameIndexAmbiguous bool
+
+	rrKnown  bool
+	rrActive bool
+	rpKnown  bool
+	rpActive bool
+	rtKnown  bool
+	rtActive bool
+	icsd     bool
+	acrd     bool
+}
+
+func (h *History) preflightTask7Modifications(targets map[string]struct{}) (int, error) {
+	states := make(map[string]*task7TargetState, len(targets))
+	for id := range targets {
+		states[id] = &task7TargetState{lastAffectedIndex: -1}
+	}
+
+	// Items mutates its receiver. Scan through a copy so every failed or
+	// incomplete preflight leaves the caller's History untouched.
+	snapshot := *h
+	snapshot.LatestServerIndex = 0
+	snapshot.LoadedServerIndex = 0
+	start, checkedHead := 0, -1
+	for {
+		items, _, err := snapshot.Items(ItemsOptions{StartIndex: start})
+		if err != nil {
+			return 0, fmt.Errorf("Task7 write preflight: %w", err)
+		}
+		if checkedHead < 0 {
+			checkedHead = snapshot.LatestServerIndex
+			if checkedHead < 0 {
+				return 0, fmt.Errorf("Task7 write preflight: invalid history head")
+			}
+		} else if snapshot.LatestServerIndex < checkedHead {
+			return 0, fmt.Errorf("Task7 write preflight: history head regressed")
+		}
+
+		for _, item := range items {
+			if !item.HasServerIndex || item.ServerIndex >= checkedHead {
+				continue
+			}
+			if err := applyTask7PreflightItem(states, item); err != nil {
+				return 0, err
+			}
+		}
+		if snapshot.LoadedServerIndex >= checkedHead {
+			break
+		}
+		if snapshot.LoadedServerIndex <= start {
+			return 0, fmt.Errorf("Task7 write preflight: history ended before checked head %d", checkedHead)
+		}
+		start = snapshot.LoadedServerIndex
+	}
+
+	for id, state := range states {
+		switch {
+		case state.future:
+			return 0, fmt.Errorf("Task7 write preflight: target %s has an unsupported future task kind", id)
+		case !state.exists || state.ambiguous || state.sameIndexAmbiguous:
+			return 0, fmt.Errorf("Task7 write preflight: target %s is missing or ambiguous", id)
+		case !state.rrKnown || !state.rpKnown || !state.rtKnown:
+			return 0, fmt.Errorf("Task7 write preflight: target %s lacks complete recurrence markers", id)
+		case state.rrActive || state.rpActive || state.rtActive || state.icsd || state.acrd:
+			return 0, fmt.Errorf("Task7 write preflight: target %s is recurring", id)
+		}
+	}
+	return checkedHead, nil
+}
+
+func applyTask7PreflightItem(states map[string]*task7TargetState, item Item) error {
+	if item.Kind == ItemKind("Tombstone2") || item.Kind == ItemKind("Tombstone") {
+		if !utf8.Valid(item.P) || rejectUnpairedJSONSurrogates(item.P) != nil || rejectDuplicateJSONKeys(item.P, true) != nil {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		var payload TombstoneActionItemPayload
+		if err := json.Unmarshal(item.P, &payload); err != nil {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		fields, err := jsonObject(item.P)
+		if err != nil {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		if _, ok := jsonString(fields["dloid"]); !ok || payload.DeletedObjectID == "" {
+			return fmt.Errorf("Task7 write preflight: malformed tombstone in raw history")
+		}
+		target := payload.DeletedObjectID
+		if item.Kind == ItemKind("Tombstone") && ValidateUUID(target) != nil {
+			target = EncodeLegacyIdentifier(target)
+		}
+		if state := states[target]; state != nil {
+			state.markAffected(item.ServerIndex)
+			state.resetSemantic(false)
+		}
+		return nil
+	}
+
+	id := item.UUID
+	if isLegacyTaskKind(item.Kind) && ValidateUUID(id) != nil {
+		id = EncodeLegacyIdentifier(id)
+	}
+	state := states[id]
+	if state == nil {
+		return nil
+	}
+	state.markAffected(item.ServerIndex)
+
+	switch string(item.Kind) {
+	case "Task6", "Task7", "Task4", "Task3", "Task":
+	case "Tombstone2", "Tombstone":
+		return nil
+	default:
+		if strings.HasPrefix(string(item.Kind), "Task") {
+			state.future = true
+		}
+		state.ambiguous = true
+		return nil
+	}
+
+	switch item.Action {
+	case ItemActionCreated:
+		ambiguous := state.ambiguous || state.future || state.exists
+		state.resetSemantic(true)
+		state.ambiguous = ambiguous
+	case ItemActionModified:
+		if !state.exists {
+			state.ambiguous = true
+		}
+	case ItemActionDeleted:
+		state.resetSemantic(false)
+		return nil
+	default:
+		state.ambiguous = true
+		return nil
+	}
+	if !utf8.Valid(item.P) || rejectUnpairedJSONSurrogates(item.P) != nil || rejectDuplicateJSONKeys(item.P, true) != nil {
+		state.ambiguous = true
+		return nil
+	}
+	payload, err := jsonObject(item.P)
+	if err != nil {
+		state.ambiguous = true
+		return nil
+	}
+	applyRawRecurrenceMarker(payload, "rr", &state.rrKnown, &state.rrActive)
+	applyRawRecurrenceMarker(payload, "rp", &state.rpKnown, &state.rpActive)
+	if raw, ok := payload["rt"]; ok {
+		state.rtKnown = true
+		if jsonNull(raw) {
+			state.rtActive = false
+		} else if values, err := jsonStringArray(raw); err == nil {
+			state.rtActive = len(values) != 0
+		} else {
+			state.ambiguous = true
+		}
+	}
+	applyRawPresenceMarker(payload, "icsd", &state.icsd)
+	applyRawPresenceMarker(payload, "acrd", &state.acrd)
+	return nil
+}
+
+func (s *task7TargetState) markAffected(serverIndex int) {
+	if s.lastAffectedIndex == serverIndex {
+		s.sameIndexAmbiguous = true
+	}
+	s.lastAffectedIndex = serverIndex
+}
+
+func (s *task7TargetState) resetSemantic(exists bool) {
+	lastIndex, sameIndexAmbiguous := s.lastAffectedIndex, s.sameIndexAmbiguous
+	*s = task7TargetState{
+		exists:             exists,
+		lastAffectedIndex:  lastIndex,
+		sameIndexAmbiguous: sameIndexAmbiguous,
+	}
+}
+
+func isLegacyTaskKind(kind ItemKind) bool {
+	switch string(kind) {
+	case "Task4", "Task3", "Task":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyRawRecurrenceMarker(payload map[string]json.RawMessage, key string, known, active *bool) {
+	if raw, ok := payload[key]; ok {
+		*known = true
+		*active = !jsonNull(raw)
+	}
+}
+
+func applyRawPresenceMarker(payload map[string]json.RawMessage, key string, active *bool) {
+	if raw, ok := payload[key]; ok {
+		*active = !jsonNull(raw)
+	}
 }

--- a/task7_write_test.go
+++ b/task7_write_test.go
@@ -1,0 +1,582 @@
+package thingscloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type rawWriteProbe struct {
+	id   string
+	body string
+}
+
+func (p rawWriteProbe) UUID() string { return p.id }
+
+func (p rawWriteProbe) MarshalJSON() ([]byte, error) { return []byte(p.body), nil }
+
+func task7CreateBody(title string) string {
+	return fmt.Sprintf(`{"e":"Task7","t":0,"p":{"tp":0,"sr":null,"dds":null,"rt":[],"rmd":null,"ss":0,"tr":false,"dl":[],"icp":false,"st":0,"ar":[],"tt":%s,"do":0,"lai":null,"tir":null,"tg":[],"agr":[],"ix":0,"cd":1770000000.25,"lt":false,"icc":0,"md":null,"ti":0,"dd":null,"ato":null,"nt":{"_t":"tx","ch":0,"v":"","t":1},"icsd":null,"pr":[],"rp":null,"acrd":null,"sp":null,"sb":0,"rr":null,"xx":{"sn":{},"_t":"oo"}}}`, strconv.Quote(title))
+}
+
+func task7UpdateBody(fields string) string {
+	if fields != "" {
+		fields = "," + fields
+	}
+	return `{"e":"Task7","t":1,"p":{"md":1770000001.5` + fields + `}}`
+}
+
+func historyPage(head int, batches ...string) string {
+	return fmt.Sprintf(`{"items":[%s],"current-item-index":%d,"schema":301}`, strings.Join(batches, ","), head)
+}
+
+func taskHistoryBatch(id string, kind ItemKind, action int, payload string) string {
+	return fmt.Sprintf(`{%s:{"e":%s,"t":%d,"p":%s}}`, strconv.Quote(id), strconv.Quote(string(kind)), action, payload)
+}
+
+func TestHistoryWriteAcceptsVerifiedTask7CreateWithoutPreflight(t *testing.T) {
+	var methods []string
+	var posted map[string]json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected %s request for create-only write", r.Method)
+		}
+		if got := r.URL.Query().Get("ancestor-index"); got != "9" {
+			t.Errorf("ancestor-index = %q, want 9", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprint(w, `{"server-head-index":10}`)
+	}))
+	defer server.Close()
+
+	id := NewUUID()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	h.LatestServerIndex = 9
+	if err := h.Write(rawWriteProbe{id: id, body: task7CreateBody("ordinary")}); err != nil {
+		t.Fatalf("Write(valid Task7 create): %v", err)
+	}
+	if len(methods) != 1 || methods[0] != http.MethodPost {
+		t.Fatalf("methods = %v, want [POST]", methods)
+	}
+	if !strings.Contains(string(posted[id]), `"e":"Task7"`) {
+		t.Fatalf("posted envelope = %s, want Task7", posted[id])
+	}
+}
+
+func TestHistoryWriteTask7UpdatePreflightsRawHistoryAndPinsAncestor(t *testing.T) {
+	target := NewUUID()
+	var starts []string
+	var posts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			starts = append(starts, r.URL.Query().Get("start-index"))
+			switch r.URL.Query().Get("start-index") {
+			case "0":
+				fmt.Fprint(w, historyPage(3,
+					taskHistoryBatch(target, ItemKindTask, 0, `{"tt":"legacy generation","rr":null,"rp":null,"rt":[]}`),
+					taskHistoryBatch(target, ItemKindTask7, 1, `{"tt":"current generation"}`),
+				))
+			case "2":
+				fmt.Fprint(w, historyPage(4, `{}`)) // growing head must not be chased
+			default:
+				t.Fatalf("unexpected start-index %q", r.URL.Query().Get("start-index"))
+			}
+		case http.MethodPost:
+			posts++
+			if got := r.URL.Query().Get("ancestor-index"); got != "3" {
+				t.Errorf("ancestor-index = %q, want frozen head 3", got)
+			}
+			fmt.Fprint(w, `{"server-head-index":4}`)
+		}
+	}))
+	defer server.Close()
+
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	h.LatestServerIndex = 99
+	if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"renamed"`)}); err != nil {
+		t.Fatalf("Write(valid ordinary update): %v", err)
+	}
+	if strings.Join(starts, ",") != "0,2" || posts != 1 {
+		t.Fatalf("starts=%v posts=%d, want [0 2] and one POST", starts, posts)
+	}
+	if h.LatestServerIndex != 4 {
+		t.Errorf("LatestServerIndex=%d, want commit head 4", h.LatestServerIndex)
+	}
+}
+
+func TestHistoryWriteRejectsRecurringAndAmbiguousTask7TargetsBeforePost(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "repeater rule", payload: `{"rr":{"f":1},"rp":null,"rt":[]}`},
+		{name: "repeater payload", payload: `{"rr":null,"rp":"opaque","rt":[]}`},
+		{name: "linked instance", payload: `{"rr":null,"rp":null,"rt":["` + NewUUID() + `"]}`},
+		{name: "instance creation marker", payload: `{"rr":null,"rp":null,"rt":[],"icsd":1770000000}`},
+		{name: "after completion marker", payload: `{"rr":null,"rp":null,"rt":[],"acrd":1770000000}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewUUID()
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posts++
+				}
+				fmt.Fprint(w, historyPage(1, taskHistoryBatch(target, ItemKindTask7, 0, tt.payload)))
+			}))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"unsafe"`)}); err == nil {
+				t.Fatal("Write(recurring target) succeeded")
+			}
+			if posts != 0 {
+				t.Fatalf("sent %d POSTs, want zero", posts)
+			}
+		})
+	}
+}
+
+func TestHistoryWriteTask7PreflightTracksOmissionsNullClearsDeletesAndKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		batches func(string) []string
+		wantOK  bool
+	}{
+		{name: "omission preserves recurrence", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":{"f":1},"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKindTask7, 1, `{"tt":"still recurring"}`),
+			}
+		}},
+		{name: "explicit null clears recurrence", wantOK: true, batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":{"f":1},"rp":"opaque","rt":["`+NewUUID()+`"],"icsd":1,"acrd":2}`),
+				taskHistoryBatch(id, ItemKindTask7, 1, `{"rr":null,"rp":null,"rt":[],"icsd":null,"acrd":null}`),
+			}
+		}},
+		{name: "legacy sparse create lacks recurrence proof", batches: func(id string) []string {
+			return []string{taskHistoryBatch(id, ItemKind("Task6"), 0, `{"tt":"unknown recurrence state"}`)}
+		}},
+		{name: "direct task deletion", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKindTask7, 2, `{}`),
+			}
+		}},
+		{name: "tombstone deletion", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(NewUUID(), ItemKindTombstone, 0, `{"dloid":"`+id+`","dld":1}`),
+			}
+		}},
+		{name: "future target kind", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task8"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+			}
+		}},
+		{name: "future kind hidden by later create", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task8"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+			}
+		}},
+		{name: "non-task modification on target", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKind("Area3"), 1, `{}`),
+			}
+		}},
+		{name: "duplicate target creation", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+			}
+		}},
+		{name: "missing target", batches: func(string) []string { return []string{`{}`} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewUUID()
+			batches := tt.batches(target)
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posts++
+					fmt.Fprint(w, `{"server-head-index":20}`)
+					return
+				}
+				fmt.Fprint(w, historyPage(len(batches), batches...))
+			}))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"update"`)})
+			if (err == nil) != tt.wantOK {
+				t.Fatalf("Write() error=%v, wantOK=%v", err, tt.wantOK)
+			}
+			if (posts == 1) != tt.wantOK {
+				t.Fatalf("posts=%d, wantOK=%v", posts, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestHistoryWriteValidatesEntireTask7BatchBeforeNetwork(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown create field", body: strings.Replace(task7CreateBody("x"), `"xx":`, `"unknown":1,"xx":`, 1)},
+		{name: "create recurrence", body: strings.Replace(task7CreateBody("x"), `"rr":null`, `"rr":{"f":1}`, 1)},
+		{name: "inbox create with dates", body: strings.NewReplacer(`"sr":null`, `"sr":1770000002`, `"tir":null`, `"tir":1770000002`).Replace(task7CreateBody("x"))},
+		{name: "create dates differ", body: strings.NewReplacer(`"st":0`, `"st":1`, `"sr":null`, `"sr":1770000002`, `"tir":null`, `"tir":1770000003`).Replace(task7CreateBody("x"))},
+		{name: "create dates null mismatch", body: strings.NewReplacer(`"st":0`, `"st":1`, `"sr":null`, `"sr":1770000002`).Replace(task7CreateBody("x"))},
+		{name: "multiple area parents", body: strings.Replace(task7CreateBody("x"), `"ar":[]`, `"ar":["`+NewUUID()+`","`+NewUUID()+`"]`, 1)},
+		{name: "malformed modification date", body: task7UpdateBody(`"tt":"x"`)[:len(task7UpdateBody(`"tt":"x"`))-2] + `,"md":"bad"}}`},
+		{name: "delta note", body: task7UpdateBody(`"nt":{"_t":"tx","t":2,"ps":[]}`)},
+		{name: "unknown update field", body: task7UpdateBody(`"private":"fixture"`)},
+		{name: "deleted action", body: `{"e":"Task7","t":2,"p":{}}`},
+		{name: "quoted action", body: strings.Replace(task7CreateBody("x"), `"t":0`, `"t":"0"`, 1)},
+		{name: "quoted payload integer", body: strings.Replace(task7CreateBody("x"), `"tp":0`, `"tp":"0"`, 1)},
+		{name: "null title", body: task7UpdateBody(`"tt":null`)},
+		{name: "null trash", body: task7UpdateBody(`"tr":null`)},
+		{name: "null create boolean", body: strings.Replace(task7CreateBody("x"), `"icp":false`, `"icp":null`, 1)},
+		{name: "null note value", body: strings.Replace(task7CreateBody("x"), `"v":""`, `"v":null`, 1)},
+		{name: "status without stop date", body: task7UpdateBody(`"ss":3`)},
+		{name: "stop date without status", body: task7UpdateBody(`"sp":1770000002`)},
+		{name: "reopen with stop date", body: task7UpdateBody(`"ss":0,"sp":1770000002`)},
+		{name: "complete with null stop date", body: task7UpdateBody(`"ss":3,"sp":null`)},
+		{name: "schedule without dates", body: task7UpdateBody(`"st":1`)},
+		{name: "schedule dates differ", body: task7UpdateBody(`"st":1,"sr":1770000002,"tir":1770000003`)},
+		{name: "inbox with dates", body: task7UpdateBody(`"st":0,"sr":1770000002,"tir":1770000002`)},
+		{name: "unpaired surrogate", body: strings.Replace(task7CreateBody("x"), `"tt":"x"`, `"tt":"\uD800"`, 1)},
+		{name: "duplicate recurrence field", body: strings.Replace(task7CreateBody("x"), `"rr":null`, `"rr":{"f":1},"rr":null`, 1)},
+		{name: "duplicate nested note field", body: strings.Replace(task7CreateBody("x"), `"_t":"tx"`, `"_t":"private","_t":"tx"`, 1)},
+		{name: "duplicate envelope kind", body: strings.Replace(task7CreateBody("x"), `{"e":"Task7"`, `{"e":"Tag4","e":"Task7"`, 1)},
+		{name: "missing payload", body: `{"e":"Task7","t":1}`},
+		{name: "payload not object", body: `{"e":"Task7","t":1,"p":null}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			err := h.Write(
+				rawWriteProbe{id: NewUUID(), body: task7CreateBody("valid sibling")},
+				rawWriteProbe{id: NewUUID(), body: tt.body},
+			)
+			if err == nil {
+				t.Fatal("Write(invalid Task7 batch) succeeded")
+			}
+			if requests != 0 {
+				t.Fatalf("sent %d requests, want zero", requests)
+			}
+		})
+	}
+}
+
+func TestHistoryWriteAcceptsVerifiedTask7FutureCreate(t *testing.T) {
+	body := strings.NewReplacer(
+		`"st":0`, `"st":2`,
+		`"sr":null`, `"sr":1770000002`,
+		`"tir":null`, `"tir":1770000002`,
+	).Replace(task7CreateBody("future"))
+	posts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("future create sent %s, want POST", r.Method)
+		}
+		posts++
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: body}); err != nil {
+		t.Fatalf("Write(valid future Task7 create): %v", err)
+	}
+	if posts != 1 {
+		t.Fatalf("posts=%d, want one", posts)
+	}
+}
+
+func TestHistoryWriteRejectsInvalidUTF8Task7BeforeNetwork(t *testing.T) {
+	body := strings.Replace(task7CreateBody("x"), `"tt":"x"`, "\"tt\":\"\xff\"", 1)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: body}); err == nil {
+		t.Fatal("Write(invalid UTF-8 Task7) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteAcceptsPairedJSONSurrogate(t *testing.T) {
+	body := strings.Replace(task7CreateBody("x"), `"tt":"x"`, `"tt":"\uD83D\uDE80"`, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: body}); err != nil {
+		t.Fatalf("Write(valid paired surrogate): %v", err)
+	}
+}
+
+func TestHistoryWriteTask7RejectsMalformedCompanionTombstoneBeforeNetwork(t *testing.T) {
+	target := NewUUID()
+	tombstone := rawWriteProbe{
+		id:   NewUUID(),
+		body: `{"e":"Tombstone2","t":0,"p":{"dloid":"` + target + `","dloid":"` + NewUUID() + `","dld":1770000001}}`,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: task7CreateBody("x")}, tombstone); err == nil {
+		t.Fatal("Write(Task7 plus malformed tombstone) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteTask7BatchRejectsOneRecurringTargetBeforeAllPosts(t *testing.T) {
+	ordinary, recurring := NewUUID(), NewUUID()
+	gets, posts := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			posts++
+			return
+		}
+		gets++
+		fmt.Fprint(w, historyPage(2,
+			taskHistoryBatch(ordinary, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`),
+			taskHistoryBatch(recurring, ItemKindTask7, 0, `{"rr":{"f":1},"rp":null,"rt":[]}`),
+		))
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	err := h.Write(
+		rawWriteProbe{id: ordinary, body: task7UpdateBody(`"tt":"safe"`)},
+		rawWriteProbe{id: recurring, body: task7UpdateBody(`"tt":"unsafe"`)},
+	)
+	if err == nil {
+		t.Fatal("Write(mixed recurrence batch) succeeded")
+	}
+	if gets != 1 || posts != 0 {
+		t.Fatalf("gets=%d posts=%d, want one shared GET and zero POSTs", gets, posts)
+	}
+}
+
+func TestHistoryWriteTask7RejectsSameBatchTombstoneAmbiguityBeforeNetwork(t *testing.T) {
+	target := NewUUID()
+	tombstone := rawWriteProbe{
+		id:   NewUUID(),
+		body: `{"e":"Tombstone2","t":0,"p":{"dloid":"` + target + `","dld":1770000001}}`,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)}, tombstone); err == nil {
+		t.Fatal("Write(Task7 modification plus target tombstone) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteTask7RejectsSameBatchCreateAndTombstoneBeforeNetwork(t *testing.T) {
+	target := NewUUID()
+	tombstone := rawWriteProbe{
+		id:   NewUUID(),
+		body: `{"e":"Tombstone2","t":0,"p":{"dloid":"` + target + `","dld":1770000001}}`,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(rawWriteProbe{id: target, body: task7CreateBody("x")}, tombstone); err == nil {
+		t.Fatal("Write(Task7 create plus target tombstone) succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("sent %d requests, want zero", requests)
+	}
+}
+
+func TestHistoryWriteTask7RejectsAmbiguousSameHistoryIndexRegardlessOfMapOrder(t *testing.T) {
+	target := NewUUID()
+	tombstoneID := NewUUID()
+	batch := fmt.Sprintf(`{%s:{"e":"Task7","t":0,"p":{"rr":null,"rp":null,"rt":[]}},%s:{"e":"Tombstone2","t":0,"p":{"dloid":%s,"dld":1}}}`,
+		strconv.Quote(target), strconv.Quote(tombstoneID), strconv.Quote(target))
+	posts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			posts++
+			return
+		}
+		fmt.Fprint(w, historyPage(1, batch))
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	for i := 0; i < 25; i++ {
+		if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)}); err == nil {
+			t.Fatalf("iteration %d accepted ambiguous same-index history", i)
+		}
+	}
+	if posts != 0 {
+		t.Fatalf("sent %d POSTs, want zero", posts)
+	}
+}
+
+func TestHistoryWriteTask7RejectsAmbiguousRawHistoryPayloads(t *testing.T) {
+	tests := []struct {
+		name    string
+		batches func(string) []string
+	}{
+		{name: "duplicate recurrence key", batches: func(id string) []string {
+			return []string{taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":{"f":1},"rr":null,"rp":null,"rt":[]}`)}
+		}},
+		{name: "duplicate tombstone target", batches: func(id string) []string {
+			return []string{
+				taskHistoryBatch(id, ItemKind("Task7"), 0, `{"rr":null,"rp":null,"rt":[]}`),
+				taskHistoryBatch(NewUUID(), ItemKind("Tombstone2"), 0, `{"dloid":"`+NewUUID()+`","dloid":"`+id+`","dld":1}`),
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := NewUUID()
+			batches := tt.batches(target)
+			posts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					posts++
+					return
+				}
+				fmt.Fprint(w, historyPage(len(batches), batches...))
+			}))
+			defer server.Close()
+			h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+			if err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)}); err == nil {
+				t.Fatal("Write(ambiguous raw history) succeeded")
+			}
+			if posts != 0 {
+				t.Fatalf("sent %d POSTs, want zero", posts)
+			}
+		})
+	}
+}
+
+func TestTask7PreflightRejectsInvalidUTF8TargetPayload(t *testing.T) {
+	target := NewUUID()
+	states := map[string]*task7TargetState{target: {lastAffectedIndex: -1}}
+	item := Item{
+		UUID:           target,
+		Kind:           ItemKind("Task7"),
+		Action:         ItemActionCreated,
+		P:              json.RawMessage("{\"rr\":null,\"rp\":null,\"rt\":[],\"tt\":\"\xff\"}"),
+		ServerIndex:    0,
+		HasServerIndex: true,
+	}
+	if err := applyTask7PreflightItem(states, item); err != nil {
+		t.Fatalf("applyTask7PreflightItem returned transport-level error: %v", err)
+	}
+	if !states[target].ambiguous {
+		t.Fatal("invalid UTF-8 target payload was not marked ambiguous")
+	}
+}
+
+func TestHistoryWriteTask7PreflightFailureDoesNotMutateHistory(t *testing.T) {
+	target := NewUUID()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("start-index") == "0" {
+			fmt.Fprint(w, historyPage(3, taskHistoryBatch(target, ItemKindTask7, 0, `{"rr":null,"rp":null,"rt":[]}`)))
+			return
+		}
+		fmt.Fprint(w, historyPage(3))
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	h.LatestServerIndex, h.LoadedServerIndex = 8, 4
+	err := h.Write(rawWriteProbe{id: target, body: task7UpdateBody(`"tt":"x"`)})
+	if err == nil {
+		t.Fatal("Write(zero-progress history) succeeded")
+	}
+	if h.LatestServerIndex != 8 || h.LoadedServerIndex != 4 {
+		t.Fatalf("history mutated on preflight failure: latest=%d loaded=%d", h.LatestServerIndex, h.LoadedServerIndex)
+	}
+}
+
+func TestHistoryWriteLegacyTaskStillSkipsPreflight(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodPost {
+			t.Fatalf("legacy write sent %s, want POST", r.Method)
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(taskWriteProbe{id: NewUUID(), kind: ItemKindTask}); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests=%d, want one POST", requests)
+	}
+}
+
+func TestHistoryWriteMutableKindVariablesCannotEnableFutureTaskWrites(t *testing.T) {
+	originalTask, originalTask7 := ItemKindTask, ItemKindTask7
+	ItemKindTask, ItemKindTask7 = "Task8", "Task8"
+	defer func() {
+		ItemKindTask, ItemKindTask7 = originalTask, originalTask7
+	}()
+
+	futureTarget := NewUUID()
+	requests, posts := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, historyPage(1, taskHistoryBatch(futureTarget, ItemKind("Task8"), 0, `{"rr":null,"rp":null,"rt":[]}`)))
+			return
+		}
+		posts++
+		fmt.Fprint(w, `{"server-head-index":1}`)
+	}))
+	defer server.Close()
+	h := New(server.URL, "test@example.com", "password").HistoryWithID("history")
+	if err := h.Write(taskWriteProbe{id: NewUUID(), kind: ItemKindTask}); err == nil {
+		t.Fatal("mutated ItemKindTask enabled serialized Task8")
+	}
+	if requests != 0 {
+		t.Fatalf("future task write sent %d requests, want zero", requests)
+	}
+	if err := h.Write(rawWriteProbe{id: NewUUID(), body: task7CreateBody("literal Task7")}); err != nil {
+		t.Fatalf("literal Task7 was not validated by its serialized kind: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("literal Task7 sent %d requests, want one POST", requests)
+	}
+	if err := h.Write(rawWriteProbe{id: futureTarget, body: task7UpdateBody(`"tt":"x"`)}); err == nil {
+		t.Fatal("mutated ItemKindTask7 made raw Task8 target look supported during preflight")
+	}
+	if requests != 2 || posts != 1 {
+		t.Fatalf("preflight mutation case requests=%d posts=%d, want two total requests and one POST", requests, posts)
+	}
+}

--- a/task_write.go
+++ b/task_write.go
@@ -1,29 +1,594 @@
 package thingscloud
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
+	"io"
+	"math"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
-// validateTaskWriteKinds checks the serialized envelopes, including custom
-// Identifiable implementations. Supporting a new kind for reads must not
-// accidentally enable writes whose contract has not been verified.
-func validateTaskWriteKinds(body []byte) error {
-	var envelopes map[string]struct {
-		Kind ItemKind `json:"e"`
-	}
+type task7WritePlan struct {
+	modificationTargets map[string]struct{}
+	creationTargets     map[string]struct{}
+	tombstoneTargets    map[string]struct{}
+}
+
+func (p *task7WritePlan) needsPreflight() bool { return len(p.modificationTargets) != 0 }
+
+func validateTaskWrites(body []byte) (*task7WritePlan, error) {
+	var envelopes map[string]json.RawMessage
 	if err := json.Unmarshal(body, &envelopes); err != nil {
-		return fmt.Errorf("refusing to write an invalid item envelope")
+		return nil, fmt.Errorf("refusing to write an invalid item envelope")
 	}
-	for _, envelope := range envelopes {
-		switch envelope.Kind {
+	plan := &task7WritePlan{
+		modificationTargets: make(map[string]struct{}),
+		creationTargets:     make(map[string]struct{}),
+		tombstoneTargets:    make(map[string]struct{}),
+	}
+	type tombstoneEnvelope struct {
+		kind string
+		raw  json.RawMessage
+	}
+	var tombstones []tombstoneEnvelope
+	for id, raw := range envelopes {
+		if err := rejectDuplicateJSONKeys(raw, false); err != nil {
+			return nil, fmt.Errorf("refusing to write an invalid item envelope")
+		}
+		var legacyEnvelope struct {
+			Kind ItemKind `json:"e"`
+		}
+		if err := json.Unmarshal(raw, &legacyEnvelope); err != nil {
+			return nil, fmt.Errorf("refusing to write an invalid item envelope")
+		}
+		kind := string(legacyEnvelope.Kind)
+		switch kind {
+		case "Task7":
+			if !utf8.Valid(raw) || rejectUnpairedJSONSurrogates(raw) != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			if err := rejectDuplicateJSONKeys(raw, true); err != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			fields, err := jsonObject(raw)
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			action, ok := jsonInteger(fields["t"])
+			if !ok || len(fields) != 3 {
+				return nil, fmt.Errorf("refusing to write invalid Task7 envelope")
+			}
+			payload, err := jsonObject(fields["p"])
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write invalid Task7 payload")
+			}
+			switch action {
+			case int64(ItemActionCreated):
+				err = validateTask7Create(payload)
+				if err == nil {
+					plan.creationTargets[id] = struct{}{}
+				}
+			case int64(ItemActionModified):
+				err = validateTask7Modification(payload)
+				if err == nil {
+					plan.modificationTargets[id] = struct{}{}
+				}
+			default:
+				err = fmt.Errorf("Task7 action %d is outside the verified write scope", action)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write Task7: %w", err)
+			}
 		case "Task6", "Task4", "Task3", "Task":
-			continue // Preserve existing write kinds; the CLI still emits Task6.
+			// Preserve existing write kinds and serialization behavior.
+		case "Tombstone2", "Tombstone":
+			tombstones = append(tombstones, tombstoneEnvelope{kind: kind, raw: raw})
+		default:
+			if strings.HasPrefix(kind, "Task") {
+				return nil, fmt.Errorf("refusing to write unverified task kind %s", taskKindDiagnostic(ItemKind(kind)))
+			}
 		}
-		if strings.HasPrefix(string(envelope.Kind), "Task") {
-			return fmt.Errorf("refusing to write unverified task kind %s", taskKindDiagnostic(envelope.Kind))
+	}
+	if len(plan.creationTargets)+len(plan.modificationTargets) != 0 {
+		for _, tombstone := range tombstones {
+			target, err := validateTask7CompanionTombstone(tombstone.raw, tombstone.kind)
+			if err != nil {
+				return nil, fmt.Errorf("refusing to write Task7 batch: invalid tombstone companion")
+			}
+			plan.tombstoneTargets[target] = struct{}{}
 		}
+	}
+	for _, targets := range []map[string]struct{}{plan.creationTargets, plan.modificationTargets} {
+		for target := range targets {
+			if _, ambiguous := plan.tombstoneTargets[target]; ambiguous {
+				return nil, fmt.Errorf("refusing to write Task7: target %s is both changed and deleted in one commit", target)
+			}
+		}
+	}
+	return plan, nil
+}
+
+func validateTask7CompanionTombstone(raw json.RawMessage, kind string) (string, error) {
+	if !utf8.Valid(raw) || rejectUnpairedJSONSurrogates(raw) != nil || rejectDuplicateJSONKeys(raw, true) != nil {
+		return "", fmt.Errorf("invalid tombstone envelope")
+	}
+	fields, err := jsonObject(raw)
+	if err != nil || exactKeys(fields, map[string]struct{}{"e": {}, "t": {}, "p": {}}) != nil {
+		return "", fmt.Errorf("invalid tombstone envelope")
+	}
+	action, ok := jsonInteger(fields["t"])
+	if !ok || action != 0 {
+		return "", fmt.Errorf("invalid tombstone action")
+	}
+	payload, err := jsonObject(fields["p"])
+	if err != nil || exactKeys(payload, map[string]struct{}{"dloid": {}, "dld": {}}) != nil {
+		return "", fmt.Errorf("invalid tombstone payload")
+	}
+	target, ok := jsonString(payload["dloid"])
+	if !ok || target == "" || requiredTimestamp(payload["dld"], true) != nil {
+		return "", fmt.Errorf("invalid tombstone payload")
+	}
+	if kind == "Tombstone2" {
+		if ValidateUUID(target) != nil {
+			return "", fmt.Errorf("invalid tombstone target")
+		}
+	} else if ValidateUUID(target) != nil {
+		target = EncodeLegacyIdentifier(target)
+	}
+	return target, nil
+}
+
+var task7CreateKeys = map[string]struct{}{
+	"tp": {}, "sr": {}, "dds": {}, "rt": {}, "rmd": {}, "ss": {}, "tr": {}, "dl": {},
+	"icp": {}, "st": {}, "ar": {}, "tt": {}, "do": {}, "lai": {}, "tir": {}, "tg": {},
+	"agr": {}, "ix": {}, "cd": {}, "lt": {}, "icc": {}, "md": {}, "ti": {}, "dd": {},
+	"ato": {}, "nt": {}, "icsd": {}, "pr": {}, "rp": {}, "acrd": {}, "sp": {}, "sb": {},
+	"rr": {}, "xx": {},
+}
+
+func validateTask7Create(p map[string]json.RawMessage) error {
+	if err := exactKeys(p, task7CreateKeys); err != nil {
+		return fmt.Errorf("create payload %w", err)
+	}
+	tp, ok := jsonInteger(p["tp"])
+	if !ok || tp < 0 || tp > 2 {
+		return fmt.Errorf("create tp must be 0, 1, or 2")
+	}
+	st, ok := jsonInteger(p["st"])
+	if !ok || st < 0 || st > 2 || (tp != 0 && st != 1) {
+		return fmt.Errorf("create st is invalid for task type")
+	}
+	if ss, ok := jsonInteger(p["ss"]); !ok || ss != 0 {
+		return fmt.Errorf("create ss must be 0")
+	}
+	if tr, ok := jsonBool(p["tr"]); !ok || tr {
+		return fmt.Errorf("create tr must be false")
+	}
+	for _, key := range []string{"icp", "lt"} {
+		if value, ok := jsonBool(p[key]); !ok || value {
+			return fmt.Errorf("create %s must be false", key)
+		}
+	}
+	for _, key := range []string{"do", "ix", "icc", "ti", "sb"} {
+		if value, ok := jsonInteger(p[key]); !ok || value != 0 {
+			return fmt.Errorf("create %s must be 0", key)
+		}
+	}
+	if _, ok := jsonString(p["tt"]); !ok {
+		return fmt.Errorf("create tt must be a string")
+	}
+	if err := requiredTimestamp(p["cd"], true); err != nil {
+		return fmt.Errorf("create cd %w", err)
+	}
+	for _, key := range []string{"sr", "tir", "dd"} {
+		if err := nullableTimestamp(p[key]); err != nil {
+			return fmt.Errorf("create %s %w", key, err)
+		}
+	}
+	srNull, tirNull := jsonNull(p["sr"]), jsonNull(p["tir"])
+	if srNull != tirNull {
+		return fmt.Errorf("create sr and tir must have the same date")
+	}
+	if st == 0 && !srNull {
+		return fmt.Errorf("create st 0 requires null sr and tir")
+	}
+	if !srNull {
+		var sr, tir float64
+		_ = json.Unmarshal(p["sr"], &sr)
+		_ = json.Unmarshal(p["tir"], &tir)
+		if sr != tir {
+			return fmt.Errorf("create sr and tir must have the same date")
+		}
+	}
+	for _, key := range []string{"dds", "rmd", "lai", "md", "ato", "icsd", "rp", "acrd", "sp", "rr"} {
+		if !jsonNull(p[key]) {
+			return fmt.Errorf("create %s must be null", key)
+		}
+	}
+	for _, key := range []string{"rt", "dl"} {
+		values, err := jsonStringArray(p[key])
+		if err != nil || len(values) != 0 {
+			return fmt.Errorf("create %s must be an empty array", key)
+		}
+	}
+	for _, key := range []string{"ar", "pr", "agr", "tg"} {
+		if err := validateReferenceArray(p[key]); err != nil {
+			return fmt.Errorf("create %s %w", key, err)
+		}
+		if key != "tg" {
+			values, _ := jsonStringArray(p[key])
+			if len(values) > 1 {
+				return fmt.Errorf("create %s supports at most one parent identifier", key)
+			}
+		}
+	}
+	if err := validateFullTextNote(p["nt"]); err != nil {
+		return fmt.Errorf("create nt %w", err)
+	}
+	if err := validateDefaultExtension(p["xx"]); err != nil {
+		return fmt.Errorf("create xx %w", err)
+	}
+	return nil
+}
+
+var task7ModificationKeys = map[string]struct{}{
+	"md": {}, "tt": {}, "nt": {}, "st": {}, "sr": {}, "tir": {}, "dd": {}, "ar": {},
+	"pr": {}, "agr": {}, "tg": {}, "ss": {}, "sp": {}, "tr": {}, "ix": {}, "ti": {}, "do": {},
+}
+
+func validateTask7Modification(p map[string]json.RawMessage) error {
+	for key := range p {
+		if _, ok := task7ModificationKeys[key]; !ok {
+			return fmt.Errorf("modification contains a property outside the verified write scope")
+		}
+	}
+	if err := requiredTimestamp(p["md"], true); err != nil {
+		return fmt.Errorf("modification md %w", err)
+	}
+	if raw, ok := p["tt"]; ok {
+		if _, ok := jsonString(raw); !ok {
+			return fmt.Errorf("modification tt must be a string")
+		}
+	}
+	if raw, ok := p["nt"]; ok {
+		if err := validateFullTextNote(raw); err != nil {
+			return fmt.Errorf("modification nt %w", err)
+		}
+	}
+	if raw, ok := p["st"]; ok {
+		value, ok := jsonInteger(raw)
+		if !ok || value < 0 || value > 2 {
+			return fmt.Errorf("modification st must be 0, 1, or 2")
+		}
+	}
+	if raw, ok := p["ss"]; ok {
+		value, ok := jsonInteger(raw)
+		if !ok || (value != 0 && value != 3) {
+			return fmt.Errorf("modification ss must be 0 or 3")
+		}
+	}
+	ssRaw, hasStatus := p["ss"]
+	spRaw, hasStopDate := p["sp"]
+	if hasStatus != hasStopDate {
+		return fmt.Errorf("modification ss and sp must be written together")
+	}
+	if hasStatus {
+		status, _ := jsonInteger(ssRaw)
+		if status == 0 && !jsonNull(spRaw) {
+			return fmt.Errorf("modification ss 0 requires null sp")
+		}
+		if status == 3 {
+			if jsonNull(spRaw) || requiredTimestamp(spRaw, true) != nil {
+				return fmt.Errorf("modification ss 3 requires a positive sp timestamp")
+			}
+		}
+	}
+	_, hasSchedule := p["st"]
+	_, hasStartDate := p["sr"]
+	_, hasTodayReference := p["tir"]
+	if hasSchedule || hasStartDate || hasTodayReference {
+		if !hasSchedule || !hasStartDate || !hasTodayReference {
+			return fmt.Errorf("modification st, sr, and tir must be written together")
+		}
+		st, _ := jsonInteger(p["st"])
+		srNull, tirNull := jsonNull(p["sr"]), jsonNull(p["tir"])
+		if srNull != tirNull {
+			return fmt.Errorf("modification sr and tir must have the same date")
+		}
+		if st == 0 && !srNull {
+			return fmt.Errorf("modification st 0 requires null sr and tir")
+		}
+		if !srNull {
+			var sr, tir float64
+			_ = json.Unmarshal(p["sr"], &sr)
+			_ = json.Unmarshal(p["tir"], &tir)
+			if sr != tir {
+				return fmt.Errorf("modification sr and tir must have the same date")
+			}
+		}
+	}
+	for _, key := range []string{"sr", "tir", "dd", "sp"} {
+		if raw, ok := p[key]; ok {
+			if err := nullableTimestamp(raw); err != nil {
+				return fmt.Errorf("modification %s %w", key, err)
+			}
+		}
+	}
+	for _, key := range []string{"ar", "pr", "agr", "tg"} {
+		if raw, ok := p[key]; ok {
+			if err := validateReferenceArray(raw); err != nil {
+				return fmt.Errorf("modification %s %w", key, err)
+			}
+		}
+	}
+	if raw, ok := p["tr"]; ok {
+		if _, ok := jsonBool(raw); !ok {
+			return fmt.Errorf("modification tr must be a boolean")
+		}
+	}
+	for _, key := range []string{"ix", "ti", "do"} {
+		if raw, ok := p[key]; ok {
+			if _, ok := jsonInteger(raw); !ok {
+				return fmt.Errorf("modification %s must be an integer", key)
+			}
+		}
+	}
+	return nil
+}
+
+func validateFullTextNote(raw json.RawMessage) error {
+	note, err := jsonObject(raw)
+	if err != nil {
+		return fmt.Errorf("must be an object")
+	}
+	want := map[string]struct{}{"_t": {}, "ch": {}, "v": {}, "t": {}}
+	if err := exactKeys(note, want); err != nil {
+		return err
+	}
+	tag, tagOK := jsonString(note["_t"])
+	typ, typeOK := jsonInteger(note["t"])
+	value, valueOK := jsonString(note["v"])
+	checksum, checksumOK := jsonInteger(note["ch"])
+	if !tagOK || tag != "tx" || !typeOK || typ != NoteTypeFullText || !valueOK || !checksumOK || checksum < 0 || checksum > math.MaxUint32 {
+		return fmt.Errorf("must be a tx full-text note with string value and CRC32 checksum")
+	}
+	if uint32(checksum) != crc32.ChecksumIEEE([]byte(value)) {
+		return fmt.Errorf("has a checksum that does not match its full text")
+	}
+	return nil
+}
+
+func validateDefaultExtension(raw json.RawMessage) error {
+	extension, err := jsonObject(raw)
+	if err != nil {
+		return fmt.Errorf("must be an object")
+	}
+	if err := exactKeys(extension, map[string]struct{}{"sn": {}, "_t": {}}); err != nil {
+		return err
+	}
+	tag, ok := jsonString(extension["_t"])
+	if !ok || tag != "oo" {
+		return fmt.Errorf("must have _t oo")
+	}
+	sn, err := jsonObject(extension["sn"])
+	if err != nil || len(sn) != 0 {
+		return fmt.Errorf("must have an empty sn object")
+	}
+	return nil
+}
+
+func validateReferenceArray(raw json.RawMessage) error {
+	values, err := jsonStringArray(raw)
+	if err != nil {
+		return fmt.Errorf("must be an array of identifiers")
+	}
+	for _, id := range values {
+		if err := ValidateUUID(id); err != nil {
+			return fmt.Errorf("contains an invalid identifier")
+		}
+	}
+	return nil
+}
+
+func jsonObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 || data[0] != '{' {
+		return nil, fmt.Errorf("must be an object")
+	}
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(data, &result); err != nil || result == nil {
+		return nil, fmt.Errorf("must be an object")
+	}
+	return result, nil
+}
+
+func exactKeys(values map[string]json.RawMessage, want map[string]struct{}) error {
+	if len(values) != len(want) {
+		return fmt.Errorf("must contain exactly the verified properties")
+	}
+	for key := range values {
+		if _, ok := want[key]; !ok {
+			return fmt.Errorf("contains unsupported property %q", key)
+		}
+	}
+	return nil
+}
+
+func jsonNull(raw json.RawMessage) bool { return bytes.Equal(bytes.TrimSpace(raw), []byte("null")) }
+
+func jsonString(raw json.RawMessage) (string, bool) {
+	data := bytes.TrimSpace(raw)
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return "", false
+	}
+	var value string
+	if json.Unmarshal(data, &value) != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func jsonBool(raw json.RawMessage) (bool, bool) {
+	switch string(bytes.TrimSpace(raw)) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func jsonInteger(raw json.RawMessage) (int64, bool) {
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(string(data), 10, 64)
+	return value, err == nil
+}
+
+// rejectDuplicateJSONKeys checks the envelope object itself for every write.
+// Task7 additionally checks every nested object because validation must not
+// approve one interpretation while the server applies another duplicate key.
+func rejectDuplicateJSONKeys(raw json.RawMessage, recursive bool) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := consumeJSONValue(decoder, recursive, 0); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return fmt.Errorf("extra JSON value")
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder, recursive bool, depth int) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("object key is not a string")
+			}
+			if depth == 0 || recursive {
+				if _, duplicate := seen[key]; duplicate {
+					return fmt.Errorf("duplicate object key")
+				}
+				seen[key] = struct{}{}
+			}
+			if err := consumeJSONValue(decoder, recursive, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return fmt.Errorf("unterminated object")
+		}
+	case '[':
+		for decoder.More() {
+			if err := consumeJSONValue(decoder, recursive, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return fmt.Errorf("unterminated array")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter")
+	}
+	return nil
+}
+
+func rejectUnpairedJSONSurrogates(raw []byte) error {
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '"' {
+			continue
+		}
+		for i++; i < len(raw) && raw[i] != '"'; i++ {
+			if raw[i] != '\\' {
+				continue
+			}
+			i++
+			if i >= len(raw) || raw[i] != 'u' {
+				continue
+			}
+			value, ok := jsonHex16(raw, i+1)
+			if !ok {
+				return fmt.Errorf("invalid unicode escape")
+			}
+			i += 4
+			switch {
+			case value >= 0xd800 && value <= 0xdbff:
+				if i+6 >= len(raw) || raw[i+1] != '\\' || raw[i+2] != 'u' {
+					return fmt.Errorf("unpaired unicode surrogate")
+				}
+				low, ok := jsonHex16(raw, i+3)
+				if !ok || low < 0xdc00 || low > 0xdfff {
+					return fmt.Errorf("unpaired unicode surrogate")
+				}
+				i += 6
+			case value >= 0xdc00 && value <= 0xdfff:
+				return fmt.Errorf("unpaired unicode surrogate")
+			}
+		}
+	}
+	return nil
+}
+
+func jsonHex16(raw []byte, start int) (uint16, bool) {
+	if start+4 > len(raw) {
+		return 0, false
+	}
+	value, err := strconv.ParseUint(string(raw[start:start+4]), 16, 16)
+	return uint16(value), err == nil
+}
+
+func jsonStringArray(raw json.RawMessage) ([]string, error) {
+	var values []string
+	if len(raw) == 0 || json.Unmarshal(raw, &values) != nil || values == nil {
+		return nil, fmt.Errorf("must be an array of strings")
+	}
+	return values, nil
+}
+
+const (
+	minTaskTimestamp = -62135596800.0
+	maxTaskTimestamp = 253402300799.0
+)
+
+func nullableTimestamp(raw json.RawMessage) error {
+	if jsonNull(raw) {
+		return nil
+	}
+	return requiredTimestamp(raw, false)
+}
+
+func requiredTimestamp(raw json.RawMessage, positive bool) error {
+	var value float64
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("must be a finite timestamp")
+	}
+	if value < minTaskTimestamp || value > maxTaskTimestamp || (positive && value <= 0) {
+		return fmt.Errorf("must be a valid timestamp")
 	}
 	return nil
 }

--- a/task_write_test.go
+++ b/task_write_test.go
@@ -22,7 +22,7 @@ func (p taskWriteProbe) MarshalJSON() ([]byte, error) {
 }
 
 func TestHistoryWriteRejectsUnverifiedTaskKinds(t *testing.T) {
-	for _, kind := range []ItemKind{"Task7", "Task8", "Task8\nprivate fixture title"} {
+	for _, kind := range []ItemKind{"Task8", "Task8\nprivate fixture title"} {
 		t.Run(string(kind), func(t *testing.T) {
 			var requests atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/types.go
+++ b/types.go
@@ -60,8 +60,8 @@ var (
 	ItemKindChecklistItem3 ItemKind = "ChecklistItem3"
 	// ItemKindTask identifies a Task or Subtask
 	ItemKindTask ItemKind = "Task6"
-	// ItemKindTask7 is supported for reading current histories. Writes continue
-	// to use ItemKindTask until the Task7 write contract is verified.
+	// ItemKindTask7 identifies the explicitly validated Task7 read/write scope.
+	// ItemKindTask remains Task6 for compatibility with existing callers.
 	ItemKindTask7     ItemKind = "Task7"
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"


### PR DESCRIPTION
The CLI now sends Task7 for verified ordinary task creation and modification. Existing SDK callers keep `ItemKindTask == "Task6"`; explicit `ItemKindTask7` writes are supported through a validated subset. Stored tasks and account history are not rewritten.

Task7 updates inspect raw history once per write batch, pin its first observed head, and reject recurring templates/instances, missing or ambiguous targets, and incomplete recurrence metadata before any POST. Full creates and sparse updates are checked for supported types, coherent scheduling/lifecycle fields, malformed JSON, and unsupported properties. Other entity formats, including Tombstone2 purge, remain unchanged.

The live CLI move test also exposed an existing bug: moving to an area retained the previous project and heading. Area/project moves now explicitly clear incompatible parents; conflicting area-plus-project/heading edits are rejected. Creation and standalone heading behavior are unchanged.

Validation passed: full race tests, wire/replay regressions, vet, lint, independent review, and disposable-account CLI create/edit/complete/trash plus both corrected container moves. Recurring-template and mixed-batch rejection left the cloud head unchanged. A same-task stale-ancestor test returned HTTP 409 without a second event. GitHub CI covers build, tests, coverage, and lint.

Compatibility limits: Task7 update preflight adds full-history reads. Older sparse histories without explicit rr/rp/rt are refused rather than guessed, including the legacy sparse SDK creation example; there is no automatic Task6 fallback. Project/heading creates are limited to Anytime in this first scope. Recurrence writes, direct note deltas, Task7 deletion events, and broader offline/multi-device convergence remain outside the verified contract.
